### PR TITLE
feat: add Telegram proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@ TELEGRAM_BOT_TOKEN=
 # Allowed Telegram User ID (from @userinfobot)
 TELEGRAM_ALLOWED_USER_ID=
 
+# Telegram Proxy URL (optional)
+# Supports socks5://, socks4://, http://, https:// protocols
+# Examples:
+#   TELEGRAM_PROXY_URL=socks5://proxy.example.com:1080
+#   TELEGRAM_PROXY_URL=socks5://user:password@proxy.example.com:1080
+#   TELEGRAM_PROXY_URL=http://proxy.example.com:8080
+# TELEGRAM_PROXY_URL=
+
 # OpenCode API URL (optional, default: http://localhost:4096)
 # OPENCODE_API_URL=http://localhost:4096
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,7 @@ OPENCODE_MODEL_ID=big-pickle
 | -------------------------- | --------------------------------- | -------- | ----------------------- |
 | `TELEGRAM_BOT_TOKEN`       | Bot token from @BotFather         | Yes      | -                       |
 | `TELEGRAM_ALLOWED_USER_ID` | Allowed Telegram user ID          | Yes      | -                       |
+| `TELEGRAM_PROXY_URL`       | Proxy URL for Telegram API        | No       | -                       |
 | `OPENCODE_MODEL_PROVIDER`  | Default model provider            | Yes      | -                       |
 | `OPENCODE_MODEL_ID`        | Default model ID                  | Yes      | -                       |
 | `OPENCODE_API_URL`         | OpenCode API URL                  | No       | `http://localhost:4096` |

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | -------------------------- | -------------------------------------------- | :------: | ----------------------- |
 | `TELEGRAM_BOT_TOKEN`       | Bot token from @BotFather                    |   Yes    | —                       |
 | `TELEGRAM_ALLOWED_USER_ID` | Your numeric Telegram user ID                |   Yes    | —                       |
+| `TELEGRAM_PROXY_URL`       | Proxy URL for Telegram API (SOCKS5/HTTP)     |    No    | —                       |
 | `OPENCODE_API_URL`         | OpenCode server URL                          |    No    | `http://localhost:4096` |
 | `OPENCODE_SERVER_USERNAME` | Server auth username                         |    No    | `opencode`              |
 | `OPENCODE_SERVER_PASSWORD` | Server auth password                         |    No    | —                       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@opencode-ai/sdk": "^1.1.21",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^17.2.3",
-        "grammy": "^1.39.2"
+        "grammy": "^1.39.2",
+        "https-proxy-agent": "^7.0.6",
+        "socks-proxy-agent": "^8.0.5"
       },
       "bin": {
         "opencode-telegram": "dist/cli.js"
@@ -1676,6 +1678,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2599,6 +2610,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2679,6 +2703,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3618,6 +3651,44 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "@opencode-ai/sdk": "^1.1.21",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^17.2.3",
-    "grammy": "^1.39.2"
+    "grammy": "^1.39.2",
+    "https-proxy-agent": "^7.0.6",
+    "socks-proxy-agent": "^8.0.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ export const config = {
   telegram: {
     token: getEnvVar("TELEGRAM_BOT_TOKEN"),
     allowedUserId: parseInt(getEnvVar("TELEGRAM_ALLOWED_USER_ID"), 10),
+    proxyUrl: getEnvVar("TELEGRAM_PROXY_URL", false),
   },
   opencode: {
     apiUrl: getEnvVar("OPENCODE_API_URL", false) || "http://localhost:4096",


### PR DESCRIPTION
## Summary
- add support for `TELEGRAM_PROXY_URL` to route Telegram Bot API requests through HTTP/SOCKS proxy
- configure Bot client transport with `https-proxy-agent` / `socks-proxy-agent`
- document `TELEGRAM_PROXY_URL` in `.env.example`, `README.md`, and `AGENTS.md`
- behavior note: proxy configuration is fail-fast (invalid proxy config causes startup failure)