### PR TITLE
feat: add option to hide subsessions in sessions list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ OPENCODE_MODEL_ID=big-pickle
 # SESSIONS_LIST_LIMIT=10
 # Bot locale: en or ru (default: en)
 # BOT_LOCALE=en
+# Hide subsessions (child sessions) in /sessions list (default: false)
+# Set to "true" to show only top-level sessions
+# HIDE_SUBSESSIONS=false
 
 # Code File Settings (optional)
 # Maximum file size in KB to send as document (default: 100)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,7 @@ OPENCODE_MODEL_ID=big-pickle
 
 # Bot options (optional)
 # SESSIONS_LIST_LIMIT=10
+# HIDE_SUBSESSIONS=false  # Hide child sessions from /sessions list
 # BOT_LOCALE=en    # en or ru
 
 # File output options (optional)
@@ -274,6 +275,7 @@ OPENCODE_MODEL_ID=big-pickle
 | `OPENCODE_SERVER_PASSWORD` | OpenCode auth password            | No       | empty                   |
 | `LOG_LEVEL`                | Logging level                     | No       | `info`                  |
 | `SESSIONS_LIST_LIMIT`      | Max sessions shown in `/sessions` | No       | `10`                    |
+| `HIDE_SUBSESSIONS`         | Hide child sessions from list     | No       | `false`                 |
 | `BOT_LOCALE`               | Bot locale (`en` or `ru`)         | No       | `en`                    |
 | `CODE_FILE_MAX_SIZE_KB`    | Max code file size to send        | No       | `100`                   |
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `OPENCODE_MODEL_ID`        | Default model ID                             |   Yes    | `big-pickle`            |
 | `BOT_LOCALE`               | Bot UI language (`en` or `ru`)               |    No    | `en`                    |
 | `SESSIONS_LIST_LIMIT`      | Max sessions shown in `/sessions`            |    No    | `10`                    |
+| `HIDE_SUBSESSIONS`         | Hide child sessions from `/sessions` list    |    No    | `false`                 |
 | `CODE_FILE_MAX_SIZE_KB`    | Max file size (KB) to send as document       |    No    | `100`                   |
 | `LOG_LEVEL`                | Log level (`debug`, `info`, `warn`, `error`) |    No    | `info`                  |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const config = {
   bot: {
     sessionsListLimit: getOptionalPositiveIntEnvVar("SESSIONS_LIST_LIMIT", 10),
     locale: getOptionalLocaleEnvVar("BOT_LOCALE", "en"),
+    hideSubsessions: getEnvVar("HIDE_SUBSESSIONS", false) === "true",
   },
   files: {
     maxFileSizeKb: parseInt(getEnvVar("CODE_FILE_MAX_SIZE_KB", false) || "100", 10),


### PR DESCRIPTION
## Summary
- add `HIDE_SUBSESSIONS` option to filter out child sessions from `/sessions`
- keep parent session browsing behavior intact while reducing list noise
- expose and document the option in runtime/config references