### PR TITLE
feat: display session cost in pinned message

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -377,6 +377,19 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     }
   });
 
+  summaryAggregator.setOnCost(async (cost) => {
+    if (!pinnedMessageManager.isInitialized()) {
+      return;
+    }
+
+    try {
+      logger.debug(`[Bot] Cost update: $${cost.toFixed(2)}`);
+      await pinnedMessageManager.onCostUpdate(cost);
+    } catch (err) {
+      logger.error("[Bot] Error updating cost:", err);
+    }
+  });
+
   summaryAggregator.setOnSessionCompacted(async (sessionId, directory) => {
     if (!pinnedMessageManager.isInitialized()) {
       return;

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -291,6 +291,7 @@ export const de: I18nDictionary = {
   "pinned.line.project": "Projekt: {project}",
   "pinned.line.model": "Modell: {model}",
   "pinned.line.context": "Kontext: {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "Kosten: {cost} ausgegeben",
   "pinned.files.title": "Dateien ({count}):",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... und {count} mehr",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -279,6 +279,7 @@ export const en = {
   "pinned.line.project": "Project: {project}",
   "pinned.line.model": "Model: {model}",
   "pinned.line.context": "Context: {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "Cost: {cost} spent",
   "pinned.files.title": "Files ({count}):",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... and {count} more",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -289,6 +289,7 @@ export const es: I18nDictionary = {
   "pinned.line.project": "Proyecto: {project}",
   "pinned.line.model": "Modelo: {model}",
   "pinned.line.context": "Contexto: {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "Costo: {cost} gastado",
   "pinned.files.title": "Archivos ({count}):",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... y {count} más",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -291,6 +291,7 @@ export const fr: I18nDictionary = {
   "pinned.line.project": "Projet : {project}",
   "pinned.line.model": "Modèle : {model}",
   "pinned.line.context": "Contexte : {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "Coût : {cost} dépensé",
   "pinned.files.title": "Fichiers ({count}) :",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... et encore {count}",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -280,6 +280,7 @@ export const ru: I18nDictionary = {
   "pinned.line.project": "Проект: {project}",
   "pinned.line.model": "Модель: {model}",
   "pinned.line.context": "Контекст: {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "Стоимость: {cost} потрачено",
   "pinned.files.title": "Файлы ({count}):",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... и еще {count}",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -253,6 +253,7 @@ export const zh: I18nDictionary = {
   "pinned.line.project": "项目: {project}",
   "pinned.line.model": "模型: {model}",
   "pinned.line.context": "上下文: {used} / {limit} ({percent}%)",
+  "pinned.line.cost": "费用: {cost}",
   "pinned.files.title": "文件（{count}）：",
   "pinned.files.item": "  {path}{diff}",
   "pinned.files.more": "  ... 还有 {count} 个",

--- a/src/pinned/manager.ts
+++ b/src/pinned/manager.ts
@@ -25,6 +25,7 @@ class PinnedMessageManager {
     tokensLimit: 0,
     lastUpdated: 0,
     changedFiles: [],
+    cost: 0,
   };
   private contextLimit: number | null = null;
   private onKeyboardUpdateCallback?: (tokensUsed: number, tokensLimit: number) => void;
@@ -52,6 +53,7 @@ class PinnedMessageManager {
 
     // Reset tokens for new session
     this.state.tokensUsed = 0;
+    this.state.cost = 0;
 
     // Update state
     this.state.sessionId = sessionId;
@@ -108,9 +110,10 @@ class PinnedMessageManager {
         return;
       }
 
-      // Get the maximum context size from session history
+      // Get the maximum context size and cost from session history
       // Context = input + cache.read (cache.read contains previously cached context)
       let maxContextSize = 0;
+      let maxCost = 0;
       logger.debug(`[PinnedManager] Processing ${messagesData.length} messages from history`);
 
       messagesData.forEach(({ info }) => {
@@ -121,6 +124,7 @@ class PinnedMessageManager {
               input: number;
               cache?: { read: number };
             };
+            cost?: number;
           };
 
           // Skip summary messages (technical, not real agent responses)
@@ -132,22 +136,31 @@ class PinnedMessageManager {
           const input = assistantInfo.tokens?.input || 0;
           const cacheRead = assistantInfo.tokens?.cache?.read || 0;
           const contextSize = input + cacheRead;
+          const cost = assistantInfo.cost || 0;
 
           logger.debug(
-            `[PinnedManager] Assistant message: input=${input}, cache.read=${cacheRead}, total=${contextSize}`,
+            `[PinnedManager] Assistant message: input=${input}, cache.read=${cacheRead}, total=${contextSize}, cost=$${cost.toFixed(2)}`,
           );
 
           // Keep track of maximum context size (peak usage in session)
           if (contextSize > maxContextSize) {
             maxContextSize = contextSize;
           }
+
+          // Keep track of maximum cost (cumulative in OpenCode)
+          if (cost > maxCost) {
+            maxCost = cost;
+          }
         }
       });
 
       this.state.tokensUsed = maxContextSize;
+      this.state.cost = maxCost;
       this.state.sessionId = sessionId;
 
-      logger.info(`[PinnedManager] Loaded context from history: ${this.state.tokensUsed} tokens`);
+      logger.info(
+        `[PinnedManager] Loaded context from history: ${this.state.tokensUsed} tokens, cost: $${this.state.cost.toFixed(2)}`,
+      );
 
       await this.updatePinnedMessage();
     } catch (err) {
@@ -186,6 +199,15 @@ class PinnedMessageManager {
     // Also fetch latest session title (it may have changed after first message)
     await this.refreshSessionTitle();
 
+    await this.updatePinnedMessage();
+  }
+
+  /**
+   * Called when cost info is received from SSE events
+   */
+  async onCostUpdate(cost: number): Promise<void> {
+    this.state.cost = cost;
+    logger.debug(`[PinnedManager] Cost updated: $${cost.toFixed(2)}`);
     await this.updatePinnedMessage();
   }
 
@@ -564,6 +586,10 @@ class PinnedMessageManager {
         percent: percentage,
       }),
     ];
+
+    if (this.state.cost !== undefined && this.state.cost !== null) {
+      lines.push(t("pinned.line.cost", { cost: `$${this.state.cost.toFixed(2)}` }));
+    }
 
     if (this.state.changedFiles.length > 0) {
       const maxFiles = 10;

--- a/src/pinned/types.ts
+++ b/src/pinned/types.ts
@@ -31,4 +31,5 @@ export interface PinnedMessageState {
   tokensLimit: number;
   lastUpdated: number;
   changedFiles: FileChange[];
+  cost?: number;
 }

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -54,6 +54,8 @@ export interface TokensInfo {
 
 type TokensCallback = (tokens: TokensInfo) => void;
 
+type CostCallback = (cost: number) => void;
+
 type SessionCompactedCallback = (sessionId: string, directory: string) => void;
 
 type SessionErrorCallback = (sessionId: string, message: string) => void;
@@ -122,6 +124,7 @@ class SummaryAggregator {
   private onQuestionErrorCallback: QuestionErrorCallback | null = null;
   private onThinkingCallback: ThinkingCallback | null = null;
   private onTokensCallback: TokensCallback | null = null;
+  private onCostCallback: CostCallback | null = null;
   private onSessionCompactedCallback: SessionCompactedCallback | null = null;
   private onSessionErrorCallback: SessionErrorCallback | null = null;
   private onSessionRetryCallback: SessionRetryCallback | null = null;
@@ -167,6 +170,10 @@ class SummaryAggregator {
 
   setOnTokens(callback: TokensCallback): void {
     this.onTokensCallback = callback;
+  }
+
+  setOnCost(callback: CostCallback): void {
+    this.onCostCallback = callback;
   }
 
   setOnSessionCompacted(callback: SessionCompactedCallback): void {
@@ -355,6 +362,7 @@ class SummaryAggregator {
             reasoning: number;
             cache: { read: number; write: number };
           };
+          cost?: number;
         };
 
         if (this.onTokensCallback && assistantInfo.tokens) {
@@ -370,6 +378,12 @@ class SummaryAggregator {
           );
           // Call synchronously so keyboardManager is updated before onComplete sends the reply
           this.onTokensCallback(tokens);
+        }
+
+        // Extract and report cost
+        if (this.onCostCallback && assistantInfo.cost !== undefined) {
+          logger.debug(`[Aggregator] Cost: $${assistantInfo.cost.toFixed(2)}`);
+          this.onCostCallback(assistantInfo.cost);
         }
 
         if (this.onCompleteCallback && lastPart.length > 0) {


### PR DESCRIPTION
## Description of changes

•   Added extraction of the cost field from OpenCode SSE message.updated events in SummaryAggregator.
•   Updated PinnedMessageManager to track and display cumulative session cost in the pinned status message.
•   Implemented cost restoration from session history in PinnedMessageManager to ensure spending is correctly displayed when reconnecting to existing sessions.
•   Added localized strings for cost display across all supported languages (EN, FR, DE, RU, ES, ZH).
•   Updated PinnedMessageState type to support persistent cost data.

## How it was tested

 Manual testing: Verified that the pinned message correctly displays cost

<img width="319" height="324" alt="image" src="https://github.com/user-attachments/assets/47339840-cd7c-4fa7-a17e-b5ad360bb179" />


## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [ ] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described
