### PR TITLE
feat(projects): show folder name and full path in /projects menu

### DIFF
--- a/src/bot/commands/projects.ts
+++ b/src/bot/commands/projects.ts
@@ -30,6 +30,22 @@ function formatProjectButtonLabel(label: string, isActive: boolean): string {
   return `${prefix}${label.slice(0, Math.max(0, availableLength - 3))}...`;
 }
 
+export function getProjectFolderName(worktree: string): string {
+  const normalized = worktree.replace(/[\\/]+$/g, "");
+
+  if (!normalized) {
+    return worktree;
+  }
+
+  const segments = normalized.split(/[\\/]/).filter(Boolean);
+  return segments.at(-1) ?? normalized;
+}
+
+export function buildProjectButtonLabel(index: number, worktree: string): string {
+  const folderName = getProjectFolderName(worktree);
+  return `${index + 1}. [${folderName}][${worktree}]`;
+}
+
 export async function projectsCommand(ctx: CommandContext<Context>) {
   try {
     await syncSessionDirectoryCache();
@@ -48,9 +64,7 @@ export async function projectsCommand(ctx: CommandContext<Context>) {
       const isActive =
         currentProject &&
         (project.id === currentProject.id || project.worktree === currentProject.worktree);
-      const label = project.name
-        ? `${index + 1}. ${project.name}`
-        : `${index + 1}. ${project.worktree}`;
+      const label = buildProjectButtonLabel(index, project.worktree);
       const labelWithCheck = formatProjectButtonLabel(label, Boolean(isActive));
       keyboard.text(labelWithCheck, `project:${project.id}`).row();
     });

--- a/tests/bot/commands/projects.test.ts
+++ b/tests/bot/commands/projects.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProjectButtonLabel,
+  getProjectFolderName,
+} from "../../../src/bot/commands/projects.js";
+
+describe("bot/commands/projects", () => {
+  describe("getProjectFolderName", () => {
+    it("extracts folder name from unix path", () => {
+      expect(getProjectFolderName("/Users/evan/work/opencode-telegram-bot")).toBe(
+        "opencode-telegram-bot",
+      );
+    });
+
+    it("extracts folder name from windows path", () => {
+      expect(getProjectFolderName("C:\\work\\my-project")).toBe("my-project");
+    });
+
+    it("handles trailing separators", () => {
+      expect(getProjectFolderName("/var/www/project/")).toBe("project");
+      expect(getProjectFolderName("C:\\repo\\project\\")).toBe("project");
+    });
+  });
+
+  describe("buildProjectButtonLabel", () => {
+    it("formats label as index + folder + full path", () => {
+      expect(buildProjectButtonLabel(0, "/Users/evan/work/opencode-telegram-bot")).toBe(
+        "1. [opencode-telegram-bot][/Users/evan/work/opencode-telegram-bot]",
+      );
+    });
+
+    it("formats windows path label", () => {
+      expect(buildProjectButtonLabel(3, "D:\\repo\\awesome")).toBe(
+        "4. [awesome][D:\\repo\\awesome]",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Improve `/projects` button labels to show both the folder name and full path in a compact, disambiguating format.
- Replace the previous label rendering with: `N. [folder-name][full-path]` so users can distinguish long/similar project paths more easily.
- Add dedicated unit tests for cross-platform path parsing (Unix/Windows), trailing separators, and final button label formatting.

## Why
When project paths are long, showing only index + path (or fallback name) makes project selection hard and error-prone. Including the folder name first provides a quick visual anchor while preserving full-path context.

## Testing
- `npm run lint`
- `npm run build`
- `npm test`