### PR TITLE
fix(status): avoid false unavailable on markdown parse errors

### DIFF
--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -9,6 +9,7 @@ import { formatModelForDisplay } from "../../model/types.js";
 import { processManager } from "../../process/manager.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
+import { sendMessageWithMarkdownFallback } from "../utils/send-with-markdown-fallback.js";
 
 export async function statusCommand(ctx: CommandContext<Context>) {
   try {
@@ -65,7 +66,16 @@ export async function statusCommand(ctx: CommandContext<Context>) {
       message += t("status.session_hint");
     }
 
-    await ctx.reply(message, { parse_mode: "Markdown" });
+    if (ctx.chat) {
+      await sendMessageWithMarkdownFallback({
+        api: ctx.api,
+        chatId: ctx.chat.id,
+        text: message,
+        parseMode: "Markdown",
+      });
+    } else {
+      await ctx.reply(message);
+    }
   } catch (error) {
     logger.error("[Bot] Error checking server status:", error);
     await ctx.reply(t("status.server_unavailable"));

--- a/src/bot/utils/send-with-markdown-fallback.ts
+++ b/src/bot/utils/send-with-markdown-fallback.ts
@@ -9,7 +9,7 @@ interface SendMessageWithMarkdownFallbackParams {
   chatId: Parameters<SendMessageApi["sendMessage"]>[0];
   text: string;
   options?: TelegramSendMessageOptions;
-  parseMode?: "MarkdownV2";
+  parseMode?: "Markdown" | "MarkdownV2";
 }
 
 const MARKDOWN_PARSE_ERROR_MARKERS = [
@@ -83,7 +83,7 @@ export async function sendMessageWithMarkdownFallback({
       throw error;
     }
 
-    logger.warn("[Bot] MarkdownV2 parse failed, retrying assistant message in raw mode", error);
+    logger.warn("[Bot] Markdown parse failed, retrying assistant message in raw mode", error);
     await api.sendMessage(chatId, text, options);
   }
 }

--- a/tests/bot/utils/send-with-markdown-fallback.test.ts
+++ b/tests/bot/utils/send-with-markdown-fallback.test.ts
@@ -73,4 +73,26 @@ describe("bot/utils/send-with-markdown-fallback", () => {
     expect(isTelegramMarkdownParseError(error)).toBe(true);
     expect(isTelegramMarkdownParseError(new Error("network timeout"))).toBe(false);
   });
+
+  it("supports Markdown parse mode with fallback", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Bad Request: can't parse entities: Character '_' is reserved"),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    await sendMessageWithMarkdownFallback({
+      api: { sendMessage },
+      chatId: 321,
+      text: "*status* project_name",
+      parseMode: "Markdown",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, 321, "*status* project_name", {
+      parse_mode: "Markdown",
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, 321, "*status* project_name", undefined);
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent `/status` from incorrectly showing "server unavailable" when Telegram Markdown parsing fails on dynamic status content.
- Route status replies through `sendMessageWithMarkdownFallback` so markdown parse errors fall back to raw text.
- Extend markdown fallback utility/tests to support legacy `Markdown` parse mode used by `/status`.

## Verification
- npm run lint
- npm run build
- npm test