### PR TITLE
fix: recover from Telegram clear-history by allowing /start to reset stuck interactions

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -5,6 +5,9 @@ import { getStoredModel } from "../../model/manager.js";
 import { formatVariantForButton } from "../../variant/manager.js";
 import { pinnedMessageManager } from "../../pinned/manager.js";
 import { keyboardManager } from "../../keyboard/manager.js";
+import { clearSession } from "../../session/manager.js";
+import { clearProject } from "../../settings/manager.js";
+import { stopCurrentOperation } from "./stop.js";
 import { t } from "../../i18n/index.js";
 
 export async function startCommand(ctx: Context): Promise<void> {
@@ -14,6 +17,13 @@ export async function startCommand(ctx: Context): Promise<void> {
     }
     keyboardManager.initialize(ctx.api, ctx.chat.id);
   }
+
+  await stopCurrentOperation(ctx, { notifyUser: false });
+
+  clearSession();
+  clearProject();
+  keyboardManager.clearContext();
+  await pinnedMessageManager.clear();
 
   if (pinnedMessageManager.getContextLimit() === 0) {
     await pinnedMessageManager.refreshContextLimit();

--- a/src/bot/commands/stop.ts
+++ b/src/bot/commands/stop.ts
@@ -9,6 +9,10 @@ import { t } from "../../i18n/index.js";
 
 type SessionState = "idle" | "busy" | "not-found";
 
+interface StopCurrentOperationOptions {
+  notifyUser?: boolean;
+}
+
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 function stopLocalStreaming(): void {
@@ -56,18 +60,37 @@ async function pollSessionStatus(
   return "busy";
 }
 
-export async function stopCommand(ctx: CommandContext<Context>) {
+export async function stopCurrentOperation(
+  ctx: Context,
+  options: StopCurrentOperationOptions = {},
+): Promise<void> {
+  const notifyUser = options.notifyUser ?? true;
+
   try {
     stopLocalStreaming();
 
     const currentSession = getCurrentSession();
 
     if (!currentSession) {
-      await ctx.reply(t("stop.no_active_session"));
+      if (notifyUser) {
+        await ctx.reply(t("stop.no_active_session"));
+      }
       return;
     }
 
-    const waitingMessage = await ctx.reply(t("stop.in_progress"));
+    let waitingMessageId: number | null = null;
+    let chatId: number | null = null;
+
+    if (notifyUser) {
+      const waitingMessage = await ctx.reply(t("stop.in_progress"));
+      waitingMessageId = waitingMessage.message_id;
+      chatId = ctx.chat?.id ?? null;
+
+      if (!chatId) {
+        logger.warn("[Stop] Chat context is missing while aborting active session");
+        return;
+      }
+    }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -85,20 +108,16 @@ export async function stopCommand(ctx: CommandContext<Context>) {
 
       if (abortError) {
         logger.warn("[Stop] Abort request failed:", abortError);
-        await ctx.api.editMessageText(
-          ctx.chat.id,
-          waitingMessage.message_id,
-          t("stop.warn_unconfirmed"),
-        );
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_unconfirmed"));
+        }
         return;
       }
 
       if (abortResult !== true) {
-        await ctx.api.editMessageText(
-          ctx.chat.id,
-          waitingMessage.message_id,
-          t("stop.warn_maybe_finished"),
-        );
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_maybe_finished"));
+        }
         return;
       }
 
@@ -109,34 +128,34 @@ export async function stopCommand(ctx: CommandContext<Context>) {
       );
 
       if (finalStatus === "idle" || finalStatus === "not-found") {
-        await ctx.api.editMessageText(ctx.chat.id, waitingMessage.message_id, t("stop.success"));
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.success"));
+        }
       } else {
-        await ctx.api.editMessageText(
-          ctx.chat.id,
-          waitingMessage.message_id,
-          t("stop.warn_still_busy"),
-        );
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_still_busy"));
+        }
       }
     } catch (error) {
       clearTimeout(timeoutId);
 
       if (error instanceof Error && error.name === "AbortError") {
-        await ctx.api.editMessageText(
-          ctx.chat.id,
-          waitingMessage.message_id,
-          t("stop.warn_timeout"),
-        );
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_timeout"));
+        }
       } else {
         logger.error("[Stop] Error while aborting session:", error);
-        await ctx.api.editMessageText(
-          ctx.chat.id,
-          waitingMessage.message_id,
-          t("stop.warn_local_only"),
-        );
+        if (notifyUser && chatId !== null && waitingMessageId !== null) {
+          await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_local_only"));
+        }
       }
     }
   } catch (error) {
     logger.error("[Stop] Unexpected error:", error);
     await ctx.reply(t("stop.error"));
   }
