### PR TITLE
fix(sessions): filter out child sessions from /sessions list

### DIFF
--- a/src/bot/commands/sessions.ts
+++ b/src/bot/commands/sessions.ts
@@ -87,6 +87,7 @@ async function loadSessionPage(
   const { data: sessions, error } = await opencodeClient.session.list({
     directory,
     limit: endExclusive + SESSION_FETCH_EXTRA_COUNT,
+    roots: true,
   });
 
   if (error || !sessions) {

--- a/tests/bot/commands/sessions.test.ts
+++ b/tests/bot/commands/sessions.test.ts
@@ -176,6 +176,7 @@ describe("bot/commands/sessions", () => {
     expect(mocked.sessionListMock).toHaveBeenCalledWith({
       directory: "/repo",
       limit: 11,
+      roots: true,
     });
 
     const keyboardRows = getKeyboardButtons(ctx);
@@ -215,6 +216,7 @@ describe("bot/commands/sessions", () => {
     expect(mocked.sessionListMock).toHaveBeenCalledWith({
       directory: "/repo",
       limit: 21,
+      roots: true,
     });
     expect(ctx.editMessageText).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Description of changes
The /sessions command returns every session from the API, including child sessions 
spawned by tool calls (look_at, task, etc.). This clutters the list and makes it 
hard to find actual user sessions.
Passes `roots: true` to `session.list()` so the server only returns root sessions. 
This is the same approach the official OpenCode CLI and web app already use.
Relates to #1.
## How it was tested
- Confirmed `roots: true` is implemented server-side in OpenCode:
  - DB query: [`session/index.ts#L773-L774`](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/index.ts#L773-L774) — adds `WHERE parent_id IS NULL`
  - API route: [`server/routes/session.ts#L50`](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/server/routes/session.ts#L50) — Zod schema with `roots` param
- All existing tests updated and passing: `npm run lint`, `npm run build`, `npm test` (405/405)
## Checklist
- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [ ] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described