### PR TITLE
feat(bot): add configurable TTS replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,8 +79,8 @@ OPENCODE_MODEL_ID=big-pickle
 # STT_LANGUAGE=
 
 # Text-to-Speech credentials (optional)
-# TTS reply behavior is controlled in chat with /tts and persisted in settings.json.
-# By default, TTS reuses STT/OpenAI credentials when dedicated TTS vars are unset.
+# TTS reply behavior is controlled globally with /tts and persisted in settings.json.
+# Set both TTS_API_URL and TTS_API_KEY to enable audio replies.
 # TTS_API_URL=
 # TTS_API_KEY=
 # TTS_MODEL=gpt-4o-mini-tts

--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,11 @@ OPENCODE_MODEL_ID=big-pickle
 # STT_API_KEY=
 # STT_MODEL=
 # STT_LANGUAGE=
+
+# Text-to-Speech credentials (optional)
+# TTS reply behavior is controlled in chat with /tts and persisted in settings.json.
+# By default, TTS reuses STT/OpenAI credentials when dedicated TTS vars are unset.
+# TTS_API_URL=
+# TTS_API_KEY=
+# TTS_MODEL=gpt-4o-mini-tts
+# TTS_VOICE=alloy

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -87,6 +87,7 @@ No public inbound ports are required for normal usage.
 - Configurable visibility for service messages (thinking/tool calls)
 - Configurable max code file size in KB (default: 100)
 - Optional STT settings for voice transcription (`STT_API_URL`, `STT_API_KEY`, `STT_MODEL`, `STT_LANGUAGE`)
+- Optional TTS settings for global audio replies (`TTS_API_URL`, `TTS_API_KEY`, `TTS_MODEL`, `TTS_VOICE`)
 
 ## Current Product Scope
 
@@ -99,6 +100,7 @@ Current command set:
 - `/abort` - stop the current task
 - `/sessions` - show and switch recent sessions
 - `/projects` - show and switch projects
+- `/tts` - toggle global audio replies
 - `/task` - create a scheduled task
 - `/tasklist` - browse and delete scheduled tasks
 - `/rename` - rename current session
@@ -109,7 +111,7 @@ Current command set:
 
 Model, agent, variant, and context actions are available from the persistent bottom keyboard.
 
-Text messages (non-commands) are treated as prompts for OpenCode only when no blocking interaction is active. Voice/audio messages are transcribed and then sent as prompts when STT is configured.
+Text messages (non-commands) are treated as prompts for OpenCode only when no blocking interaction is active. Voice/audio messages are transcribed and then sent as prompts when STT is configured. When `/tts` is enabled globally, completed assistant replies also include a generated audio file if TTS is configured.
 
 Interaction routing rules:
 
@@ -148,6 +150,7 @@ Model picker behavior:
 - [x] PDF attachments support (send documents from Telegram to OpenCode)
 - [x] Text file attachments support (send code/config/log files from Telegram to OpenCode)
 - [x] Voice/audio transcription via Whisper-compatible APIs (OpenAI/Groq/Together and compatible providers)
+- [x] Optional global audio replies with `/tts` via OpenAI-compatible APIs
 
 ## Current Task List
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Languages: English (`en`), Deutsch (`de`), Español (`es`), Français (`fr`), Р
 - **Subagent activity** — watch live subagent progress in chat, including the current task, agent, model, and active tool step
 - **Custom Commands** — run OpenCode custom commands (and built-ins like `init`/`review`) from an inline menu with confirmation
 - **Interactive Q&A** — answer agent questions and approve permissions via inline buttons