+}
+
+export async function stopCommand(ctx: CommandContext<Context>): Promise<void> {
+  await stopCurrentOperation(ctx);
 }

--- a/src/interaction/guard.ts
+++ b/src/interaction/guard.ts
@@ -112,6 +112,10 @@ export function resolveInteractionGuardDecision(ctx: Context): GuardDecision {
   }
 
   if (inputType === "command") {
+    if (command === "/start") {
+      return createAllowDecision(inputType, state, command);
+    }
+
     if (command && state.allowedCommands.includes(command)) {
       return createAllowDecision(inputType, state, command);
     }

--- a/tests/bot/commands/start.test.ts
+++ b/tests/bot/commands/start.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+import { startCommand } from "../../../src/bot/commands/start.js";
+import { t } from "../../../src/i18n/index.js";
+
+const mocked = vi.hoisted(() => ({
+  stopCurrentOperationMock: vi.fn(),
+  clearSessionMock: vi.fn(),
+  clearProjectMock: vi.fn(),
+  createMainKeyboardMock: vi.fn(() => ({ keyboard: true })),
+  getStoredAgentMock: vi.fn(() => "build"),
+  getStoredModelMock: vi.fn(() => ({
+    providerID: "openai",
+    modelID: "gpt-5",
+    variant: "default",
+  })),
+  formatVariantForButtonMock: vi.fn(() => "Default"),
+  pinnedIsInitializedMock: vi.fn(() => false),
+  pinnedInitializeMock: vi.fn(),
+  pinnedGetContextLimitMock: vi.fn(() => 0),
+  pinnedRefreshContextLimitMock: vi.fn().mockResolvedValue(undefined),
+  pinnedGetContextInfoMock: vi.fn(() => null),
+  pinnedClearMock: vi.fn().mockResolvedValue(undefined),
+  keyboardInitializeMock: vi.fn(),
+  keyboardUpdateAgentMock: vi.fn(),
+  keyboardUpdateModelMock: vi.fn(),
+  keyboardUpdateContextMock: vi.fn(),
+  keyboardClearContextMock: vi.fn(),
+}));
+
+vi.mock("../../../src/bot/commands/stop.js", () => ({
+  stopCurrentOperation: mocked.stopCurrentOperationMock,
+}));
+
+vi.mock("../../../src/session/manager.js", () => ({
+  clearSession: mocked.clearSessionMock,
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  clearProject: mocked.clearProjectMock,
+}));
+
+vi.mock("../../../src/bot/utils/keyboard.js", () => ({
+  createMainKeyboard: mocked.createMainKeyboardMock,
+}));
+
+vi.mock("../../../src/agent/manager.js", () => ({
+  getStoredAgent: mocked.getStoredAgentMock,
+}));
+
+vi.mock("../../../src/model/manager.js", () => ({
+  getStoredModel: mocked.getStoredModelMock,
+}));
+
+vi.mock("../../../src/variant/manager.js", () => ({
+  formatVariantForButton: mocked.formatVariantForButtonMock,
+}));
+
+vi.mock("../../../src/pinned/manager.js", () => ({
+  pinnedMessageManager: {
+    isInitialized: mocked.pinnedIsInitializedMock,
+    initialize: mocked.pinnedInitializeMock,
+    getContextLimit: mocked.pinnedGetContextLimitMock,
+    refreshContextLimit: mocked.pinnedRefreshContextLimitMock,
+    getContextInfo: mocked.pinnedGetContextInfoMock,
+    clear: mocked.pinnedClearMock,
+  },
+}));
+
+vi.mock("../../../src/keyboard/manager.js", () => ({
+  keyboardManager: {
+    initialize: mocked.keyboardInitializeMock,
+    updateAgent: mocked.keyboardUpdateAgentMock,
+    updateModel: mocked.keyboardUpdateModelMock,
+    updateContext: mocked.keyboardUpdateContextMock,
+    clearContext: mocked.keyboardClearContextMock,
+  },
+}));
+
+function createStartContext(): Context {
+  return {
+    chat: { id: 100 },
+    api: {},
+    reply: vi.fn().mockResolvedValue({ message_id: 1 }),
+  } as unknown as Context;
+}
+
+describe("bot/commands/start", () => {
+  beforeEach(() => {
+    mocked.stopCurrentOperationMock.mockReset();
+    mocked.stopCurrentOperationMock.mockResolvedValue(undefined);
+
+    mocked.clearSessionMock.mockReset();
+    mocked.clearProjectMock.mockReset();
+
+    mocked.createMainKeyboardMock.mockReset();
+    mocked.createMainKeyboardMock.mockReturnValue({ keyboard: true });
+
+    mocked.getStoredAgentMock.mockReset();
+    mocked.getStoredAgentMock.mockReturnValue("build");
+
+    mocked.getStoredModelMock.mockReset();
+    mocked.getStoredModelMock.mockReturnValue({
+      providerID: "openai",
+      modelID: "gpt-5",
+      variant: "default",
+    });
+
+    mocked.formatVariantForButtonMock.mockReset();
+    mocked.formatVariantForButtonMock.mockReturnValue("Default");
+
+    mocked.pinnedIsInitializedMock.mockReset();
+    mocked.pinnedIsInitializedMock.mockReturnValue(false);
+    mocked.pinnedInitializeMock.mockReset();
+    mocked.pinnedGetContextLimitMock.mockReset();
+    mocked.pinnedGetContextLimitMock.mockReturnValue(0);
+    mocked.pinnedRefreshContextLimitMock.mockReset();
+    mocked.pinnedRefreshContextLimitMock.mockResolvedValue(undefined);
+    mocked.pinnedGetContextInfoMock.mockReset();
+    mocked.pinnedGetContextInfoMock.mockReturnValue(null);
+    mocked.pinnedClearMock.mockReset();
+    mocked.pinnedClearMock.mockResolvedValue(undefined);
+
+    mocked.keyboardInitializeMock.mockReset();
+    mocked.keyboardUpdateAgentMock.mockReset();
+    mocked.keyboardUpdateModelMock.mockReset();
+    mocked.keyboardUpdateContextMock.mockReset();
+    mocked.keyboardClearContextMock.mockReset();
+  });
+
+  it("stops active flow, resets project/session, and sends welcome message", async () => {
+    const ctx = createStartContext();
+
+    await startCommand(ctx);
+
+    expect(mocked.stopCurrentOperationMock).toHaveBeenCalledWith(ctx, { notifyUser: false });
+    expect(mocked.clearSessionMock).toHaveBeenCalledTimes(1);
+    expect(mocked.clearProjectMock).toHaveBeenCalledTimes(1);
+    expect(mocked.keyboardClearContextMock).toHaveBeenCalledTimes(1);
+    expect(mocked.pinnedClearMock).toHaveBeenCalledTimes(1);
+
+    expect(mocked.pinnedInitializeMock).toHaveBeenCalledWith(ctx.api, 100);
+    expect(mocked.keyboardInitializeMock).toHaveBeenCalledWith(ctx.api, 100);
+    expect(mocked.pinnedRefreshContextLimitMock).toHaveBeenCalledTimes(1);
+
+    expect(ctx.reply).toHaveBeenCalledWith(t("start.welcome"), {
+      reply_markup: { keyboard: true },
+    });
+  });
+});

--- a/tests/bot/commands/stop.test.ts
+++ b/tests/bot/commands/stop.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "grammy";
-import { stopCommand } from "../../../src/bot/commands/stop.js";
+import { stopCommand, stopCurrentOperation } from "../../../src/bot/commands/stop.js";
 import { clearAllInteractionState } from "../../../src/interaction/cleanup.js";
 import { questionManager } from "../../../src/question/manager.js";
 import { permissionManager } from "../../../src/permission/manager.js";
@@ -117,6 +117,46 @@ describe("bot/commands/stop", () => {
     expect(replyMock).toHaveBeenCalledWith(t("stop.in_progress"));
     expect(mocked.abortMock).toHaveBeenCalled();
     expect(editMessageTextMock).toHaveBeenCalledWith(777, 88, t("stop.success"));
+
+    expect(questionManager.isActive()).toBe(false);
+    expect(permissionManager.isActive()).toBe(false);
+    expect(renameManager.isWaitingForName()).toBe(false);
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("can stop silently without stop progress messages", async () => {
+    activateInteractionState();
+
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+
+    mocked.abortMock.mockResolvedValue({ data: true, error: null });
+    mocked.statusMock.mockResolvedValue({
+      data: {
+        "session-1": { type: "idle" },
+      },
+      error: null,
+    });
+
+    const replyMock = vi.fn().mockResolvedValue({ message_id: 88 });
+    const editMessageTextMock = vi.fn().mockResolvedValue(undefined);
+
+    const ctx = {
+      chat: { id: 777 },
+      reply: replyMock,
+      api: {
+        editMessageText: editMessageTextMock,
+      },
+    } as unknown as Context;
+
+    await stopCurrentOperation(ctx as never, { notifyUser: false });
+
+    expect(mocked.abortMock).toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(editMessageTextMock).not.toHaveBeenCalled();
 
     expect(questionManager.isActive()).toBe(false);
     expect(permissionManager.isActive()).toBe(false);

--- a/tests/bot/middleware/interaction-guard.test.ts
+++ b/tests/bot/middleware/interaction-guard.test.ts
@@ -94,6 +94,22 @@ describe("interactionGuardMiddleware", () => {
     expect(ctx.reply).not.toHaveBeenCalled();
   });
 
+  it("always allows /start even when command list is restricted", async () => {
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      allowedCommands: ["/status"],
+    });
+
+    const ctx = createTextContext("/start");
+    const next: NextFunction = vi.fn().mockResolvedValue(undefined);
+
+    await interactionGuardMiddleware(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
   it("blocks disallowed command", async () => {
     interactionManager.start({
       kind: "inline",

--- a/tests/interaction/guard.test.ts
+++ b/tests/interaction/guard.test.ts
@@ -31,11 +31,14 @@ function createContext({
   }
 
   if (photo) {
-    message.photo = [{ file_id: "photo-file-id", file_unique_id: "unique-photo-id", width: 1280, height: 720 }];
+    message.photo = [
+      { file_id: "photo-file-id", file_unique_id: "unique-photo-id", width: 1280, height: 720 },
+    ];
   }
 
   return {
-    message: Object.keys(message).length > 0 ? (message as unknown as Context["message"]) : undefined,
+    message:
+      Object.keys(message).length > 0 ? (message as unknown as Context["message"]) : undefined,
     callbackQuery:
       callbackData !== undefined ? ({ data: callbackData } as Context["callbackQuery"]) : undefined,
   } as Context;
@@ -91,6 +94,19 @@ describe("interaction guard", () => {
 
     expect(decision.allow).toBe(true);
     expect(decision.command).toBe("/status");
+  });
+
+  it("always allows /start even when command list is restricted", () => {
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      allowedCommands: ["/status"],
+    });
+
+    const decision = resolveInteractionGuardDecision(createContext({ text: "/start" }));
+
+    expect(decision.allow).toBe(true);
+    expect(decision.command).toBe("/start");
   });
 
   it("blocks command that is not allowed", () => {


### PR DESCRIPTION
## Summary

recover from Telegram clear-history by allowing /start to reset stuck interactions

Closes #40 

## User-visible impact

-

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] If this is a new feature, an approved issue is linked
- [x] If this PR includes OS-sensitive changes, behavior is verified on Linux/macOS/Windows (see `CONTRIBUTING.md`), or limitations are described
