### PR TITLE
fix(interaction): allow /new to interrupt inline menus

### DIFF
--- a/src/interaction/guard.ts
+++ b/src/interaction/guard.ts
@@ -8,6 +8,8 @@ import type {
   InteractionState,
 } from "./types.js";
 
+const INLINE_INTERRUPT_COMMANDS = new Set(["/new"]);
+
 function normalizeIncomingCommand(text: string): string | null {
   const trimmed = text.trim();
   if (!trimmed.startsWith("/")) {
@@ -112,6 +114,11 @@ export function resolveInteractionGuardDecision(ctx: Context): GuardDecision {
   }
 
   if (inputType === "command") {
+    if (command && state.kind === "inline" && INLINE_INTERRUPT_COMMANDS.has(command)) {
+      interactionManager.clear(`inline_interrupted:${command.slice(1)}`);
+      return createAllowDecision(inputType, null, command);
+    }
+
     if (command && state.allowedCommands.includes(command)) {
       return createAllowDecision(inputType, state, command);
     }

--- a/tests/bot/middleware/interaction-guard.test.ts
+++ b/tests/bot/middleware/interaction-guard.test.ts
@@ -110,6 +110,23 @@ describe("interactionGuardMiddleware", () => {
     expect(ctx.reply).toHaveBeenCalledWith(t("inline.blocked.command_not_allowed"));
   });
 
+  it("allows /new to interrupt an inline interaction", async () => {
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      allowedCommands: ["/status"],
+    });
+
+    const ctx = createTextContext("/new");
+    const next: NextFunction = vi.fn().mockResolvedValue(undefined);
+
+    await interactionGuardMiddleware(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.reply).not.toHaveBeenCalled();
+    expect(interactionManager.isActive()).toBe(false);
+  });
+
   it("shows permission-specific message for blocked text", async () => {
     interactionManager.start({
       kind: "permission",

--- a/tests/interaction/guard.test.ts
+++ b/tests/interaction/guard.test.ts
@@ -107,6 +107,21 @@ describe("interaction guard", () => {
     expect(decision.command).toBe("/help");
   });
 
+  it("allows /new to interrupt an active inline interaction", () => {
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      allowedCommands: ["/status"],
+    });
+
+    const decision = resolveInteractionGuardDecision(createContext({ text: "/new" }));
+
+    expect(decision.allow).toBe(true);
+    expect(decision.command).toBe("/new");
+    expect(decision.state).toBeNull();
+    expect(interactionManager.isActive()).toBe(false);
+  });
+
   it("clears state and blocks when interaction is expired", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));


### PR DESCRIPTION
## Summary
- allow `/new` to clear an active inline menu instead of blocking the command at the interaction guard
- keep question, permission, and rename flows unchanged so only inline menus are interruptible
- add guard and middleware tests that cover the `/new` interruption path

## Verification
- `npm run build`
- `npm run lint`
- `npm test`