### PR TITLE
feat(bot): pass unknown slash commands through to OpenCode

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -58,6 +58,20 @@ import type { FilePartInput } from "@opencode-ai/sdk/v2";
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
 let commandsInitialized = false;
+const BOT_COMMAND_NAMES = new Set([
+  "start",
+  "help",
+  "status",
+  "opencode_start",
+  "opencode_stop",
+  "projects",
+  "sessions",
+  "new",
+  "agent",
+  "model",
+  "stop",
+  "rename",
+]);
 
 const TELEGRAM_DOCUMENT_CAPTION_MAX_LENGTH = 1024;
 const __filename = fileURLToPath(import.meta.url);
@@ -771,7 +785,12 @@ export function createBot(): Bot<Context> {
     }
 
     if (text.startsWith("/")) {
-      return;
+      const commandToken = text.trim().split(/\s+/)[0] || "";
+      const commandName = commandToken.replace(/^\//, "").split("@")[0];
+      const isKnownBotCommand = BOT_COMMAND_NAMES.has(commandName);
+      if (isKnownBotCommand) {
+        return;
+      }
     }
 
     if (questionManager.isActive()) {
@@ -788,7 +807,8 @@ export function createBot(): Bot<Context> {
     chatIdInstance = ctx.chat.id;
 
     const promptDeps = { bot, ensureEventSubscription };
-    await processUserPrompt(ctx, text, promptDeps);
+    const forwardedPrompt = text === "/oc" ? "" : text.startsWith("/oc ") ? text.slice(4) : text;
+    await processUserPrompt(ctx, forwardedPrompt, promptDeps);
 
     logger.debug("[Bot] message:text handler completed (prompt sent in background)");
   });

--- a/src/bot/middleware/unknown-command.ts
+++ b/src/bot/middleware/unknown-command.ts
@@ -1,7 +1,6 @@
 import type { Context, NextFunction } from "grammy";
 import { extractCommandName, isKnownCommand } from "../utils/commands.js";
 import { logger } from "../../utils/logger.js";
-import { t } from "../../i18n/index.js";
 
 export async function unknownCommandMiddleware(ctx: Context, next: NextFunction): Promise<void> {
   const text = ctx.message?.text;
@@ -22,6 +21,6 @@ export async function unknownCommandMiddleware(ctx: Context, next: NextFunction)
   }
 
   const commandToken = text.trim().split(/\s+/)[0];
-  logger.debug(`[Bot] Unknown slash command received: ${commandToken}`);
-  await ctx.reply(t("bot.unknown_command", { command: commandToken }));
+  logger.debug(`[Bot] Unknown slash command passthrough: ${commandToken}`);
+  await next();
 }


### PR DESCRIPTION
## Summary
- allow unknown slash-prefixed messages (for example /mcp, /skill, /tools) to pass through to OpenCode instead of being intercepted by Telegram unknown-command handling
- keep built-in Telegram bot commands (/status, /new, /projects, etc.) handled locally as before
- preserve explicit passthrough alias behavior by continuing to support /oc-prefixed forwarding

## Why
The previous behavior blocked OpenCode slash workflows in Telegram chat. This change restores a tmux-like passthrough experience while keeping bot control commands safe and deterministic.