### PR TITLE
feat: STT prompt injection configurable via STT_PROMPT_INJECTION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,4 @@ OPENCODE_MODEL_ID=big-pickle
 # STT_API_KEY=
 # STT_MODEL=
 # STT_LANGUAGE=
+# STT_PROMPT_INJECTION=true # Set to "true" to inject a warning about potential STT typos to the LLM. Or set a custom string.

--- a/src/bot/handlers/voice.ts
+++ b/src/bot/handlers/voice.ts
@@ -219,8 +219,24 @@ export async function handleVoiceMessage(ctx: Context, deps: VoiceMessageDeps): 
 
     logger.info(`[Voice] Transcribed audio: ${recognizedText.length} chars`);
 
+    // --- NEW LOGIC: Inject Prompt for LLM ---
+    let textForLLM = recognizedText;
+    const injectionSetting = config.stt.promptInjection;
+
+    if (injectionSetting) {
+      const normalizedSetting = injectionSetting.trim().toLowerCase();
+      if (normalizedSetting === "true" || normalizedSetting === "1") {
+        const defaultPrompt =
+          "[Note: The following text is transcribed from voice. There may be homophone or mispronunciation errors. Please interpret the intended meaning based on context.]";
+        textForLLM = `${defaultPrompt}\n${recognizedText}`;
+      } else if (normalizedSetting !== "false" && normalizedSetting !== "0") {
+        textForLLM = `${injectionSetting}\n${recognizedText}`;
+      }
+    }
+
     // Process the recognized text as a prompt
-    await processPrompt(ctx, recognizedText, deps);
+    await processPrompt(ctx, textForLLM, deps);
+
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "unknown error";
     logger.error("[Voice] Error processing voice message:", err);

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,5 +131,6 @@ export const config = {
     apiKey: getEnvVar("STT_API_KEY", false),
     model: getEnvVar("STT_MODEL", false) || "whisper-large-v3-turbo",
     language: getEnvVar("STT_LANGUAGE", false),
+    promptInjection: getEnvVar("STT_PROMPT_INJECTION", false),
   },
 };


### PR DESCRIPTION
## Description
This PR addresses an issue where Speech-to-Text (STT) transcriptions often contain homophone or phonetic errors, causing the LLM to misinterpret user intent, especially in Chinese/multilingual scenarios.

By introducing a new environment variable `STT_PROMPT_INJECTION`, a system prompt is dynamically injected **before** the transcribed text when communicating with the LLM provider. This instructs the model to anticipate phonetic inaccuracies and infer intent based on context.

## Changes Made
- Added `STT_PROMPT_INJECTION` to `config.stt` schema in `src/config.ts`.
- Updated `.env.example` with usage instructions.
- Modified `src/bot/handlers/voice.ts` to conditionally prefix `textForLLM` while keeping the original UI transcription message untouched.

### Configuration Behaviors
- **Missing / `false` / `0`**: (Default) Feature disabled. STT output is untouched (backward compatible).
- **`true` / `1`**: Feature enabled using the built-in English system prompt.
- **Any other string**: Feature enabled using the string provided as a custom system prompt.