### PR TITLE
fix(keyboard): prevent Mode button from opening model selector

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -12,7 +12,11 @@ import { BOT_COMMANDS } from "./commands/definitions.js";
 import { startCommand } from "./commands/start.js";
 import { helpCommand } from "./commands/help.js";
 import { statusCommand } from "./commands/status.js";
-import { MODEL_BUTTON_TEXT_PATTERN, VARIANT_BUTTON_TEXT_PATTERN } from "./message-patterns.js";
+import {
+  AGENT_MODE_BUTTON_TEXT_PATTERN,
+  MODEL_BUTTON_TEXT_PATTERN,
+  VARIANT_BUTTON_TEXT_PATTERN,
+} from "./message-patterns.js";
 import { sessionsCommand, handleSessionSelect } from "./commands/sessions.js";
 import { newCommand } from "./commands/new.js";
 import { projectsCommand, handleProjectSelect } from "./commands/projects.js";
@@ -613,7 +617,7 @@ export function createBot(): Bot<Context> {
   });
 
   // Handle Reply Keyboard button press (agent mode indicator)
-  bot.hears(/^(📋|🛠️|💬|🔍|📝|📄|📦|🤖) \w+ Mode$/, async (ctx) => {
+  bot.hears(AGENT_MODE_BUTTON_TEXT_PATTERN, async (ctx) => {
     logger.debug(`[Bot] Agent mode button pressed: ${ctx.message?.text}`);
 
     try {

--- a/src/bot/message-patterns.ts
+++ b/src/bot/message-patterns.ts
@@ -1,4 +1,6 @@
-export const MODEL_BUTTON_TEXT_PATTERN = /^🤖\s[\s\S]+$/;
+export const AGENT_MODE_BUTTON_TEXT_PATTERN = /^(📋|🛠️|💬|🔍|📝|📄|📦|🤖)\s.+\sMode$/;
+
+export const MODEL_BUTTON_TEXT_PATTERN = /^🤖\s(?!.*\sMode$)[\s\S]+$/;
 
 // Keep support for both legacy "💭" and current "💡" prefix.
 export const VARIANT_BUTTON_TEXT_PATTERN = /^(💡|💭)\s.+$/;

--- a/tests/bot/message-patterns.test.ts
+++ b/tests/bot/message-patterns.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createMainKeyboard } from "../../src/bot/utils/keyboard.js";
 import {
+  AGENT_MODE_BUTTON_TEXT_PATTERN,
   MODEL_BUTTON_TEXT_PATTERN,
   VARIANT_BUTTON_TEXT_PATTERN,
 } from "../../src/bot/message-patterns.js";
@@ -20,6 +21,10 @@ describe("bot/message-patterns", () => {
     expect(modelButtonText).toMatch(MODEL_BUTTON_TEXT_PATTERN);
   });
 
+  it("matches single-line model button text", () => {
+    expect("🤖 cliproxyapi2/gpt-5.3-codex").toMatch(MODEL_BUTTON_TEXT_PATTERN);
+  });
+
   it("matches current and legacy variant button prefixes", () => {
     const keyboard = createMainKeyboard("build", {
       providerID: "openrouter",
@@ -33,6 +38,12 @@ describe("bot/message-patterns", () => {
 
   it("does not match plain prompt text", () => {
     expect("Create a migration plan").not.toMatch(MODEL_BUTTON_TEXT_PATTERN);
+    expect("Create a migration plan").not.toMatch(AGENT_MODE_BUTTON_TEXT_PATTERN);
     expect("Create a migration plan").not.toMatch(VARIANT_BUTTON_TEXT_PATTERN);
+  });
+
+  it("matches agent mode labels with extra descriptors", () => {
+    expect("🤖 Sisyphus (Ultraworker) Mode").toMatch(AGENT_MODE_BUTTON_TEXT_PATTERN);
+    expect("🤖 Sisyphus (Ultraworker) Mode").not.toMatch(MODEL_BUTTON_TEXT_PATTERN);
   });
 });


### PR DESCRIPTION
## Summary
- Fix reply-keyboard routing so agent mode labels (including names with descriptors like `Sisyphus (Ultraworker)`) are handled by the agent menu path.
- Make model button matching exclude texts that end with `Mode` while still supporting both single-line and multi-line model button formats.
- Add regression tests for single-line model buttons and `Mode` label disambiguation.

## Validation
- `npm test`
- `npm run lint`
- `npm run build`