### PR TITLE
feat: add OpenCode server auth in setup wizard

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -240,6 +240,11 @@ export const en = {
     "Application is not configured yet. Starting wizard...\n",
   "runtime.wizard.tty_required":
     "Interactive wizard requires a TTY terminal. Run `opencode-telegram config` in an interactive shell.",
+  "runtime.wizard.server_auth_header": "--- Server Authentication (optional) ---",
+  "runtime.wizard.ask_server_username":
+    "Enter OpenCode server username (optional, press Enter for default: opencode).\n> ",
+  "runtime.wizard.ask_server_password":
+    "Enter OpenCode server password (optional, press Enter to skip).\n> ",
 
   "cli.usage":
     "Usage:\n  opencode-telegram [start] [--mode sources|installed]\n  opencode-telegram status\n  opencode-telegram stop\n  opencode-telegram config\n\nNotes:\n  - No command defaults to `start`\n  - `--mode` is currently supported for `start` only",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -242,6 +242,11 @@ export const ru: I18nDictionary = {
     "Приложение еще не сконфигурировано. Запускаю wizard...\n",
   "runtime.wizard.tty_required":
     "Интерактивный wizard требует TTY-терминал. Запустите `opencode-telegram config` в интерактивной оболочке.",
+  "runtime.wizard.server_auth_header": "--- Аутентификация сервера (опционально) ---",
+  "runtime.wizard.ask_server_username":
+    "Введите имя пользователя OpenCode сервера (опционально, нажмите Enter для значения по умолчанию: opencode).\n> ",
+  "runtime.wizard.ask_server_password":
+    "Введите пароль OpenCode сервера (опционально, нажмите Enter чтобы пропустить).\n> ",
 
   "cli.usage":
     "Использование:\n  opencode-telegram [start] [--mode sources|installed]\n  opencode-telegram status\n  opencode-telegram stop\n  opencode-telegram config\n\nЗаметки:\n  - Без команды по умолчанию используется `start`\n  - `--mode` сейчас поддерживается только для `start`",

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -25,12 +25,16 @@ interface WizardCollectedValues {
   token: string;
   allowedUserId: string;
   apiUrl?: string;
+  serverUsername?: string;
+  serverPassword?: string;
 }
 
 export interface WizardEnvValues {
   TELEGRAM_BOT_TOKEN: string;
   TELEGRAM_ALLOWED_USER_ID: string;
   OPENCODE_API_URL?: string;
+  OPENCODE_SERVER_USERNAME?: string;
+  OPENCODE_SERVER_PASSWORD?: string;
   OPENCODE_MODEL_PROVIDER: string;
   OPENCODE_MODEL_ID: string;
 }
@@ -103,6 +107,8 @@ export function buildEnvFileContent(existingContent: string, values: WizardEnvVa
     ["TELEGRAM_BOT_TOKEN", values.TELEGRAM_BOT_TOKEN],
     ["TELEGRAM_ALLOWED_USER_ID", values.TELEGRAM_ALLOWED_USER_ID],
     ["OPENCODE_API_URL", values.OPENCODE_API_URL],
+    ["OPENCODE_SERVER_USERNAME", values.OPENCODE_SERVER_USERNAME],
+    ["OPENCODE_SERVER_PASSWORD", values.OPENCODE_SERVER_PASSWORD],
     ["OPENCODE_MODEL_PROVIDER", values.OPENCODE_MODEL_PROVIDER],
     ["OPENCODE_MODEL_ID", values.OPENCODE_MODEL_ID],
   ];
@@ -289,6 +295,28 @@ async function askApiUrl(): Promise<string | undefined> {
   }
 }
 
+async function askServerUsername(): Promise<string | undefined> {
+  const prompt = t("runtime.wizard.ask_server_username");
+  const username = await askVisible(prompt);
+
+  if (!username) {
+    return undefined;
+  }
+
+  return username;
+}
+
+async function askServerPassword(): Promise<string | undefined> {
+  const prompt = t("runtime.wizard.ask_server_password");
+  const password = await askHidden(prompt);
+
+  if (!password) {
+    return undefined;
+  }
+
+  return password;
+}
+
 async function collectWizardValues(): Promise<WizardCollectedValues> {
   process.stdout.write(t("runtime.wizard.start"));
   process.stdout.write("\n");
@@ -298,11 +326,20 @@ async function collectWizardValues(): Promise<WizardCollectedValues> {
   const apiUrl = await askApiUrl();
 
   process.stdout.write("\n");
+  process.stdout.write(t("runtime.wizard.server_auth_header"));
+  process.stdout.write("\n");
+
+  const serverUsername = await askServerUsername();
+  const serverPassword = await askServerPassword();
+
+  process.stdout.write("\n");
 
   return {
     token,
     allowedUserId,
     apiUrl,
+    serverUsername,
+    serverPassword,
   };
 }
 
@@ -340,6 +377,8 @@ async function runWizardAndPersist(runtimePaths: RuntimePaths): Promise<void> {
     TELEGRAM_BOT_TOKEN: wizardValues.token,
     TELEGRAM_ALLOWED_USER_ID: wizardValues.allowedUserId,
     OPENCODE_API_URL: wizardValues.apiUrl,
+    OPENCODE_SERVER_USERNAME: wizardValues.serverUsername,
+    OPENCODE_SERVER_PASSWORD: wizardValues.serverPassword,
     OPENCODE_MODEL_PROVIDER: provider,
     OPENCODE_MODEL_ID: modelId,
   };


### PR DESCRIPTION
## Summary
- add wizard prompts for OpenCode server authentication settings
- persist server auth configuration alongside existing runtime settings
- improve first-run setup for protected OpenCode server deployments