### PR TITLE
fix: convert long messages to file when exceeding Telegram limit

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -58,7 +58,7 @@ import { processUserPrompt } from "./handlers/prompt.js";
 import { handleVoiceMessage } from "./handlers/voice.js";
 import { handleDocumentMessage } from "./handlers/document.js";
 import { downloadTelegramFile, toDataUri } from "./utils/file-download.js";
-import { sendBotText } from "./utils/telegram-text.js";
+import { sendBotText, sendBotTextWithFileFallback } from "./utils/telegram-text.js";
 import { getModelCapabilities, supportsInput } from "../model/capabilities.js";
 import { getStoredModel } from "../model/manager.js";
 import type { FilePartInput } from "@opencode-ai/sdk/v2";
@@ -98,8 +98,11 @@ const toolMessageBatcher = new ToolMessageBatcher({
       return;
     }
 
-    await botInstance.api.sendMessage(chatIdInstance, text, {
-      disable_notification: true,
+    await sendBotTextWithFileFallback({
+      api: botInstance.api,
+      chatId: chatIdInstance,
+      text,
+      options: { disable_notification: true },
     });
   },
   sendFile: async (sessionId, fileData) => {
@@ -200,7 +203,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
           isLastPart && keyboardManager.isInitialized() ? keyboardManager.getKeyboard() : undefined;
         const options = keyboard ? { reply_markup: keyboard } : undefined;
 
-        await sendBotText({
+        await sendBotTextWithFileFallback({
           api: botInstance.api,
           chatId: chatIdInstance,
           text: parts[i],

--- a/src/bot/utils/telegram-text.ts
+++ b/src/bot/utils/telegram-text.ts
@@ -1,10 +1,15 @@
+import { InputFile } from "grammy";
+import { promises as fs } from "fs";
+import * as path from "path";
 import type { Api, RawApi } from "grammy";
 import {
   editMessageWithMarkdownFallback,
   sendMessageWithMarkdownFallback,
 } from "./send-with-markdown-fallback.js";
 
-type SendMessageApi = Pick<Api<RawApi>, "sendMessage">;
+const TELEGRAM_MESSAGE_MAX_LENGTH = 4096;
+
+type SendMessageApi = Pick<Api<RawApi>, "sendMessage" | "sendDocument">;
 type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
 
 type TelegramSendMessageOptions = Parameters<SendMessageApi["sendMessage"]>[2];
@@ -51,6 +56,45 @@ export async function sendBotText({
     options,
     parseMode: resolveParseMode(format),
   });
+}
+
+export async function sendBotTextWithFileFallback({
+  api,
+  chatId,
+  text,
+  options,
+  format = "raw",
+}: SendBotTextParams): Promise<void> {
+  // Si el mensaje cabe en un solo mensaje de Telegram, enviar normal
+  if (text.length <= TELEGRAM_MESSAGE_MAX_LENGTH) {
+    return sendBotText({ api, chatId, text, options, format });
+  }
+
+  // Mensaje de advertencia indicando que el contenido se envía como archivo
+  await api.sendMessage(
+    chatId,
+    "⚠️ El mensaje es muy largo y se ha convertido en archivo.",
+    { disable_notification: options?.disable_notification }
+  );
+
+  // Crear archivo temporal
+  const tempDir = path.join(process.cwd(), ".tmp");
+  await fs.mkdir(tempDir, { recursive: true });
+
+  const filename = `opencode_output_${Date.now()}.txt`;
+  const tempFilePath = path.join(tempDir, filename);
+
+  await fs.writeFile(tempFilePath, text, "utf-8");
+
+  try {
+    await api.sendDocument(chatId, new InputFile(tempFilePath), {
+      caption: `Respuesta de OpenCode (${text.length} caracteres)`,
+      disable_notification: options?.disable_notification,
+    });
+  } finally {
+    // IMPORTANTE: Borrar archivo después de enviar
+    await fs.unlink(tempFilePath).catch(() => {});
+  }
 }
 
 export async function editBotText({


### PR DESCRIPTION
## Description
This PR fixes the issue where long responses from OpenCode get truncated or fail to send when they exceed Telegram's 4096 character message limit.
## Changes
1. **Added `sendBotTextWithFileFallback` function** in `src/bot/utils/telegram-text.ts`:
   - Checks if message length exceeds 4096 characters
   - If message is too long:
     - Sends a warning message to the user
     - Creates a temporary .txt file with the full content
     - Sends it as a document attachment
     - Deletes the temporary file after sending
   - If message fits within limit: sends normally
2. **Updated `src/bot/index.ts`**:
   - Replaced `sendBotText` with `sendBotTextWithFileFallback` in:
     - `toolMessageBatcher.sendText` (for tool messages)
     - `setOnComplete` callback (for agent responses)
## Why
Telegram has a 4096 character limit per message. When OpenCode returns long responses (e.g., large code explanations, multi-file outputs), the bot would either truncate the message or fail entirely. 
This change ensures users always receive the complete response, either as a regular message (if short enough) or as a downloadable file (if too long), with a clear warning message explaining the conversion.
---