-- **Voice prompts** — send voice/audio messages, transcribe them via a Whisper-compatible API, then forward recognized text to OpenCode
+- **Voice prompts** — send voice/audio messages, transcribe them via a Whisper-compatible API, and optionally enable spoken replies with `/tts`
 - **File attachments** — send images, PDF documents, and any text-based files to OpenCode (code, logs, configs etc.)
 - **Scheduled tasks** — schedule prompts to run later or on a recurring interval; see [Scheduled Tasks](#scheduled-tasks)
 - **Context control** — compact context when it gets too large, right from the chat
@@ -109,6 +109,7 @@ opencode-telegram config
 | `/abort`          | Abort the current task                                  |
 | `/sessions`       | Browse and switch between recent sessions               |
 | `/projects`       | Switch between OpenCode projects                        |
+| `/tts`            | Toggle audio replies                                    |
 | `/rename`         | Rename the current session                              |
 | `/commands`       | Browse and run custom commands                          |
 | `/task`           | Create a scheduled task                                 |
@@ -147,31 +148,36 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 - **Windows:** `%APPDATA%\opencode-telegram-bot\.env`
 - **Linux:** `~/.config/opencode-telegram-bot/.env`
 
-| Variable                      | Description                                                                      | Required | Default                  |
-| ----------------------------- | -------------------------------------------------------------------------------- | :------: | ------------------------ |
-| `TELEGRAM_BOT_TOKEN`          | Bot token from @BotFather                                                        |   Yes    | —                        |
-| `TELEGRAM_ALLOWED_USER_ID`    | Your numeric Telegram user ID                                                    |   Yes    | —                        |
-| `TELEGRAM_PROXY_URL`          | Proxy URL for Telegram API (SOCKS5/HTTP)                                         |    No    | —                        |
-| `OPENCODE_API_URL`            | OpenCode server URL                                                              |    No    | `http://localhost:4096`  |
-| `OPENCODE_SERVER_USERNAME`    | Server auth username                                                             |    No    | `opencode`               |
-| `OPENCODE_SERVER_PASSWORD`    | Server auth password                                                             |    No    | —                        |
-| `OPENCODE_MODEL_PROVIDER`     | Default model provider                                                           |   Yes    | `opencode`               |
-| `OPENCODE_MODEL_ID`           | Default model ID                                                                 |   Yes    | `big-pickle`             |
-| `BOT_LOCALE`                  | Bot UI language (supported locale code, e.g. `en`, `de`, `es`, `fr`, `ru`, `zh`) |    No    | `en`                     |
-| `SESSIONS_LIST_LIMIT`         | Sessions per page in `/sessions`                                                 |    No    | `10`                     |
-| `PROJECTS_LIST_LIMIT`         | Projects per page in `/projects`                                                 |    No    | `10`                     |
-| `COMMANDS_LIST_LIMIT`         | Commands per page in `/commands`                                                 |    No    | `10`                     |
-| `TASK_LIMIT`                  | Maximum number of scheduled tasks that can exist at once                         |    No    | `10`                     |
-| `RESPONSE_STREAM_THROTTLE_MS` | Stream edit throttle (ms) for assistant and tool updates                         |    No    | `500`                    |
-| `HIDE_THINKING_MESSAGES`      | Hide `💭 Thinking...` service messages                                           |    No    | `false`                  |
-| `HIDE_TOOL_CALL_MESSAGES`     | Hide tool-call service messages (`💻 bash ...`, `📖 read ...`, etc.)             |    No    | `false`                  |
-| `MESSAGE_FORMAT_MODE`         | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw`       |    No    | `markdown`               |
-| `CODE_FILE_MAX_SIZE_KB`       | Max file size (KB) to send as document                                           |    No    | `100`                    |
-| `STT_API_URL`                 | Whisper-compatible API base URL (enables voice/audio transcription)              |    No    | —                        |
-| `STT_API_KEY`                 | API key for your STT provider                                                    |    No    | —                        |
-| `STT_MODEL`                   | STT model name passed to `/audio/transcriptions`                                 |    No    | `whisper-large-v3-turbo` |
-| `STT_LANGUAGE`                | Optional language hint (empty = provider auto-detect)                            |    No    | —                        |
-| `LOG_LEVEL`                   | Log level (`debug`, `info`, `warn`, `error`)                                     |    No    | `info`                   |
+| Variable                        | Description                                                                                                  | Required | Default                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ | :------: | ------------------------ |
+| `TELEGRAM_BOT_TOKEN`            | Bot token from @BotFather                                                                                    |   Yes    | —                        |
+| `TELEGRAM_ALLOWED_USER_ID`      | Your numeric Telegram user ID                                                                                |   Yes    | —                        |
+| `TELEGRAM_PROXY_URL`            | Proxy URL for Telegram API (SOCKS5/HTTP)                                                                     |    No    | —                        |
+| `OPENCODE_API_URL`              | OpenCode server URL                                                                                          |    No    | `http://localhost:4096`  |
+| `OPENCODE_SERVER_USERNAME`      | Server auth username                                                                                         |    No    | `opencode`               |
+| `OPENCODE_SERVER_PASSWORD`      | Server auth password                                                                                         |    No    | —                        |
+| `OPENCODE_MODEL_PROVIDER`       | Default model provider                                                                                       |   Yes    | `opencode`               |
+| `OPENCODE_MODEL_ID`             | Default model ID                                                                                             |   Yes    | `big-pickle`             |
+| `BOT_LOCALE`                    | Bot UI language (supported locale code, e.g. `en`, `de`, `es`, `fr`, `ru`, `zh`)                             |    No    | `en`                     |
+| `SESSIONS_LIST_LIMIT`           | Sessions per page in `/sessions`                                                                             |    No    | `10`                     |
+| `PROJECTS_LIST_LIMIT`           | Projects per page in `/projects`                                                                             |    No    | `10`                     |
+| `COMMANDS_LIST_LIMIT`           | Commands per page in `/commands`                                                                             |    No    | `10`                     |
+| `TASK_LIMIT`                    | Maximum number of scheduled tasks that can exist at once                                                     |    No    | `10`                     |
+| `SERVICE_MESSAGES_INTERVAL_SEC` | Service messages interval (thinking + tool calls); keep `>=2` to avoid Telegram rate limits, `0` = immediate |    No    | `5`                      |
+| `HIDE_THINKING_MESSAGES`        | Hide `💭 Thinking...` service messages                                                                       |    No    | `false`                  |
+| `HIDE_TOOL_CALL_MESSAGES`       | Hide tool-call service messages (`💻 bash ...`, `📖 read ...`, etc.)                                         |    No    | `false`                  |
+| `RESPONSE_STREAMING`            | Stream assistant replies while they are generated across one or more Telegram messages                       |    No    | `true`                   |
+| `MESSAGE_FORMAT_MODE`           | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw`                                   |    No    | `markdown`               |
+| `CODE_FILE_MAX_SIZE_KB`         | Max file size (KB) to send as document                                                                       |    No    | `100`                    |
+| `STT_API_URL`                   | Whisper-compatible API base URL (enables voice/audio transcription)                                          |    No    | —                        |
+| `STT_API_KEY`                   | API key for your STT provider                                                                                |    No    | —                        |
+| `STT_MODEL`                     | STT model name passed to `/audio/transcriptions`                                                             |    No    | `whisper-large-v3-turbo` |
+| `STT_LANGUAGE`                  | Optional language hint (empty = provider auto-detect)                                                        |    No    | —                        |
+| `TTS_API_URL`                   | TTS API base URL                                                                                             |    No    | —                        |
+| `TTS_API_KEY`                   | TTS API key                                                                                                  |    No    | —                        |
+| `TTS_MODEL`                     | TTS model name passed to `/audio/speech`                                                                     |    No    | `gpt-4o-mini-tts`        |
+| `TTS_VOICE`                     | OpenAI-compatible TTS voice name                                                                             |    No    | `alloy`                  |
+| `LOG_LEVEL`                     | Log level (`debug`, `info`, `warn`, `error`)                                                                 |    No    | `info`                   |
 
 > **Keep your `.env` file private.** It contains your bot token. Never commit it to version control.
 
@@ -183,6 +189,17 @@ If `STT_API_URL` and `STT_API_KEY` are set, the bot will:
 2. Transcribe them via `POST {STT_API_URL}/audio/transcriptions`
 3. Show recognized text in chat
 4. Send the recognized text to OpenCode as a normal prompt
+
+If TTS credentials are configured, you can toggle spoken replies globally with `/tts`. The preference is stored in `settings.json` and persists across restarts.
+
+TTS configuration example:
+
+```env
+TTS_API_URL=https://api.openai.com/v1
+TTS_API_KEY=your-tts-api-key
+TTS_MODEL=gpt-4o-mini-tts
+TTS_VOICE=alloy
+```
 
 Supported provider examples (Whisper-compatible):
 

--- a/src/bot/commands/definitions.ts
+++ b/src/bot/commands/definitions.ts
@@ -25,6 +25,7 @@ const COMMAND_DEFINITIONS: BotCommandI18nDefinition[] = [
   { command: "new", descriptionKey: "cmd.description.new" },
   { command: "abort", descriptionKey: "cmd.description.stop" },
   { command: "sessions", descriptionKey: "cmd.description.sessions" },
+  { command: "tts", descriptionKey: "cmd.description.tts" },
   { command: "projects", descriptionKey: "cmd.description.projects" },
   { command: "task", descriptionKey: "cmd.description.task" },
   { command: "tasklist", descriptionKey: "cmd.description.tasklist" },

--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -1,7 +1,7 @@
 import { CommandContext, Context } from "grammy";
 import { opencodeClient } from "../../opencode/client.js";
 import { getCurrentSession } from "../../session/manager.js";
-import { getCurrentProject } from "../../settings/manager.js";
+import { getCurrentProject, isTtsEnabled } from "../../settings/manager.js";
 import { fetchCurrentAgent } from "../../agent/manager.js";
 import { getAgentDisplayName } from "../../agent/types.js";
 import { fetchCurrentModel } from "../../model/manager.js";
@@ -26,6 +26,9 @@ export async function statusCommand(ctx: CommandContext<Context>) {
     if (data.version) {
       message += `${t("status.line.version", { version: data.version })}\n`;
     }
+    message += `${t("status.line.tts", {
+      tts: isTtsEnabled() ? t("status.tts.on") : t("status.tts.off"),
+    })}\n`;
 
     // Add process management information
     if (processManager.isRunning()) {

--- a/src/bot/commands/tts.ts
+++ b/src/bot/commands/tts.ts
@@ -6,13 +6,14 @@ import { t } from "../../i18n/index.js";
 export async function ttsCommand(ctx: CommandContext<Context>): Promise<void> {
   const enabled = !isTtsEnabled();
 
+  if (enabled && !isTtsConfigured()) {
+    await ctx.reply(t("tts.not_configured"));
+    return;
+  }
+
   setTtsEnabled(enabled);
 
-  const message = enabled
-    ? isTtsConfigured()
-      ? t("tts.enabled")
-      : t("tts.enabled_not_configured")
-    : t("tts.disabled");
+  const message = enabled ? t("tts.enabled") : t("tts.disabled");
 
   await ctx.reply(message);
 }

--- a/src/bot/commands/tts.ts
+++ b/src/bot/commands/tts.ts
@@ -1,0 +1,18 @@
+import { CommandContext, Context } from "grammy";
+import { isTtsConfigured } from "../../tts/client.js";
+import { isTtsEnabled, setTtsEnabled } from "../../settings/manager.js";
+import { t } from "../../i18n/index.js";
+
+export async function ttsCommand(ctx: CommandContext<Context>): Promise<void> {
+  const enabled = !isTtsEnabled();
+
+  setTtsEnabled(enabled);
+
+  const message = enabled
+    ? isTtsConfigured()
+      ? t("tts.enabled")
+      : t("tts.enabled_not_configured")
+    : t("tts.disabled");
+
+  await ctx.reply(message);
+}

--- a/src/bot/handlers/prompt.ts
+++ b/src/bot/handlers/prompt.ts
@@ -286,6 +286,7 @@ export async function processUserPrompt(
     );
 
     foregroundSessionState.markBusy(currentSession.id);
+    setPromptResponseMode(currentSession.id, responseMode);
 
     // CRITICAL: DO NOT wait for session.prompt to complete.
     // If we wait, the handler will not finish and grammY will not call getUpdates,
@@ -311,7 +312,6 @@ export async function processUserPrompt(
           return;
         }
 
-        setPromptResponseMode(currentSession.id, responseMode);
         logger.info("[Bot] session.prompt completed");
       },
       onError: (error) => {

--- a/src/bot/handlers/prompt.ts
+++ b/src/bot/handlers/prompt.ts
@@ -3,7 +3,7 @@ import type { FilePartInput, TextPartInput } from "@opencode-ai/sdk/v2";
 import { opencodeClient } from "../../opencode/client.js";
 import { clearSession, getCurrentSession, setCurrentSession } from "../../session/manager.js";
 import { ingestSessionInfoForCache } from "../../session/cache-manager.js";
-import { getCurrentProject } from "../../settings/manager.js";
+import { getCurrentProject, isTtsEnabled } from "../../settings/manager.js";
 import { getStoredAgent } from "../../agent/manager.js";
 import { getStoredModel } from "../../model/manager.js";
 import { formatVariantForButton } from "../../variant/manager.js";
@@ -23,6 +23,13 @@ import { foregroundSessionState } from "../../scheduled-task/foreground-state.js
 /** Module-level references for async callbacks that don't have ctx. */
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
+const promptResponseModes = new Map<string, PromptResponseMode>();
+
+export type PromptResponseMode = "text_only" | "text_and_tts";
+
+type ProcessPromptOptions = {
+  responseMode?: PromptResponseMode;
+};
 
 export function getPromptBotInstance(): Bot<Context> | null {
   return botInstance;
@@ -30,6 +37,20 @@ export function getPromptBotInstance(): Bot<Context> | null {
 
 export function getPromptChatId(): number | null {
   return chatIdInstance;
+}
+
+export function setPromptResponseMode(sessionId: string, responseMode: PromptResponseMode): void {
+  promptResponseModes.set(sessionId, responseMode);
+}
+
+export function clearPromptResponseMode(sessionId: string): void {
+  promptResponseModes.delete(sessionId);
+}
+
+export function consumePromptResponseMode(sessionId: string): PromptResponseMode | null {
+  const responseMode = promptResponseModes.get(sessionId) ?? null;
+  promptResponseModes.delete(sessionId);
+  return responseMode;
 }
 
 async function isSessionBusy(sessionId: string, directory: string): Promise<boolean> {
@@ -93,8 +114,10 @@ export async function processUserPrompt(
   text: string,
   deps: ProcessPromptDeps,
   fileParts: FilePartInput[] = [],
+  options: ProcessPromptOptions = {},
 ): Promise<boolean> {
   const { bot, ensureEventSubscription } = deps;
+  const responseMode = options.responseMode ?? (isTtsEnabled() ? "text_and_tts" : "text_only");
 
   const currentProject = getCurrentProject();
   if (!currentProject) {
@@ -274,6 +297,7 @@ export async function processUserPrompt(
       onSuccess: ({ error }) => {
         if (error) {
           foregroundSessionState.markIdle(currentSession.id);
+          clearPromptResponseMode(currentSession.id);
           const details = formatErrorDetails(error, 6000);
           logger.error(
             "[Bot] OpenCode API returned an error for session.prompt",
@@ -287,10 +311,12 @@ export async function processUserPrompt(
           return;
         }
 
+        setPromptResponseMode(currentSession.id, responseMode);
         logger.info("[Bot] session.prompt completed");
       },
       onError: (error) => {
         foregroundSessionState.markIdle(currentSession.id);
+        clearPromptResponseMode(currentSession.id);
         const details = formatErrorDetails(error, 6000);
         logger.error("[Bot] session.prompt background task failed", promptErrorLogContext);
         logger.error("[Bot] session.prompt background failure details:", details);

--- a/src/bot/handlers/voice.ts
+++ b/src/bot/handlers/voice.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import https from "node:https";
 import { URL } from "node:url";
 import type { Context } from "grammy";
+import type { FilePartInput } from "@opencode-ai/sdk/v2";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { SocksProxyAgent } from "socks-proxy-agent";
 import { config } from "../../config.js";
@@ -96,7 +97,13 @@ export interface VoiceMessageDeps extends ProcessPromptDeps {
     fileId: string,
   ) => Promise<{ buffer: Buffer; filename: string } | null>;
   transcribeAudio?: (audioBuffer: Buffer, filename: string) => Promise<SttResult>;
-  processPrompt?: (ctx: Context, text: string, deps: ProcessPromptDeps) => Promise<boolean>;
+  processPrompt?: (
+    ctx: Context,
+    text: string,
+    deps: ProcessPromptDeps,
+    fileParts?: FilePartInput[],
+    options?: { responseMode?: "text_only" | "text_and_tts" },
+  ) => Promise<boolean>;
 }
 
 /**

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -31,6 +31,7 @@ import {
   handleCommandsCallback,
   handleCommandTextArguments,
 } from "./commands/commands.js";
+import { ttsCommand } from "./commands/tts.js";
 import {
   handleQuestionCallback,
   showCurrentQuestion,
@@ -63,11 +64,12 @@ import { safeBackgroundTask } from "../utils/safe-background-task.js";
 import { withTelegramRateLimitRetry } from "../utils/telegram-rate-limit-retry.js";
 import { pinnedMessageManager } from "../pinned/manager.js";
 import { t } from "../i18n/index.js";
-import { processUserPrompt } from "./handlers/prompt.js";
+import { clearPromptResponseMode, processUserPrompt } from "./handlers/prompt.js";
 import { handleVoiceMessage } from "./handlers/voice.js";
 import { handleDocumentMessage } from "./handlers/document.js";
 import { downloadTelegramFile, toDataUri } from "./utils/file-download.js";
 import { finalizeAssistantResponse } from "./utils/finalize-assistant-response.js";
+import { sendTtsResponseForSession } from "./utils/send-tts-response.js";
 import { deliverThinkingMessage } from "./utils/thinking-message.js";
 import { sendBotText } from "./utils/telegram-text.js";
 import { getModelCapabilities, supportsInput } from "../model/capabilities.js";
@@ -379,6 +381,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
   summaryAggregator.setOnComplete(async (sessionId, messageId, messageText) => {
     if (!botInstance || !chatIdInstance) {
       logger.error("Bot or chat ID not available for sending message");
+      clearPromptResponseMode(sessionId);
       responseStreamer.clearMessage(sessionId, messageId, "bot_context_missing");
       toolCallStreamer.clearSession(sessionId, "bot_context_missing");
       foregroundSessionState.markIdle(sessionId);
@@ -387,6 +390,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
 
     const currentSession = getCurrentSession();
     if (currentSession?.id !== sessionId) {
+      clearPromptResponseMode(sessionId);
       responseStreamer.clearMessage(sessionId, messageId, "session_mismatch");
       toolCallStreamer.clearSession(sessionId, "session_mismatch");
       foregroundSessionState.markIdle(sessionId);
@@ -433,7 +437,15 @@ async function ensureEventSubscription(directory: string): Promise<void> {
           }
         },
       });
+
+      await sendTtsResponseForSession({
+        api: botApi,
+        sessionId,
+        chatId,
+        text: messageText,
+      });
     } catch (err) {
+      clearPromptResponseMode(sessionId);
       logger.error("Failed to send message to Telegram:", err);
       // Stop processing events after critical error to prevent infinite loop
       logger.error("[Bot] CRITICAL: Stopping event processing due to error");
@@ -681,12 +693,14 @@ async function ensureEventSubscription(directory: string): Promise<void> {
 
   summaryAggregator.setOnSessionError(async (sessionId, message) => {
     if (!botInstance || !chatIdInstance) {
+      clearPromptResponseMode(sessionId);
       foregroundSessionState.markIdle(sessionId);
       return;
     }
 
     const currentSession = getCurrentSession();
     if (!currentSession || currentSession.id !== sessionId) {
+      clearPromptResponseMode(sessionId);
       responseStreamer.clearSession(sessionId, "session_error_not_current");
       toolCallStreamer.clearSession(sessionId, "session_error_not_current");
       foregroundSessionState.markIdle(sessionId);
@@ -695,6 +709,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     }
 
     responseStreamer.clearSession(sessionId, "session_error");
+    clearPromptResponseMode(sessionId);
     await Promise.all([
       toolMessageBatcher.flushSession(sessionId, "session_error"),
       toolCallStreamer.flushSession(sessionId, "session_error"),
@@ -879,6 +894,7 @@ export function createBot(): Bot<Context> {
   bot.command("start", startCommand);
   bot.command("help", helpCommand);
   bot.command("status", statusCommand);
+  bot.command("tts", ttsCommand);
   bot.command("opencode_start", opencodeStartCommand);
   bot.command("opencode_stop", opencodeStopCommand);
   bot.command("projects", projectsCommand);

--- a/src/bot/utils/send-tts-response.ts
+++ b/src/bot/utils/send-tts-response.ts
@@ -1,0 +1,62 @@
+import { InputFile } from "grammy";
+import { consumePromptResponseMode } from "../handlers/prompt.js";
+import { isTtsConfigured, synthesizeSpeech, type TtsResult } from "../../tts/client.js";
+import { logger } from "../../utils/logger.js";
+
+const MAX_TTS_INPUT_CHARS = 4_000;
+
+interface TelegramAudioApi {
+  sendAudio: (chatId: number, audio: InputFile) => Promise<unknown>;
+}
+
+interface SendTtsResponseParams {
+  api: TelegramAudioApi;
+  sessionId: string;
+  chatId: number;
+  text: string;
+  consumeResponseMode?: (sessionId: string) => "text_only" | "text_and_tts" | null;
+  isTtsConfigured?: () => boolean;
+  synthesizeSpeech?: (text: string) => Promise<TtsResult>;
+}
+
+export async function sendTtsResponseForSession({
+  api,
+  sessionId,
+  chatId,
+  text,
+  consumeResponseMode: consumeResponseModeImpl = consumePromptResponseMode,
+  isTtsConfigured: isTtsConfiguredImpl = isTtsConfigured,
+  synthesizeSpeech: synthesizeSpeechImpl = synthesizeSpeech,
+}: SendTtsResponseParams): Promise<boolean> {
+  const responseMode = consumeResponseModeImpl(sessionId);
+  if (responseMode !== "text_and_tts") {
+    return false;
+  }
+
+  const normalizedText = text.trim();
+  if (!normalizedText) {
+    return false;
+  }
+
+  if (!isTtsConfiguredImpl()) {
+    logger.info(`[TTS] Skipping audio reply for session ${sessionId}: TTS is not configured`);
+    return false;
+  }
+
+  if (normalizedText.length > MAX_TTS_INPUT_CHARS) {
+    logger.warn(
+      `[TTS] Skipping audio reply for session ${sessionId}: text length ${normalizedText.length} exceeds limit ${MAX_TTS_INPUT_CHARS}`,
+    );
+    return false;
+  }
+
+  try {
+    const speech = await synthesizeSpeechImpl(normalizedText);
+    await api.sendAudio(chatId, new InputFile(speech.buffer, speech.filename));
+    logger.info(`[TTS] Sent audio reply for session ${sessionId}`);
+    return true;
+  } catch (error) {
+    logger.warn(`[TTS] Failed to send audio reply for session ${sessionId}`, error);
+    return false;
+  }
+}

--- a/src/bot/utils/send-tts-response.ts
+++ b/src/bot/utils/send-tts-response.ts
@@ -1,12 +1,14 @@
 import { InputFile } from "grammy";
 import { consumePromptResponseMode } from "../handlers/prompt.js";
 import { isTtsConfigured, synthesizeSpeech, type TtsResult } from "../../tts/client.js";
+import { t } from "../../i18n/index.js";
 import { logger } from "../../utils/logger.js";
 
 const MAX_TTS_INPUT_CHARS = 4_000;
 
 interface TelegramAudioApi {
   sendAudio: (chatId: number, audio: InputFile) => Promise<unknown>;
+  sendMessage: (chatId: number, text: string) => Promise<unknown>;
 }
 
 interface SendTtsResponseParams {
@@ -57,6 +59,11 @@ export async function sendTtsResponseForSession({
     return true;
   } catch (error) {
     logger.warn(`[TTS] Failed to send audio reply for session ${sessionId}`, error);
+
+    await api.sendMessage(chatId, t("tts.failed")).catch((sendError) => {
+      logger.warn(`[TTS] Failed to send audio error message for session ${sessionId}`, sendError);
+    });
+
     return false;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,8 +114,8 @@ export const config = {
     language: getEnvVar("STT_LANGUAGE", false),
   },
   tts: {
-    apiUrl: getEnvVar("TTS_API_URL", false) || getEnvVar("STT_API_URL", false),
-    apiKey: getEnvVar("TTS_API_KEY", false) || getEnvVar("STT_API_KEY", false),
+    apiUrl: getEnvVar("TTS_API_URL", false),
+    apiKey: getEnvVar("TTS_API_KEY", false),
     model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
     voice: getEnvVar("TTS_VOICE", false) || "alloy",
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,4 +113,10 @@ export const config = {
     model: getEnvVar("STT_MODEL", false) || "whisper-large-v3-turbo",
     language: getEnvVar("STT_LANGUAGE", false),
   },
+  tts: {
+    apiUrl: getEnvVar("TTS_API_URL", false) || getEnvVar("STT_API_URL", false),
+    apiKey: getEnvVar("TTS_API_KEY", false) || getEnvVar("STT_API_KEY", false),
+    model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
+    voice: getEnvVar("TTS_VOICE", false) || "alloy",
+  },
 };

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -5,7 +5,7 @@ export const de: I18nDictionary = {
   "cmd.description.new": "Neue Sitzung erstellen",
   "cmd.description.stop": "Aktuelle Aktion stoppen",
   "cmd.description.sessions": "Sitzungen auflisten",
-  "cmd.description.tts": "TTS-Antworten umschalten",
+  "cmd.description.tts": "Audioantworten umschalten",
   "cmd.description.projects": "Projekte auflisten",
   "cmd.description.task": "Geplante Aufgabe erstellen",
   "cmd.description.tasklist": "Geplante Aufgaben anzeigen",
@@ -111,10 +111,11 @@ export const de: I18nDictionary = {
   "status.server_unavailable":
     "🔴 OpenCode-Server ist nicht verfügbar\n\nNutze /opencode_start, um den Server zu starten.",
 
-  "tts.enabled": "🔊 TTS-Antworten für diesen Chat aktiviert.",
-  "tts.enabled_not_configured":
-    "🔊 TTS-Antworten für diesen Chat aktiviert.\n\nTTS-Zugangsdaten sind noch nicht konfiguriert. Setze `TTS_API_URL` und `TTS_API_KEY` oder nutze `STT_API_URL` und `STT_API_KEY` als Fallback.",
-  "tts.disabled": "🔇 TTS-Antworten für diesen Chat deaktiviert.",
+  "tts.enabled": "🔊 Audioantworten global aktiviert.",
+  "tts.not_configured":
+    "⚠️ Audioantworten sind nicht verfugbar. Setze zuerst `TTS_API_URL` und `TTS_API_KEY`.",
+  "tts.disabled": "🔇 Audioantworten global deaktiviert.",
+  "tts.failed": "⚠️ Audioreply konnte nicht erzeugt werden.",
 
   "projects.empty":
     "📭 Keine Projekte gefunden.\n\nÖffne ein Verzeichnis in OpenCode und erstelle mindestens eine Sitzung, dann erscheint es hier.",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -5,6 +5,7 @@ export const de: I18nDictionary = {
   "cmd.description.new": "Neue Sitzung erstellen",
   "cmd.description.stop": "Aktuelle Aktion stoppen",
   "cmd.description.sessions": "Sitzungen auflisten",
+  "cmd.description.tts": "TTS-Antworten umschalten",
   "cmd.description.projects": "Projekte auflisten",
   "cmd.description.task": "Geplante Aufgabe erstellen",
   "cmd.description.tasklist": "Geplante Aufgaben anzeigen",
@@ -97,6 +98,9 @@ export const de: I18nDictionary = {
   "status.line.uptime_sec": "Betriebszeit: {seconds} s",
   "status.line.mode": "Modus: {mode}",
   "status.line.model": "Modell: {model}",
+  "status.line.tts": "TTS-Antworten: {tts}",
+  "status.tts.on": "Ein",
+  "status.tts.off": "Aus",
   "status.agent_not_set": "nicht gesetzt",
   "status.project_selected": "Projekt: {project}",
   "status.project_not_selected": "Projekt: nicht ausgewählt",
@@ -106,6 +110,11 @@ export const de: I18nDictionary = {
   "status.session_hint": "Nutze /sessions zur Auswahl oder /new zum Erstellen",
   "status.server_unavailable":
     "🔴 OpenCode-Server ist nicht verfügbar\n\nNutze /opencode_start, um den Server zu starten.",
+
+  "tts.enabled": "🔊 TTS-Antworten für diesen Chat aktiviert.",
+  "tts.enabled_not_configured":
+    "🔊 TTS-Antworten für diesen Chat aktiviert.\n\nTTS-Zugangsdaten sind noch nicht konfiguriert. Setze `TTS_API_URL` und `TTS_API_KEY` oder nutze `STT_API_URL` und `STT_API_KEY` als Fallback.",
+  "tts.disabled": "🔇 TTS-Antworten für diesen Chat deaktiviert.",
 
   "projects.empty":
     "📭 Keine Projekte gefunden.\n\nÖffne ein Verzeichnis in OpenCode und erstelle mindestens eine Sitzung, dann erscheint es hier.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -3,7 +3,7 @@ export const en = {
   "cmd.description.new": "Create a new session",
   "cmd.description.stop": "Stop current action",
   "cmd.description.sessions": "List sessions",
-  "cmd.description.tts": "Toggle TTS replies",
+  "cmd.description.tts": "Toggle audio replies",
   "cmd.description.projects": "List projects",
   "cmd.description.task": "Create a scheduled task",
   "cmd.description.tasklist": "List scheduled tasks",
@@ -105,10 +105,11 @@ export const en = {
   "status.server_unavailable":
     "🔴 OpenCode Server is unavailable\n\nUse /opencode_start to start the server.",
 
-  "tts.enabled": "🔊 TTS replies enabled for this chat.",
-  "tts.enabled_not_configured":
-    "🔊 TTS replies enabled for this chat.\n\nTTS credentials are not configured yet. Set `TTS_API_URL` and `TTS_API_KEY`, or let them fall back to `STT_API_URL` and `STT_API_KEY`.",
-  "tts.disabled": "🔇 TTS replies disabled for this chat.",
+  "tts.enabled": "🔊 Audio replies enabled globally.",
+  "tts.not_configured":
+    "⚠️ Audio replies are unavailable. Set `TTS_API_URL` and `TTS_API_KEY` first.",
+  "tts.disabled": "🔇 Audio replies disabled globally.",
+  "tts.failed": "⚠️ Failed to generate audio reply.",
 
   "projects.empty":
     "📭 No projects found.\n\nOpen a directory in OpenCode and create at least one session, then it will appear here.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -3,6 +3,7 @@ export const en = {
   "cmd.description.new": "Create a new session",
   "cmd.description.stop": "Stop current action",
   "cmd.description.sessions": "List sessions",
+  "cmd.description.tts": "Toggle TTS replies",
   "cmd.description.projects": "List projects",
   "cmd.description.task": "Create a scheduled task",
   "cmd.description.tasklist": "List scheduled tasks",
@@ -91,6 +92,9 @@ export const en = {
   "status.line.uptime_sec": "Uptime: {seconds} sec",
   "status.line.mode": "Mode: {mode}",
   "status.line.model": "Model: {model}",
+  "status.line.tts": "TTS replies: {tts}",
+  "status.tts.on": "On",
+  "status.tts.off": "Off",
   "status.agent_not_set": "not set",
   "status.project_selected": "Project: {project}",
   "status.project_not_selected": "Project: not selected",
@@ -100,6 +104,11 @@ export const en = {
   "status.session_hint": "Use /sessions to select one or /new to create one",
   "status.server_unavailable":
     "🔴 OpenCode Server is unavailable\n\nUse /opencode_start to start the server.",
+
+  "tts.enabled": "🔊 TTS replies enabled for this chat.",
+  "tts.enabled_not_configured":
+    "🔊 TTS replies enabled for this chat.\n\nTTS credentials are not configured yet. Set `TTS_API_URL` and `TTS_API_KEY`, or let them fall back to `STT_API_URL` and `STT_API_KEY`.",
+  "tts.disabled": "🔇 TTS replies disabled for this chat.",
 
   "projects.empty":
     "📭 No projects found.\n\nOpen a directory in OpenCode and create at least one session, then it will appear here.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -5,6 +5,7 @@ export const es: I18nDictionary = {
   "cmd.description.new": "Crear una sesión nueva",
   "cmd.description.stop": "Detener la acción actual",
   "cmd.description.sessions": "Listar sesiones",
+  "cmd.description.tts": "Alternar respuestas TTS",
   "cmd.description.projects": "Listar proyectos",
   "cmd.description.task": "Crear tarea programada",
   "cmd.description.tasklist": "Ver tareas programadas",
@@ -97,6 +98,9 @@ export const es: I18nDictionary = {
   "status.line.uptime_sec": "Tiempo activo: {seconds} s",
   "status.line.mode": "Modo: {mode}",
   "status.line.model": "Modelo: {model}",
+  "status.line.tts": "Respuestas TTS: {tts}",
+  "status.tts.on": "Activadas",
+  "status.tts.off": "Desactivadas",
   "status.agent_not_set": "no configurado",
   "status.project_selected": "Proyecto: {project}",
   "status.project_not_selected": "Proyecto: no seleccionado",
@@ -106,6 +110,11 @@ export const es: I18nDictionary = {
   "status.session_hint": "Usa /sessions para elegir una o /new para crear una",
   "status.server_unavailable":
     "🔴 OpenCode Server no está disponible\n\nUsa /opencode_start para iniciar el servidor.",
+
+  "tts.enabled": "🔊 Respuestas TTS activadas para este chat.",
+  "tts.enabled_not_configured":
+    "🔊 Respuestas TTS activadas para este chat.\n\nLas credenciales de TTS todavía no están configuradas. Define `TTS_API_URL` y `TTS_API_KEY`, o deja que usen como respaldo `STT_API_URL` y `STT_API_KEY`.",
+  "tts.disabled": "🔇 Respuestas TTS desactivadas para este chat.",
 
   "projects.empty":
     "📭 No se encontraron proyectos.\n\nAbre un directorio en OpenCode y crea al menos una sesión; entonces aparecerá aquí.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -5,7 +5,7 @@ export const es: I18nDictionary = {
   "cmd.description.new": "Crear una sesión nueva",
   "cmd.description.stop": "Detener la acción actual",
   "cmd.description.sessions": "Listar sesiones",
-  "cmd.description.tts": "Alternar respuestas TTS",
+  "cmd.description.tts": "Alternar respuestas de audio",
   "cmd.description.projects": "Listar proyectos",
   "cmd.description.task": "Crear tarea programada",
   "cmd.description.tasklist": "Ver tareas programadas",
@@ -111,10 +111,11 @@ export const es: I18nDictionary = {
   "status.server_unavailable":
     "🔴 OpenCode Server no está disponible\n\nUsa /opencode_start para iniciar el servidor.",
 
-  "tts.enabled": "🔊 Respuestas TTS activadas para este chat.",
-  "tts.enabled_not_configured":
-    "🔊 Respuestas TTS activadas para este chat.\n\nLas credenciales de TTS todavía no están configuradas. Define `TTS_API_URL` y `TTS_API_KEY`, o deja que usen como respaldo `STT_API_URL` y `STT_API_KEY`.",
-  "tts.disabled": "🔇 Respuestas TTS desactivadas para este chat.",
+  "tts.enabled": "🔊 Respuestas de audio activadas globalmente.",
+  "tts.not_configured":
+    "⚠️ Las respuestas de audio no estan disponibles. Configura primero `TTS_API_URL` y `TTS_API_KEY`.",
+  "tts.disabled": "🔇 Respuestas de audio desactivadas globalmente.",
+  "tts.failed": "⚠️ No se pudo generar la respuesta de audio.",
 
   "projects.empty":
     "📭 No se encontraron proyectos.\n\nAbre un directorio en OpenCode y crea al menos una sesión; entonces aparecerá aquí.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -5,7 +5,7 @@ export const fr: I18nDictionary = {
   "cmd.description.new": "Créer une nouvelle session",
   "cmd.description.stop": "Arrêter l'action en cours",
   "cmd.description.sessions": "Lister les sessions",
-  "cmd.description.tts": "Basculer les réponses TTS",
+  "cmd.description.tts": "Basculer les réponses audio",
   "cmd.description.projects": "Lister les projets",
   "cmd.description.task": "Créer une tâche planifiée",
   "cmd.description.tasklist": "Afficher les tâches planifiées",
@@ -112,10 +112,11 @@ export const fr: I18nDictionary = {
   "status.server_unavailable":
     "🔴 Le serveur OpenCode est indisponible\n\nUtilisez /opencode_start pour démarrer le serveur.",
 
-  "tts.enabled": "🔊 Réponses TTS activées pour ce chat.",
-  "tts.enabled_not_configured":
-    "🔊 Réponses TTS activées pour ce chat.\n\nLes identifiants TTS ne sont pas encore configurés. Définissez `TTS_API_URL` et `TTS_API_KEY`, ou laissez-les utiliser `STT_API_URL` et `STT_API_KEY` comme repli.",
-  "tts.disabled": "🔇 Réponses TTS désactivées pour ce chat.",
+  "tts.enabled": "🔊 Réponses audio activées globalement.",
+  "tts.not_configured":
+    "⚠️ Les réponses audio ne sont pas disponibles. Définissez d'abord `TTS_API_URL` et `TTS_API_KEY`.",
+  "tts.disabled": "🔇 Réponses audio désactivées globalement.",
+  "tts.failed": "⚠️ Impossible de générer la réponse audio.",
 
   "projects.empty":
     "📭 Aucun projet trouvé.\n\nOuvrez un répertoire dans OpenCode et créez au moins une session, il apparaîtra ensuite ici.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -5,6 +5,7 @@ export const fr: I18nDictionary = {
   "cmd.description.new": "Créer une nouvelle session",
   "cmd.description.stop": "Arrêter l'action en cours",
   "cmd.description.sessions": "Lister les sessions",
+  "cmd.description.tts": "Basculer les réponses TTS",
   "cmd.description.projects": "Lister les projets",
   "cmd.description.task": "Créer une tâche planifiée",
   "cmd.description.tasklist": "Afficher les tâches planifiées",
@@ -98,6 +99,9 @@ export const fr: I18nDictionary = {
   "status.line.uptime_sec": "Temps de fonctionnement : {seconds} sec",
   "status.line.mode": "Mode : {mode}",
   "status.line.model": "Modèle : {model}",
+  "status.line.tts": "Réponses TTS : {tts}",
+  "status.tts.on": "Activées",
+  "status.tts.off": "Désactivées",
   "status.agent_not_set": "non défini",
   "status.project_selected": "Projet : {project}",
   "status.project_not_selected": "Projet : non sélectionné",
@@ -107,6 +111,11 @@ export const fr: I18nDictionary = {
   "status.session_hint": "Utilisez /sessions pour en sélectionner une ou /new pour en créer une",
   "status.server_unavailable":
     "🔴 Le serveur OpenCode est indisponible\n\nUtilisez /opencode_start pour démarrer le serveur.",
+
+  "tts.enabled": "🔊 Réponses TTS activées pour ce chat.",
+  "tts.enabled_not_configured":
+    "🔊 Réponses TTS activées pour ce chat.\n\nLes identifiants TTS ne sont pas encore configurés. Définissez `TTS_API_URL` et `TTS_API_KEY`, ou laissez-les utiliser `STT_API_URL` et `STT_API_KEY` comme repli.",
+  "tts.disabled": "🔇 Réponses TTS désactivées pour ce chat.",
 
   "projects.empty":
     "📭 Aucun projet trouvé.\n\nOuvrez un répertoire dans OpenCode et créez au moins une session, il apparaîtra ensuite ici.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -5,7 +5,7 @@ export const ru: I18nDictionary = {
   "cmd.description.new": "Создать новую сессию",
   "cmd.description.stop": "Прервать текущее действие",
   "cmd.description.sessions": "Список сессий",
-  "cmd.description.tts": "Переключить TTS-ответы",
+  "cmd.description.tts": "Переключить аудиоответы",
   "cmd.description.projects": "Список проектов",
   "cmd.description.task": "Создать задачу по расписанию",
   "cmd.description.tasklist": "Список задач по расписанию",
@@ -105,10 +105,10 @@ export const ru: I18nDictionary = {
   "status.server_unavailable":
     "🔴 OpenCode Server недоступен\n\nИспользуйте /opencode_start для запуска сервера.",
 
-  "tts.enabled": "🔊 TTS-ответы включены для этого чата.",
-  "tts.enabled_not_configured":
-    "🔊 TTS-ответы включены для этого чата.\n\nУчетные данные TTS пока не настроены. Укажите `TTS_API_URL` и `TTS_API_KEY` или используйте `STT_API_URL` и `STT_API_KEY` как резервный вариант.",
-  "tts.disabled": "🔇 TTS-ответы выключены для этого чата.",
+  "tts.enabled": "🔊 Аудиоответы включены глобально.",
+  "tts.not_configured": "⚠️ Аудиоответы недоступны. Сначала укажите `TTS_API_URL` и `TTS_API_KEY`.",
+  "tts.disabled": "🔇 Аудиоответы выключены глобально.",
+  "tts.failed": "⚠️ Не удалось создать аудиоответ.",
 
   "projects.empty":
     "📭 Проектов нет.\n\nОткройте директорию в OpenCode и создайте хотя бы одну сессию, после этого она появится здесь.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -5,6 +5,7 @@ export const ru: I18nDictionary = {
   "cmd.description.new": "Создать новую сессию",
   "cmd.description.stop": "Прервать текущее действие",
   "cmd.description.sessions": "Список сессий",
+  "cmd.description.tts": "Переключить TTS-ответы",
   "cmd.description.projects": "Список проектов",
   "cmd.description.task": "Создать задачу по расписанию",
   "cmd.description.tasklist": "Список задач по расписанию",
@@ -91,6 +92,9 @@ export const ru: I18nDictionary = {
   "status.line.uptime_sec": "Uptime: {seconds} сек",
   "status.line.mode": "Режим: {mode}",
   "status.line.model": "Модель: {model}",
+  "status.line.tts": "TTS-ответы: {tts}",
+  "status.tts.on": "Вкл",
+  "status.tts.off": "Выкл",
   "status.agent_not_set": "не установлен",
   "status.project_selected": "Проект: {project}",
   "status.project_not_selected": "Проект: не выбран",
@@ -100,6 +104,11 @@ export const ru: I18nDictionary = {
   "status.session_hint": "Используйте /sessions для выбора или /new для создания",
   "status.server_unavailable":
     "🔴 OpenCode Server недоступен\n\nИспользуйте /opencode_start для запуска сервера.",
+
+  "tts.enabled": "🔊 TTS-ответы включены для этого чата.",
+  "tts.enabled_not_configured":
+    "🔊 TTS-ответы включены для этого чата.\n\nУчетные данные TTS пока не настроены. Укажите `TTS_API_URL` и `TTS_API_KEY` или используйте `STT_API_URL` и `STT_API_KEY` как резервный вариант.",
+  "tts.disabled": "🔇 TTS-ответы выключены для этого чата.",
 
   "projects.empty":
     "📭 Проектов нет.\n\nОткройте директорию в OpenCode и создайте хотя бы одну сессию, после этого она появится здесь.",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -5,6 +5,7 @@ export const zh: I18nDictionary = {
   "cmd.description.new": "创建新会话",
   "cmd.description.stop": "停止当前操作",
   "cmd.description.sessions": "列出会话",
+  "cmd.description.tts": "切换 TTS 回复",
   "cmd.description.projects": "列出项目",
   "cmd.description.task": "创建定时任务",
   "cmd.description.tasklist": "查看定时任务",
@@ -82,6 +83,9 @@ export const zh: I18nDictionary = {
   "status.line.uptime_sec": "运行时间：{seconds} 秒",
   "status.line.mode": "模式：{mode}",
   "status.line.model": "模型：{model}",
+  "status.line.tts": "TTS 回复：{tts}",
+  "status.tts.on": "开启",
+  "status.tts.off": "关闭",
   "status.agent_not_set": "未设置",
   "status.project_selected": "项目：{project}",
   "status.project_not_selected": "项目：未选择",
@@ -90,6 +94,11 @@ export const zh: I18nDictionary = {
   "status.session_not_selected": "当前会话：未选择",
   "status.session_hint": "使用 /sessions 选择一个会话，或 /new 创建",
   "status.server_unavailable": "🔴 OpenCode 服务器不可用\n\n使用 /opencode_start 启动服务器。",
+
+  "tts.enabled": "🔊 已为当前聊天启用 TTS 回复。",
+  "tts.enabled_not_configured":
+    "🔊 已为当前聊天启用 TTS 回复。\n\n当前尚未配置 TTS 凭据。请设置 `TTS_API_URL` 和 `TTS_API_KEY`，或让它们回退到 `STT_API_URL` 和 `STT_API_KEY`。",
+  "tts.disabled": "🔇 已为当前聊天关闭 TTS 回复。",
 
   "projects.empty":
     "📭 未找到项目。\n\n在 OpenCode 中打开一个目录并至少创建一个会话，然后它会出现在这里。",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -5,7 +5,7 @@ export const zh: I18nDictionary = {
   "cmd.description.new": "创建新会话",
   "cmd.description.stop": "停止当前操作",
   "cmd.description.sessions": "列出会话",
-  "cmd.description.tts": "切换 TTS 回复",
+  "cmd.description.tts": "切换语音回复",
   "cmd.description.projects": "列出项目",
   "cmd.description.task": "创建定时任务",
   "cmd.description.tasklist": "查看定时任务",
@@ -95,10 +95,10 @@ export const zh: I18nDictionary = {
   "status.session_hint": "使用 /sessions 选择一个会话，或 /new 创建",
   "status.server_unavailable": "🔴 OpenCode 服务器不可用\n\n使用 /opencode_start 启动服务器。",
 
-  "tts.enabled": "🔊 已为当前聊天启用 TTS 回复。",
-  "tts.enabled_not_configured":
-    "🔊 已为当前聊天启用 TTS 回复。\n\n当前尚未配置 TTS 凭据。请设置 `TTS_API_URL` 和 `TTS_API_KEY`，或让它们回退到 `STT_API_URL` 和 `STT_API_KEY`。",
-  "tts.disabled": "🔇 已为当前聊天关闭 TTS 回复。",
+  "tts.enabled": "🔊 已全局启用语音回复。",
+  "tts.not_configured": "⚠️ 语音回复暂不可用。请先设置 `TTS_API_URL` 和 `TTS_API_KEY`。",
+  "tts.disabled": "🔇 已全局关闭语音回复。",
+  "tts.failed": "⚠️ 生成语音回复失败。",
 
   "projects.empty":
     "📭 未找到项目。\n\n在 OpenCode 中打开一个目录并至少创建一个会话，然后它会出现在这里。",

--- a/src/settings/manager.ts
+++ b/src/settings/manager.ts
@@ -36,6 +36,7 @@ export interface Settings {
   currentAgent?: string;
   currentModel?: ModelInfo;
   pinnedMessageId?: number;
+  ttsEnabled?: boolean;
   serverProcess?: ServerProcessInfo;
   sessionDirectoryCache?: SessionDirectoryCacheInfo;
   scheduledTasks?: ScheduledTask[];
@@ -110,6 +111,15 @@ export function setCurrentSession(sessionInfo: SessionInfo): void {
 
 export function clearSession(): void {
   currentSettings.currentSession = undefined;
+  void writeSettingsFile(currentSettings);
+}
+
+export function isTtsEnabled(): boolean {
+  return currentSettings.ttsEnabled === true;
+}
+
+export function setTtsEnabled(enabled: boolean): void {
+  currentSettings.ttsEnabled = enabled;
   void writeSettingsFile(currentSettings);
 }
 

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -15,7 +15,7 @@ export function isTtsConfigured(): boolean {
 
 export async function synthesizeSpeech(text: string): Promise<TtsResult> {
   if (!isTtsConfigured()) {
-    throw new Error("TTS is not configured: set TTS/STT API credentials");
+    throw new Error("TTS is not configured: set TTS API credentials");
   }
 
   const input = text.trim();

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -1,0 +1,81 @@
+import { config } from "../config.js";
+import { logger } from "../utils/logger.js";
+
+const TTS_REQUEST_TIMEOUT_MS = 60_000;
+
+export interface TtsResult {
+  buffer: Buffer;
+  filename: string;
+  mimeType: string;
+}
+
+export function isTtsConfigured(): boolean {
+  return Boolean(config.tts.apiUrl && config.tts.apiKey);
+}
+
+export async function synthesizeSpeech(text: string): Promise<TtsResult> {
+  if (!isTtsConfigured()) {
+    throw new Error("TTS is not configured: set TTS/STT API credentials");
+  }
+
+  const input = text.trim();
+  if (!input) {
+    throw new Error("TTS input text is empty");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TTS_REQUEST_TIMEOUT_MS);
+
+  try {
+    const url = `${config.tts.apiUrl}/audio/speech`;
+
+    logger.debug(
+      `[TTS] Sending speech synthesis request: url=${url}, model=${config.tts.model}, voice=${config.tts.voice}, chars=${input.length}`,
+    );
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.tts.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: config.tts.model,
+        voice: config.tts.voice,
+        input,
+        response_format: "mp3",
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(
+        `TTS API returned HTTP ${response.status}: ${errorBody || response.statusText}`,
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    if (buffer.length === 0) {
+      throw new Error("TTS API returned an empty audio response");
+    }
+
+    logger.debug(`[TTS] Generated speech audio: ${buffer.length} bytes`);
+
+    return {
+      buffer,
+      filename: "assistant-reply.mp3",
+      mimeType: "audio/mpeg",
+    };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error(`TTS request timed out after ${TTS_REQUEST_TIMEOUT_MS}ms`);
+    }
+
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/bot/commands/status.test.ts
+++ b/tests/bot/commands/status.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+import { statusCommand } from "../../../src/bot/commands/status.js";
+
+const mocked = vi.hoisted(() => ({
+  healthMock: vi.fn(),
+  getCurrentSessionMock: vi.fn(),
+  getCurrentProjectMock: vi.fn(),
+  isTtsEnabledMock: vi.fn(),
+  fetchCurrentAgentMock: vi.fn(),
+  fetchCurrentModelMock: vi.fn(),
+  isRunningMock: vi.fn(),
+  getUptimeMock: vi.fn(),
+  getPidMock: vi.fn(),
+  keyboardInitializeMock: vi.fn(),
+  keyboardUpdateContextMock: vi.fn(),
+  keyboardGetKeyboardMock: vi.fn(),
+  pinnedIsInitializedMock: vi.fn(),
+  pinnedInitializeMock: vi.fn(),
+  pinnedGetContextLimitMock: vi.fn(),
+  pinnedRefreshContextLimitMock: vi.fn(),
+  pinnedGetContextInfoMock: vi.fn(),
+  sendBotTextMock: vi.fn(),
+}));
+
+vi.mock("../../../src/opencode/client.js", () => ({
+  opencodeClient: {
+    global: {
+      health: mocked.healthMock,
+    },
+  },
+}));
+
+vi.mock("../../../src/session/manager.js", () => ({
+  getCurrentSession: mocked.getCurrentSessionMock,
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  getCurrentProject: mocked.getCurrentProjectMock,
+  isTtsEnabled: mocked.isTtsEnabledMock,
+}));
+
+vi.mock("../../../src/agent/manager.js", () => ({
+  fetchCurrentAgent: mocked.fetchCurrentAgentMock,
+}));
+
+vi.mock("../../../src/model/manager.js", () => ({
+  fetchCurrentModel: mocked.fetchCurrentModelMock,
+}));
+
+vi.mock("../../../src/process/manager.js", () => ({
+  processManager: {
+    isRunning: mocked.isRunningMock,
+    getUptime: mocked.getUptimeMock,
+    getPID: mocked.getPidMock,
+  },
+}));
+
+vi.mock("../../../src/keyboard/manager.js", () => ({
+  keyboardManager: {
+    initialize: mocked.keyboardInitializeMock,
+    updateContext: mocked.keyboardUpdateContextMock,
+    getKeyboard: mocked.keyboardGetKeyboardMock,
+  },
+}));
+
+vi.mock("../../../src/pinned/manager.js", () => ({
+  pinnedMessageManager: {
+    isInitialized: mocked.pinnedIsInitializedMock,
+    initialize: mocked.pinnedInitializeMock,
+    getContextLimit: mocked.pinnedGetContextLimitMock,
+    refreshContextLimit: mocked.pinnedRefreshContextLimitMock,
+    getContextInfo: mocked.pinnedGetContextInfoMock,
+  },
+}));
+
+vi.mock("../../../src/bot/utils/telegram-text.js", () => ({
+  sendBotText: mocked.sendBotTextMock,
+}));
+
+describe("bot/commands/status", () => {
+  beforeEach(() => {
+    mocked.healthMock.mockReset();
+    mocked.getCurrentSessionMock.mockReset();
+    mocked.getCurrentProjectMock.mockReset();
+    mocked.isTtsEnabledMock.mockReset();
+    mocked.fetchCurrentAgentMock.mockReset();
+    mocked.fetchCurrentModelMock.mockReset();
+    mocked.isRunningMock.mockReset();
+    mocked.getUptimeMock.mockReset();
+    mocked.getPidMock.mockReset();
+    mocked.keyboardInitializeMock.mockReset();
+    mocked.keyboardUpdateContextMock.mockReset();
+    mocked.keyboardGetKeyboardMock.mockReset();
+    mocked.pinnedIsInitializedMock.mockReset();
+    mocked.pinnedInitializeMock.mockReset();
+    mocked.pinnedGetContextLimitMock.mockReset();
+    mocked.pinnedRefreshContextLimitMock.mockReset();
+    mocked.pinnedGetContextInfoMock.mockReset();
+    mocked.sendBotTextMock.mockReset();
+
+    mocked.healthMock.mockResolvedValue({ data: { healthy: true, version: "1.0.0" }, error: null });
+    mocked.getCurrentSessionMock.mockReturnValue({ id: "s1", title: "S", directory: "/repo" });
+    mocked.getCurrentProjectMock.mockReturnValue({ id: "p1", worktree: "/repo", name: "Repo" });
+    mocked.isTtsEnabledMock.mockReturnValue(true);
+    mocked.fetchCurrentAgentMock.mockResolvedValue("build");
+    mocked.fetchCurrentModelMock.mockReturnValue({ providerID: "openai", modelID: "gpt-5" });
+    mocked.isRunningMock.mockReturnValue(false);
+    mocked.getUptimeMock.mockReturnValue(null);
+    mocked.getPidMock.mockReturnValue(null);
+    mocked.keyboardGetKeyboardMock.mockReturnValue({ inline_keyboard: [] });
+    mocked.pinnedIsInitializedMock.mockReturnValue(false);
+    mocked.pinnedGetContextLimitMock.mockReturnValue(200000);
+    mocked.pinnedRefreshContextLimitMock.mockResolvedValue(undefined);
+    mocked.pinnedGetContextInfoMock.mockReturnValue(null);
+    mocked.sendBotTextMock.mockResolvedValue(undefined);
+  });
+
+  it("includes TTS status in the rendered message", async () => {
+    const ctx = {
+      chat: { id: 42, type: "private" },
+      message: { text: "/status" },
+      api: {},
+      reply: vi.fn(),
+    } as unknown as Context;
+
+    await statusCommand(ctx as never);
+
+    const message = mocked.sendBotTextMock.mock.calls[0]?.[0]?.text as string;
+    expect(message).toContain("TTS replies");
+    expect(message).toContain("On");
+  });
+});

--- a/tests/bot/commands/tts.test.ts
+++ b/tests/bot/commands/tts.test.ts
@@ -25,7 +25,7 @@ describe("bot/commands/tts", () => {
     mocked.isTtsConfiguredMock.mockReset();
   });
 
-  it("enables TTS replies for the current chat", async () => {
+  it("enables audio replies globally", async () => {
     mocked.isTtsEnabledMock.mockReturnValue(false);
     mocked.isTtsConfiguredMock.mockReturnValue(true);
     const replyMock = vi.fn().mockResolvedValue(undefined);
@@ -41,7 +41,23 @@ describe("bot/commands/tts", () => {
     expect(replyMock).toHaveBeenCalledWith(t("tts.enabled"));
   });
 
-  it("disables TTS replies for the current chat", async () => {
+  it("does not enable audio replies when TTS is not configured", async () => {
+    mocked.isTtsEnabledMock.mockReturnValue(false);
+    mocked.isTtsConfiguredMock.mockReturnValue(false);
+    const replyMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 42, type: "private" },
+      message: { text: "/tts" },
+      reply: replyMock,
+    } as unknown as Context;
+
+    await ttsCommand(ctx as never);
+
+    expect(mocked.setTtsEnabledMock).not.toHaveBeenCalled();
+    expect(replyMock).toHaveBeenCalledWith(t("tts.not_configured"));
+  });
+
+  it("disables audio replies globally", async () => {
     mocked.isTtsEnabledMock.mockReturnValue(true);
     const replyMock = vi.fn().mockResolvedValue(undefined);
     const ctx = {

--- a/tests/bot/commands/tts.test.ts
+++ b/tests/bot/commands/tts.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+import { ttsCommand } from "../../../src/bot/commands/tts.js";
+import { t } from "../../../src/i18n/index.js";
+
+const mocked = vi.hoisted(() => ({
+  isTtsEnabledMock: vi.fn(),
+  setTtsEnabledMock: vi.fn(),
+  isTtsConfiguredMock: vi.fn(),
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  isTtsEnabled: mocked.isTtsEnabledMock,
+  setTtsEnabled: mocked.setTtsEnabledMock,
+}));
+
+vi.mock("../../../src/tts/client.js", () => ({
+  isTtsConfigured: mocked.isTtsConfiguredMock,
+}));
+
+describe("bot/commands/tts", () => {
+  beforeEach(() => {
+    mocked.isTtsEnabledMock.mockReset();
+    mocked.setTtsEnabledMock.mockReset();
+    mocked.isTtsConfiguredMock.mockReset();
+  });
+
+  it("enables TTS replies for the current chat", async () => {
+    mocked.isTtsEnabledMock.mockReturnValue(false);
+    mocked.isTtsConfiguredMock.mockReturnValue(true);
+    const replyMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 42, type: "private" },
+      message: { text: "/tts" },
+      reply: replyMock,
+    } as unknown as Context;
+
+    await ttsCommand(ctx as never);
+
+    expect(mocked.setTtsEnabledMock).toHaveBeenCalledWith(true);
+    expect(replyMock).toHaveBeenCalledWith(t("tts.enabled"));
+  });
+
+  it("disables TTS replies for the current chat", async () => {
+    mocked.isTtsEnabledMock.mockReturnValue(true);
+    const replyMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 42, type: "private" },
+      message: { text: "/tts" },
+      reply: replyMock,
+    } as unknown as Context;
+
+    await ttsCommand(ctx as never);
+
+    expect(mocked.setTtsEnabledMock).toHaveBeenCalledWith(false);
+    expect(replyMock).toHaveBeenCalledWith(t("tts.disabled"));
+  });
+});

--- a/tests/bot/utils/send-tts-response.test.ts
+++ b/tests/bot/utils/send-tts-response.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { InputFile } from "grammy";
+import { sendTtsResponseForSession } from "../../../src/bot/utils/send-tts-response.js";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("bot/utils/send-tts-response", () => {
+  it("sends audio when the session response mode requires TTS", async () => {
+    const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const synthesizeSpeechMock = vi.fn().mockResolvedValue({
+      buffer: Buffer.from("mp3"),
+      filename: "assistant-reply.mp3",
+      mimeType: "audio/mpeg",
+    });
+
+    const result = await sendTtsResponseForSession({
+      api: { sendAudio: sendAudioMock },
+      sessionId: "session-1",
+      chatId: 123,
+      text: "Hello from audio",
+      consumeResponseMode: () => "text_and_tts",
+      isTtsConfigured: () => true,
+      synthesizeSpeech: synthesizeSpeechMock,
+    });
+
+    expect(result).toBe(true);
+    expect(synthesizeSpeechMock).toHaveBeenCalledWith("Hello from audio");
+    expect(sendAudioMock).toHaveBeenCalledTimes(1);
+    const [chatId, inputFile] = sendAudioMock.mock.calls[0];
+    expect(chatId).toBe(123);
+    expect(inputFile).toBeInstanceOf(InputFile);
+  });
+
+  it("skips audio when the session response mode is text only", async () => {
+    const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const synthesizeSpeechMock = vi.fn();
+
+    const result = await sendTtsResponseForSession({
+      api: { sendAudio: sendAudioMock },
+      sessionId: "session-1",
+      chatId: 123,
+      text: "Hello from text",
+      consumeResponseMode: () => "text_only",
+      isTtsConfigured: () => true,
+      synthesizeSpeech: synthesizeSpeechMock,
+    });
+
+    expect(result).toBe(false);
+    expect(synthesizeSpeechMock).not.toHaveBeenCalled();
+    expect(sendAudioMock).not.toHaveBeenCalled();
+  });
+
+  it("skips audio when TTS is not configured", async () => {
+    const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const synthesizeSpeechMock = vi.fn();
+
+    const result = await sendTtsResponseForSession({
+      api: { sendAudio: sendAudioMock },
+      sessionId: "session-1",
+      chatId: 123,
+      text: "Hello from audio",
+      consumeResponseMode: () => "text_and_tts",
+      isTtsConfigured: () => false,
+      synthesizeSpeech: synthesizeSpeechMock,
+    });
+
+    expect(result).toBe(false);
+    expect(synthesizeSpeechMock).not.toHaveBeenCalled();
+    expect(sendAudioMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/bot/utils/send-tts-response.test.ts
+++ b/tests/bot/utils/send-tts-response.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { InputFile } from "grammy";
 import { sendTtsResponseForSession } from "../../../src/bot/utils/send-tts-response.js";
+import { t } from "../../../src/i18n/index.js";
 
 vi.mock("../../../src/utils/logger.js", () => ({
   logger: {
@@ -14,6 +15,7 @@ vi.mock("../../../src/utils/logger.js", () => ({
 describe("bot/utils/send-tts-response", () => {
   it("sends audio when the session response mode requires TTS", async () => {
     const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const sendMessageMock = vi.fn().mockResolvedValue(undefined);
     const synthesizeSpeechMock = vi.fn().mockResolvedValue({
       buffer: Buffer.from("mp3"),
       filename: "assistant-reply.mp3",
@@ -21,7 +23,7 @@ describe("bot/utils/send-tts-response", () => {
     });
 
     const result = await sendTtsResponseForSession({
-      api: { sendAudio: sendAudioMock },
+      api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
       chatId: 123,
       text: "Hello from audio",
@@ -36,14 +38,16 @@ describe("bot/utils/send-tts-response", () => {
     const [chatId, inputFile] = sendAudioMock.mock.calls[0];
     expect(chatId).toBe(123);
     expect(inputFile).toBeInstanceOf(InputFile);
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
   it("skips audio when the session response mode is text only", async () => {
     const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const sendMessageMock = vi.fn().mockResolvedValue(undefined);
     const synthesizeSpeechMock = vi.fn();
 
     const result = await sendTtsResponseForSession({
-      api: { sendAudio: sendAudioMock },
+      api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
       chatId: 123,
       text: "Hello from text",
@@ -55,14 +59,16 @@ describe("bot/utils/send-tts-response", () => {
     expect(result).toBe(false);
     expect(synthesizeSpeechMock).not.toHaveBeenCalled();
     expect(sendAudioMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
   it("skips audio when TTS is not configured", async () => {
     const sendAudioMock = vi.fn().mockResolvedValue(undefined);
+    const sendMessageMock = vi.fn().mockResolvedValue(undefined);
     const synthesizeSpeechMock = vi.fn();
 
     const result = await sendTtsResponseForSession({
-      api: { sendAudio: sendAudioMock },
+      api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
       chatId: 123,
       text: "Hello from audio",
@@ -74,5 +80,29 @@ describe("bot/utils/send-tts-response", () => {
     expect(result).toBe(false);
     expect(synthesizeSpeechMock).not.toHaveBeenCalled();
     expect(sendAudioMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a user-facing error when audio generation fails", async () => {
+    const sendAudioMock = vi.fn().mockRejectedValue(new Error("tts failed"));
+    const sendMessageMock = vi.fn().mockResolvedValue(undefined);
+    const synthesizeSpeechMock = vi.fn().mockResolvedValue({
+      buffer: Buffer.from("mp3"),
+      filename: "assistant-reply.mp3",
+      mimeType: "audio/mpeg",
+    });
+
+    const result = await sendTtsResponseForSession({
+      api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
+      sessionId: "session-1",
+      chatId: 123,
+      text: "Hello from audio",
+      consumeResponseMode: () => "text_and_tts",
+      isTtsConfigured: () => true,
+      synthesizeSpeech: synthesizeSpeechMock,
+    });
+
+    expect(result).toBe(false);
+    expect(sendMessageMock).toHaveBeenCalledWith(123, t("tts.failed"));
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -150,7 +150,7 @@ describe("config boolean env parsing", () => {
     expect(config.bot.taskLimit).toBe(10);
   });
 
-  it("falls back to STT credentials for TTS when dedicated vars are unset", async () => {
+  it("keeps TTS credentials unset when dedicated vars are missing", async () => {
     vi.stubEnv("STT_API_URL", "https://api.openai.com/v1");
     vi.stubEnv("STT_API_KEY", "sk-test-key");
     vi.stubEnv("TTS_API_URL", "");
@@ -159,8 +159,8 @@ describe("config boolean env parsing", () => {
 
     const config = await loadConfig();
 
-    expect(config.tts.apiUrl).toBe("https://api.openai.com/v1");
-    expect(config.tts.apiKey).toBe("sk-test-key");
+    expect(config.tts.apiUrl).toBe("");
+    expect(config.tts.apiKey).toBe("");
     expect(config.tts.model).toBe("gpt-4o-mini-tts");
     expect(config.tts.voice).toBe("alloy");
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -149,4 +149,19 @@ describe("config boolean env parsing", () => {
 
     expect(config.bot.taskLimit).toBe(10);
   });
+
+  it("falls back to STT credentials for TTS when dedicated vars are unset", async () => {
+    vi.stubEnv("STT_API_URL", "https://api.openai.com/v1");
+    vi.stubEnv("STT_API_KEY", "sk-test-key");
+    vi.stubEnv("TTS_API_URL", "");
+    vi.stubEnv("TTS_API_KEY", "");
+    vi.stubEnv("TTS_VOICE", "");
+
+    const config = await loadConfig();
+
+    expect(config.tts.apiUrl).toBe("https://api.openai.com/v1");
+    expect(config.tts.apiKey).toBe("sk-test-key");
+    expect(config.tts.model).toBe("gpt-4o-mini-tts");
+    expect(config.tts.voice).toBe("alloy");
+  });
 });

--- a/tests/tts/client.test.ts
+++ b/tests/tts/client.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockTts = vi.hoisted(() => ({
+  apiUrl: "",
+  apiKey: "",
+  model: "gpt-4o-mini-tts",
+  voice: "alloy",
+}));
+
+vi.mock("../../src/config.js", () => ({
+  config: {
+    tts: mockTts,
+    telegram: { token: "test", allowedUserId: 0, proxyUrl: "" },
+    opencode: {
+      apiUrl: "http://localhost:4096",
+      username: "opencode",
+      password: "",
+      model: { provider: "test", modelId: "test" },
+    },
+    server: { logLevel: "error" },
+    bot: {
+      sessionsListLimit: 10,
+      projectsListLimit: 10,
+      commandsListLimit: 10,
+      taskLimit: 10,
+      locale: "en",
+      serviceMessagesIntervalSec: 5,
+      hideThinkingMessages: false,
+      hideToolCallMessages: false,
+      responseStreaming: true,
+      messageFormatMode: "markdown",
+    },
+    files: { maxFileSizeKb: 100 },
+    stt: {
+      apiUrl: "",
+      apiKey: "",
+      model: "whisper-large-v3-turbo",
+      language: "",
+    },
+  },
+}));
+
+import { isTtsConfigured, synthesizeSpeech } from "../../src/tts/client.js";
+
+describe("isTtsConfigured", () => {
+  beforeEach(() => {
+    mockTts.apiUrl = "";
+    mockTts.apiKey = "";
+    mockTts.model = "gpt-4o-mini-tts";
+    mockTts.voice = "alloy";
+  });
+
+  it("returns false when credentials are missing", () => {
+    mockTts.apiUrl = "https://api.openai.com/v1";
+    expect(isTtsConfigured()).toBe(false);
+  });
+
+  it("returns true when credentials are set", () => {
+    mockTts.apiUrl = "https://api.openai.com/v1";
+    mockTts.apiKey = "sk-test-key";
+    expect(isTtsConfigured()).toBe(true);
+  });
+});
+
+describe("synthesizeSpeech", () => {
+  beforeEach(() => {
+    mockTts.apiUrl = "https://api.openai.com/v1";
+    mockTts.apiKey = "sk-test-key";
+    mockTts.model = "gpt-4o-mini-tts";
+    mockTts.voice = "alloy";
+    vi.restoreAllMocks();
+  });
+
+  it("throws when TTS is not configured", async () => {
+    mockTts.apiKey = "";
+
+    await expect(synthesizeSpeech("hello")).rejects.toThrow("TTS is not configured");
+  });
+
+  it("sends correct request and returns audio bytes", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(Uint8Array.from([1, 2, 3]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+    );
+
+    const result = await synthesizeSpeech("Hello world");
+
+    expect(result.filename).toBe("assistant-reply.mp3");
+    expect(result.mimeType).toBe("audio/mpeg");
+    expect(result.buffer).toEqual(Buffer.from([1, 2, 3]));
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/audio/speech");
+    expect(options?.method).toBe("POST");
+    expect((options?.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer sk-test-key",
+    );
+    expect((options?.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(String(options?.body))).toEqual({
+      model: "gpt-4o-mini-tts",
+      voice: "alloy",
+      input: "Hello world",
+      response_format: "mp3",
+    });
+  });
+
+  it("throws on non-OK HTTP response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Bad request", {
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+
+    await expect(synthesizeSpeech("Hello world")).rejects.toThrow(
+      "TTS API returned HTTP 400: Bad request",
+    );
+  });
+});


### PR DESCRIPTION
## Description of changes

- add configurable TTS replies with `/tts` toggle and persisted per-chat setting
- synthesize audio replies from completed assistant responses using configurable TTS provider settings
- add tests and docs for TTS config, command behavior, and audio reply flow

## Closes issue (optional)

- Closes #63

## How it was tested

<img width="624" height="434" alt="image" src="https://github.com/user-attachments/assets/e33085cc-a1d1-48d0-bdf1-82a081d9042b" />


## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [x] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described
