### PR TITLE
fix: rename .oga audio extensions to .ogg for STT compatibility

### DIFF
--- a/src/bot/handlers/voice.ts
+++ b/src/bot/handlers/voice.ts
@@ -123,7 +123,11 @@ async function downloadTelegramFile(
     const buffer = await downloadTelegramFileByUrl(fileUrl);
 
     // Extract filename from file_path (e.g., "voice/file_123.oga" -> "file_123.oga")
-    const filename = file.file_path.split("/").pop() || "audio.ogg";
+    let filename = file.file_path.split("/").pop() || "audio.ogg";
+
+    if (filename.endsWith(".oga")) {
+      filename = filename.slice(0, -4) + ".ogg";
+    }
 
     logger.debug(`[Voice] Downloaded file: ${filename} (${buffer.length} bytes)`);
     return { buffer, filename };


### PR DESCRIPTION
## Description
Fixes an issue where Telegram voice messages sent with the `.oga` extension cause STT APIs (like OpenAI, Groq, Whisper-compatible endpoints) to return a HTTP 400 error (`invalid_request_error`), because they expect the `.ogg` file extension.

## Changes Made
- Intercept the filename parsed from the Telegram file path.
- If the file ends with `.oga`, replace it with `.ogg`.
- Preserves compatibility without changing the underlying file payload since `.oga` is just an Ogg container.