### PR TITLE
feat: add open command for opening directories as projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,14 @@ OPENCODE_MODEL_ID=big-pickle
 # raw = show assistant replies as plain text
 # MESSAGE_FORMAT_MODE=markdown
 
+# Directory Browser Roots (optional)
+# Comma-separated list of absolute paths that /open is allowed to browse.
+# Defaults to the user's home directory when not set.
+# Examples:
+#   OPEN_BROWSER_ROOTS=/home/user/projects
+#   OPEN_BROWSER_ROOTS=/home/user/projects,/opt/repos,/var/www
+# OPEN_BROWSER_ROOTS=
+
 # Code File Settings (optional)
 # Maximum file size in KB to send as document (default: 100)
 # CODE_FILE_MAX_SIZE_KB=100

--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,11 @@ OPENCODE_MODEL_ID=big-pickle
 # MESSAGE_FORMAT_MODE=markdown
 
 # Directory Browser Roots (optional)
-# Comma-separated list of absolute paths that /open is allowed to browse.
-# Defaults to the user's home directory when not set.
+# Comma-separated list of paths that /open is allowed to browse.
+# Supports ~ for home directory. Defaults to ~ when not set.
 # Examples:
-#   OPEN_BROWSER_ROOTS=/home/user/projects
-#   OPEN_BROWSER_ROOTS=/home/user/projects,/opt/repos,/var/www
+#   OPEN_BROWSER_ROOTS=~/projects
+#   OPEN_BROWSER_ROOTS=~/projects,~/work,/opt/repos
 # OPEN_BROWSER_ROOTS=
 
 # Code File Settings (optional)

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -168,6 +168,6 @@ Open tasks for upcoming iterations:
 
 Optional or longer-term enhancements:
 
-- [ ] Create new OpenCode projects directly from Telegram
+- [x] Create new OpenCode projects directly from Telegram
 - [ ] Add project file browsing helpers (for example, `ls` and `open` flows)
 - [ ] Add a bot settings command with in-chat UI

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ opencode-telegram config
 | `/abort`          | Abort the current task                                  |
 | `/sessions`       | Browse and switch between recent sessions               |
 | `/projects`       | Switch between OpenCode projects                        |
+| `/open`           | Add a project by browsing directories                   |
 | `/tts`            | Toggle audio replies                                    |
 | `/rename`         | Rename the current session                              |
 | `/commands`       | Browse and run custom commands                          |
@@ -161,6 +162,7 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `BOT_LOCALE`                    | Bot UI language (supported locale code, e.g. `en`, `de`, `es`, `fr`, `ru`, `zh`)                             |    No    | `en`                     |
 | `SESSIONS_LIST_LIMIT`           | Sessions per page in `/sessions`                                                                             |    No    | `10`                     |
 | `PROJECTS_LIST_LIMIT`           | Projects per page in `/projects`                                                                             |    No    | `10`                     |
+| `OPEN_BROWSER_ROOTS`            | Comma-separated paths `/open` is allowed to browse (supports `~`)                                            |    No    | `~` (home directory)     |
 | `COMMANDS_LIST_LIMIT`           | Commands per page in `/commands`                                                                             |    No    | `10`                     |
 | `TASK_LIMIT`                    | Maximum number of scheduled tasks that can exist at once                                                     |    No    | `10`                     |
 | `BASH_TOOL_DISPLAY_MAX_LENGTH`  | Maximum displayed length for `bash` tool commands in Telegram summaries; longer commands are truncated       |    No    | `128`                    |

--- a/src/bot/commands/definitions.ts
+++ b/src/bot/commands/definitions.ts
@@ -33,6 +33,7 @@ const COMMAND_DEFINITIONS: BotCommandI18nDefinition[] = [
   { command: "commands", descriptionKey: "cmd.description.commands" },
   { command: "opencode_start", descriptionKey: "cmd.description.opencode_start" },
   { command: "opencode_stop", descriptionKey: "cmd.description.opencode_stop" },
+  { command: "open", descriptionKey: "cmd.description.open" },
   { command: "help", descriptionKey: "cmd.description.help" },
 ];
 

--- a/src/bot/commands/open.ts
+++ b/src/bot/commands/open.ts
@@ -304,15 +304,16 @@ async function selectDirectory(ctx: Context, directory: string) {
   try {
     logger.info(`[Bot] Adding project directory: ${directory}`);
 
-    // Register directory in the session cache so it appears in /projects
-    await upsertSessionDirectory(directory, Date.now());
-
     const projectInfo = await getProjectByWorktree(directory);
     const replyKeyboard = await switchToProject(
       ctx,
       { ...projectInfo, name: displayPath },
       "open_project_selected",
     );
+
+    // Register directory in the session cache only after the project switch
+    // succeeded — avoids leaving a stale entry if an earlier step fails.
+    await upsertSessionDirectory(directory, Date.now());
 
     await ctx.answerCallbackQuery();
     await ctx.reply(t("open.selected", { project: displayPath }), {

--- a/src/bot/commands/open.ts
+++ b/src/bot/commands/open.ts
@@ -4,7 +4,6 @@ import { appendInlineMenuCancelButton, ensureActiveInlineMenu } from "../handler
 import { interactionManager } from "../../interaction/manager.js";
 import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
 import {
-  getHomeDirectory,
   pathToDisplayPath,
   scanDirectory,
   buildEntryLabel,
@@ -13,6 +12,7 @@ import {
   MAX_ENTRIES_PER_PAGE,
   type DirectoryEntry,
 } from "../utils/file-tree.js";
+import { getBrowserRoots, isWithinAllowedRoot, isAllowedRoot } from "../utils/browser-roots.js";
 import { upsertSessionDirectory } from "../../session/cache-manager.js";
 import { getProjectByWorktree } from "../../project/manager.js";
 import { switchToProject } from "../utils/switch-project.js";
@@ -23,7 +23,7 @@ const CALLBACK_PREFIX = "open:";
 const CALLBACK_NAV_PREFIX = "open:nav:";
 const CALLBACK_SELECT_PREFIX = "open:sel:";
 const CALLBACK_PAGE_PREFIX = "open:pg:";
-const CALLBACK_HOME = "open:home";
+const CALLBACK_ROOTS = "open:roots";
 const MAX_BUTTON_LABEL_LENGTH = 64;
 
 /**
@@ -145,17 +145,20 @@ function buildBrowseKeyboard(
     keyboard.text(label, encodePathForCallback(CALLBACK_NAV_PREFIX, entry.fullPath)).row();
   }
 
-  // Navigation: Up + Home
-  const showUp = hasParent;
-  const showHome = currentPath !== getHomeDirectory();
+  // Navigation: Up + Back to roots
+  // Suppress "Up" when at an allowed root (don't let user navigate above it)
+  const atRoot = isAllowedRoot(currentPath);
+  const showUp = hasParent && !atRoot;
+  const roots = getBrowserRoots();
+  const showRoots = roots.length > 1;
 
-  if (showUp || showHome) {
+  if (showUp || showRoots) {
     if (showUp) {
       const parentPath = path.dirname(currentPath);
       keyboard.text(t("open.back"), encodePathForCallback(CALLBACK_NAV_PREFIX, parentPath));
     }
-    if (showHome) {
-      keyboard.text(t("open.home"), CALLBACK_HOME);
+    if (showRoots) {
+      keyboard.text(t("open.roots"), CALLBACK_ROOTS);
     }
     keyboard.row();
   }
@@ -197,6 +200,19 @@ async function renderBrowseView(dirPath: string, page: number = 0) {
   return { text: header, keyboard };
 }
 
+function buildRootsKeyboard(): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const roots = getBrowserRoots();
+
+  for (const root of roots) {
+    const label = truncateLabel(`📂 ${pathToDisplayPath(root)}`);
+    keyboard.text(label, encodePathForCallback(CALLBACK_NAV_PREFIX, root)).row();
+  }
+
+  appendInlineMenuCancelButton(keyboard, "open");
+  return keyboard;
+}
+
 export async function openCommand(ctx: CommandContext<Context>) {
   try {
     if (isForegroundBusy()) {
@@ -207,16 +223,27 @@ export async function openCommand(ctx: CommandContext<Context>) {
     // Reset path index for new interaction
     clearOpenPathIndex();
 
-    const view = await renderBrowseView(getHomeDirectory());
+    const roots = getBrowserRoots();
 
-    if ("error" in view) {
-      await ctx.reply(t("open.scan_error", { error: view.error }));
-      return;
+    let text: string;
+    let keyboard: InlineKeyboard;
+
+    if (roots.length === 1) {
+      // Single root — navigate directly into it
+      const view = await renderBrowseView(roots[0]);
+      if ("error" in view) {
+        await ctx.reply(t("open.scan_error", { error: view.error }));
+        return;
+      }
+      text = view.text;
+      keyboard = view.keyboard;
+    } else {
+      // Multiple roots — show root selection
+      text = t("open.select_root");
+      keyboard = buildRootsKeyboard();
     }
 
-    const message = await ctx.reply(view.text, {
-      reply_markup: view.keyboard,
-    });
+    const message = await ctx.reply(text, { reply_markup: keyboard });
 
     interactionManager.start({
       kind: "inline",
@@ -249,15 +276,19 @@ export async function handleOpenCallback(ctx: Context): Promise<boolean> {
   }
 
   try {
-    // Navigate to home
-    if (data === CALLBACK_HOME) {
-      await navigateTo(ctx, getHomeDirectory());
+    // Back to root selection (multi-root mode)
+    if (data === CALLBACK_ROOTS) {
+      await showRoots(ctx);
       return true;
     }
 
     // Navigate into a directory (including "up")
     const navPath = decodePathFromCallback(CALLBACK_NAV_PREFIX, data);
     if (navPath !== null) {
+      if (!isWithinAllowedRoot(navPath)) {
+        await ctx.answerCallbackQuery({ text: t("open.access_denied") });
+        return true;
+      }
       await navigateTo(ctx, navPath);
       return true;
     }
@@ -265,6 +296,10 @@ export async function handleOpenCallback(ctx: Context): Promise<boolean> {
     // Pagination
     const pageInfo = decodePaginationCallback(data);
     if (pageInfo !== null) {
+      if (!isWithinAllowedRoot(pageInfo.path)) {
+        await ctx.answerCallbackQuery({ text: t("open.access_denied") });
+        return true;
+      }
       await navigateTo(ctx, pageInfo.path, pageInfo.page);
       return true;
     }
@@ -272,6 +307,10 @@ export async function handleOpenCallback(ctx: Context): Promise<boolean> {
     // Select directory as project
     const selectPath = decodePathFromCallback(CALLBACK_SELECT_PREFIX, data);
     if (selectPath !== null) {
+      if (!isWithinAllowedRoot(selectPath)) {
+        await ctx.answerCallbackQuery({ text: t("open.access_denied") });
+        return true;
+      }
       await selectDirectory(ctx, selectPath);
       return true;
     }
@@ -282,6 +321,14 @@ export async function handleOpenCallback(ctx: Context): Promise<boolean> {
     await ctx.answerCallbackQuery({ text: t("callback.processing_error") });
     return true;
   }
+}
+
+async function showRoots(ctx: Context) {
+  const text = t("open.select_root");
+  const keyboard = buildRootsKeyboard();
+
+  await ctx.answerCallbackQuery();
+  await ctx.editMessageText(text, { reply_markup: keyboard });
 }
 
 async function navigateTo(ctx: Context, dirPath: string, page: number = 0) {

--- a/src/bot/commands/open.ts
+++ b/src/bot/commands/open.ts
@@ -1,0 +1,334 @@
+import { CommandContext, Context, InlineKeyboard } from "grammy";
+import path from "node:path";
+import { appendInlineMenuCancelButton, ensureActiveInlineMenu } from "../handlers/inline-menu.js";
+import { interactionManager } from "../../interaction/manager.js";
+import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
+import {
+  getHomeDirectory,
+  pathToDisplayPath,
+  scanDirectory,
+  buildEntryLabel,
+  buildTreeHeader,
+  isScanError,
+  MAX_ENTRIES_PER_PAGE,
+  type DirectoryEntry,
+} from "../utils/file-tree.js";
+import { upsertSessionDirectory } from "../../session/cache-manager.js";
+import { getProjectByWorktree } from "../../project/manager.js";
+import { switchToProject } from "../utils/switch-project.js";
+import { logger } from "../../utils/logger.js";
+import { t } from "../../i18n/index.js";
+
+const CALLBACK_PREFIX = "open:";
+const CALLBACK_NAV_PREFIX = "open:nav:";
+const CALLBACK_SELECT_PREFIX = "open:sel:";
+const CALLBACK_PAGE_PREFIX = "open:pg:";
+const CALLBACK_HOME = "open:home";
+const MAX_BUTTON_LABEL_LENGTH = 64;
+
+/**
+ * Separator used inside pagination callback data between the encoded path
+ * reference and the page number. We avoid `:` because it appears in Windows
+ * drive letters (e.g. `C:\`) and is already used as a prefix delimiter.
+ */
+const PAGE_SEPARATOR = "|";
+
+function truncateLabel(label: string, maxLen: number = MAX_BUTTON_LABEL_LENGTH): string {
+  if (label.length <= maxLen) {
+    return label;
+  }
+  return label.slice(0, Math.max(0, maxLen - 3)) + "...";
+}
+
+/**
+ * Encode a path into callback data. Telegram limits callback_data to 64 bytes.
+ * Long absolute paths can exceed this, so we encode them as a compact index
+ * when necessary. The index is stored in a module-level map that lives for the
+ * duration of the current inline menu interaction.
+ */
+const pathIndex = new Map<string, string>();
+let pathCounter = 0;
+
+/** Clear the path index. Exported so it can be called on menu cancel/cleanup. */
+export function clearOpenPathIndex(): void {
+  pathIndex.clear();
+  pathCounter = 0;
+}
+
+/**
+ * @param prefix   Callback-data prefix that precedes the path.
+ * @param fullPath Absolute path to encode.
+ * @param reserveBytes Extra bytes to reserve for a suffix that will be
+ *   appended *after* the returned value (e.g. the page separator + digits in
+ *   pagination callbacks). The total callback_data must stay ≤ 64 bytes.
+ */
+function encodePathForCallback(prefix: string, fullPath: string, reserveBytes: number = 0): string {
+  const naive = `${prefix}${fullPath}`;
+  if (Buffer.byteLength(naive, "utf-8") + reserveBytes <= 64) {
+    return naive;
+  }
+
+  // Use a short numeric key instead
+  const key = `#${pathCounter++}`;
+  pathIndex.set(key, fullPath);
+  return `${prefix}${key}`;
+}
+
+function decodePathFromCallback(prefix: string, data: string): string | null {
+  if (!data.startsWith(prefix)) {
+    return null;
+  }
+  const raw = data.slice(prefix.length);
+  if (raw.startsWith("#")) {
+    return pathIndex.get(raw) ?? null;
+  }
+  return raw;
+}
+
+/**
+ * Encode a pagination callback. The path part goes through the same 64-byte
+ * safe encoding used by nav/select callbacks, followed by a separator and
+ * the page number.
+ *
+ * We reserve bytes for the page suffix so the 64-byte check inside
+ * `encodePathForCallback` accounts for the complete final callback length.
+ */
+function encodePaginationCallback(currentPath: string, page: number): string {
+  const pageSuffix = `${PAGE_SEPARATOR}${page}`;
+  const reserveBytes = Buffer.byteLength(pageSuffix, "utf-8");
+  const pathRef = encodePathForCallback(CALLBACK_PAGE_PREFIX, currentPath, reserveBytes);
+  return `${pathRef}${pageSuffix}`;
+}
+
+/**
+ * Decode a pagination callback into { path, page } or null on failure.
+ */
+function decodePaginationCallback(data: string): { path: string; page: number } | null {
+  if (!data.startsWith(CALLBACK_PAGE_PREFIX)) {
+    return null;
+  }
+
+  const payload = data.slice(CALLBACK_PAGE_PREFIX.length);
+  const sepIndex = payload.lastIndexOf(PAGE_SEPARATOR);
+  if (sepIndex < 0) {
+    return null;
+  }
+
+  const pathRef = payload.slice(0, sepIndex);
+  const pageNum = Number.parseInt(payload.slice(sepIndex + 1), 10);
+  if (Number.isNaN(pageNum)) {
+    return null;
+  }
+
+  // Resolve indexed path references
+  const resolvedPath = pathRef.startsWith("#") ? (pathIndex.get(pathRef) ?? null) : pathRef;
+  if (resolvedPath === null) {
+    return null;
+  }
+
+  return { path: resolvedPath, page: pageNum };
+}
+
+function buildBrowseKeyboard(
+  entries: DirectoryEntry[],
+  currentPath: string,
+  hasParent: boolean,
+  page: number,
+  totalCount: number,
+): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const totalPages = Math.max(1, Math.ceil(totalCount / MAX_ENTRIES_PER_PAGE));
+
+  // Directory entries
+  for (const entry of entries) {
+    const label = truncateLabel(buildEntryLabel(entry));
+    keyboard.text(label, encodePathForCallback(CALLBACK_NAV_PREFIX, entry.fullPath)).row();
+  }
+
+  // Navigation: Up + Home
+  const showUp = hasParent;
+  const showHome = currentPath !== getHomeDirectory();
+
+  if (showUp || showHome) {
+    if (showUp) {
+      const parentPath = path.dirname(currentPath);
+      keyboard.text(t("open.back"), encodePathForCallback(CALLBACK_NAV_PREFIX, parentPath));
+    }
+    if (showHome) {
+      keyboard.text(t("open.home"), CALLBACK_HOME);
+    }
+    keyboard.row();
+  }
+
+  // Pagination
+  if (totalPages > 1) {
+    if (page > 0) {
+      keyboard.text(t("open.prev_page"), encodePaginationCallback(currentPath, page - 1));
+    }
+    if (page < totalPages - 1) {
+      keyboard.text(t("open.next_page"), encodePaginationCallback(currentPath, page + 1));
+    }
+    keyboard.row();
+  }
+
+  // Select current folder
+  keyboard
+    .text(t("open.select_current"), encodePathForCallback(CALLBACK_SELECT_PREFIX, currentPath))
+    .row();
+
+  // Cancel
+  appendInlineMenuCancelButton(keyboard, "open");
+
+  return keyboard;
+}
+
+async function renderBrowseView(dirPath: string, page: number = 0) {
+  const result = await scanDirectory(dirPath, page);
+
+  if (isScanError(result)) {
+    return { error: result.error };
+  }
+
+  const { entries, totalCount, currentPath, displayPath, hasParent } = result;
+  const totalPages = Math.max(1, Math.ceil(totalCount / MAX_ENTRIES_PER_PAGE));
+  const header = buildTreeHeader(displayPath, totalCount, page, totalPages);
+  const keyboard = buildBrowseKeyboard(entries, currentPath, hasParent, page, totalCount);
+
+  return { text: header, keyboard };
+}
+
+export async function openCommand(ctx: CommandContext<Context>) {
+  try {
+    if (isForegroundBusy()) {
+      await replyBusyBlocked(ctx);
+      return;
+    }
+
+    // Reset path index for new interaction
+    clearOpenPathIndex();
+
+    const view = await renderBrowseView(getHomeDirectory());
+
+    if ("error" in view) {
+      await ctx.reply(t("open.scan_error", { error: view.error }));
+      return;
+    }
+
+    const message = await ctx.reply(view.text, {
+      reply_markup: view.keyboard,
+    });
+
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      metadata: {
+        menuKind: "open",
+        messageId: message.message_id,
+      },
+    });
+  } catch (error) {
+    logger.error("[Bot] Error opening directory browser:", error);
+    await ctx.reply(t("open.open_error"));
+  }
+}
+
+export async function handleOpenCallback(ctx: Context): Promise<boolean> {
+  const data = ctx.callbackQuery?.data;
+  if (!data || !data.startsWith(CALLBACK_PREFIX)) {
+    return false;
+  }
+
+  if (isForegroundBusy()) {
+    await replyBusyBlocked(ctx);
+    return true;
+  }
+
+  const isActiveMenu = await ensureActiveInlineMenu(ctx, "open");
+  if (!isActiveMenu) {
+    return true;
+  }
+
+  try {
+    // Navigate to home
+    if (data === CALLBACK_HOME) {
+      await navigateTo(ctx, getHomeDirectory());
+      return true;
+    }
+
+    // Navigate into a directory (including "up")
+    const navPath = decodePathFromCallback(CALLBACK_NAV_PREFIX, data);
+    if (navPath !== null) {
+      await navigateTo(ctx, navPath);
+      return true;
+    }
+
+    // Pagination
+    const pageInfo = decodePaginationCallback(data);
+    if (pageInfo !== null) {
+      await navigateTo(ctx, pageInfo.path, pageInfo.page);
+      return true;
+    }
+
+    // Select directory as project
+    const selectPath = decodePathFromCallback(CALLBACK_SELECT_PREFIX, data);
+    if (selectPath !== null) {
+      await selectDirectory(ctx, selectPath);
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    logger.error("[Bot] Error handling open callback:", error);
+    await ctx.answerCallbackQuery({ text: t("callback.processing_error") });
+    return true;
+  }
+}
+
+async function navigateTo(ctx: Context, dirPath: string, page: number = 0) {
+  const view = await renderBrowseView(dirPath, page);
+
+  if ("error" in view) {
+    await ctx.answerCallbackQuery({ text: view.error });
+    return;
+  }
+
+  await ctx.answerCallbackQuery();
+  await ctx.editMessageText(view.text, {
+    reply_markup: view.keyboard,
+  });
+}
+
+async function selectDirectory(ctx: Context, directory: string) {
+  const displayPath = pathToDisplayPath(directory);
+
+  try {
+    logger.info(`[Bot] Adding project directory: ${directory}`);
+
+    // Register directory in the session cache so it appears in /projects
+    await upsertSessionDirectory(directory, Date.now());
+
+    const projectInfo = await getProjectByWorktree(directory);
+    const replyKeyboard = await switchToProject(
+      ctx,
+      { ...projectInfo, name: displayPath },
+      "open_project_selected",
+    );
+
+    await ctx.answerCallbackQuery();
+    await ctx.reply(t("open.selected", { project: displayPath }), {
+      reply_markup: replyKeyboard,
+    });
+
+    // Clean up the inline menu message
+    await ctx.deleteMessage();
+
+    // Clear path index after selection
+    clearOpenPathIndex();
+
+    logger.info(`[Bot] Project added and selected: ${displayPath}`);
+  } catch (error) {
+    logger.error("[Bot] Error selecting directory:", error);
+    await ctx.answerCallbackQuery({ text: t("callback.processing_error") });
+    await ctx.reply(t("open.select_error"));
+  }
+}

--- a/src/bot/commands/open.ts
+++ b/src/bot/commands/open.ts
@@ -351,16 +351,19 @@ async function selectDirectory(ctx: Context, directory: string) {
   try {
     logger.info(`[Bot] Adding project directory: ${directory}`);
 
+    // Register directory in the session cache first — getProjectByWorktree
+    // needs the entry to exist so it can resolve the project. If the
+    // subsequent switch fails, the entry stays in the cache, which is
+    // acceptable: it's a real directory the user explicitly selected and
+    // will simply appear in /projects for retry.
+    await upsertSessionDirectory(directory, Date.now());
+
     const projectInfo = await getProjectByWorktree(directory);
     const replyKeyboard = await switchToProject(
       ctx,
       { ...projectInfo, name: displayPath },
       "open_project_selected",
     );
-
-    // Register directory in the session cache only after the project switch
-    // succeeded — avoids leaving a stale entry if an earlier step fails.
-    await upsertSessionDirectory(directory, Date.now());
 
     await ctx.answerCallbackQuery();
     await ctx.reply(t("open.selected", { project: displayPath }), {

--- a/src/bot/commands/open.ts
+++ b/src/bot/commands/open.ts
@@ -189,10 +189,10 @@ async function renderBrowseView(dirPath: string, page: number = 0) {
     return { error: result.error };
   }
 
-  const { entries, totalCount, currentPath, displayPath, hasParent } = result;
+  const { entries, totalCount, page: clampedPage, currentPath, displayPath, hasParent } = result;
   const totalPages = Math.max(1, Math.ceil(totalCount / MAX_ENTRIES_PER_PAGE));
-  const header = buildTreeHeader(displayPath, totalCount, page, totalPages);
-  const keyboard = buildBrowseKeyboard(entries, currentPath, hasParent, page, totalCount);
+  const header = buildTreeHeader(displayPath, totalCount, clampedPage, totalPages);
+  const keyboard = buildBrowseKeyboard(entries, currentPath, hasParent, clampedPage, totalCount);
 
   return { text: header, keyboard };
 }

--- a/src/bot/commands/projects.ts
+++ b/src/bot/commands/projects.ts
@@ -1,22 +1,16 @@
 import { CommandContext, Context } from "grammy";
 import { InlineKeyboard } from "grammy";
-import { setCurrentProject, getCurrentProject } from "../../settings/manager.js";
+import { getCurrentProject } from "../../settings/manager.js";
 import { getProjects } from "../../project/manager.js";
 import { syncSessionDirectoryCache } from "../../session/cache-manager.js";
-import { clearSession } from "../../session/manager.js";
-import { summaryAggregator } from "../../summary/aggregator.js";
-import { pinnedMessageManager } from "../../pinned/manager.js";
-import { keyboardManager } from "../../keyboard/manager.js";
-import { getStoredAgent, resolveProjectAgent } from "../../agent/manager.js";
-import { getStoredModel } from "../../model/manager.js";
-import { formatVariantForButton } from "../../variant/manager.js";
-import { clearAllInteractionState } from "../../interaction/cleanup.js";
-import { createMainKeyboard } from "../utils/keyboard.js";
+
 import {
   appendInlineMenuCancelButton,
   ensureActiveInlineMenu,
   replyWithInlineMenu,
 } from "../handlers/inline-menu.js";
+import { switchToProject } from "../utils/switch-project.js";
+import { clearAllInteractionState } from "../../interaction/cleanup.js";
 import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
@@ -257,43 +251,11 @@ export async function handleProjectSelect(ctx: Context): Promise<boolean> {
       throw new Error(`Project with id ${projectId} not found`);
     }
 
-    logger.info(
-      `[Bot] Project selected: ${selectedProject.name || selectedProject.worktree} (id: ${projectId})`,
-    );
-
-    setCurrentProject(selectedProject);
-    clearSession();
-    summaryAggregator.clear();
-    clearAllInteractionState("project_switched");
-
-    // Clear pinned message when switching projects
-    try {
-      await pinnedMessageManager.clear();
-    } catch (err) {
-      logger.error("[Bot] Error clearing pinned message:", err);
-    }
-
-    // Initialize keyboard manager if not already
-    if (ctx.chat) {
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
-    }
-
-    // Refresh context limit for current model
-    await pinnedMessageManager.refreshContextLimit();
-    const contextLimit = pinnedMessageManager.getContextLimit();
-
-    // Reset context to 0 (no session selected) with current model's limit
-    keyboardManager.updateContext(0, contextLimit);
-
-    // Get current state for keyboard (with context = 0)
-    const currentAgent = await resolveProjectAgent(getStoredAgent());
-    const currentModel = getStoredModel();
-    const contextInfo = { tokensUsed: 0, tokensLimit: contextLimit };
-    const variantName = formatVariantForButton(currentModel.variant || "default");
-    keyboardManager.updateAgent(currentAgent);
-    const keyboard = createMainKeyboard(currentAgent, currentModel, contextInfo, variantName);
-
     const projectName = selectedProject.name || selectedProject.worktree;
+
+    logger.info(`[Bot] Project selected: ${projectName} (id: ${projectId})`);
+
+    const keyboard = await switchToProject(ctx, selectedProject, "project_switched");
 
     await ctx.answerCallbackQuery();
     await ctx.reply(t("projects.selected", { project: projectName }), {

--- a/src/bot/handlers/inline-menu.ts
+++ b/src/bot/handlers/inline-menu.ts
@@ -7,7 +7,15 @@ import { t } from "../../i18n/index.js";
 const INLINE_MENU_CANCEL_PREFIX = "inline:cancel:";
 const LEGACY_CONTEXT_CANCEL_CALLBACK = "compact:cancel";
 
-const INLINE_MENU_KINDS = ["project", "session", "model", "agent", "variant", "context"] as const;
+const INLINE_MENU_KINDS = [
+  "project",
+  "session",
+  "model",
+  "agent",
+  "variant",
+  "context",
+  "open",
+] as const;
 
 export type InlineMenuKind = (typeof INLINE_MENU_KINDS)[number];
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -20,6 +20,7 @@ import {
 import { sessionsCommand, handleSessionSelect } from "./commands/sessions.js";
 import { newCommand } from "./commands/new.js";
 import { projectsCommand, handleProjectSelect } from "./commands/projects.js";
+import { openCommand, handleOpenCallback, clearOpenPathIndex } from "./commands/open.js";
 import { abortCommand } from "./commands/abort.js";
 import { opencodeStartCommand } from "./commands/opencode-start.js";
 import { opencodeStopCommand } from "./commands/opencode-stop.js";
@@ -911,6 +912,7 @@ export function createBot(): Bot<Context> {
   bot.command("opencode_start", opencodeStartCommand);
   bot.command("opencode_stop", opencodeStopCommand);
   bot.command("projects", projectsCommand);
+  bot.command("open", openCommand);
   bot.command("sessions", sessionsCommand);
   bot.command("new", newCommand);
   bot.command("abort", abortCommand);
@@ -932,8 +934,13 @@ export function createBot(): Bot<Context> {
 
     try {
       const handledInlineCancel = await handleInlineMenuCancel(ctx);
+      if (handledInlineCancel) {
+        // Clean up path index when the open-directory menu is cancelled
+        clearOpenPathIndex();
+      }
       const handledSession = await handleSessionSelect(ctx);
       const handledProject = await handleProjectSelect(ctx);
+      const handledOpen = await handleOpenCallback(ctx);
       const handledQuestion = await handleQuestionCallback(ctx);
       const handledPermission = await handlePermissionCallback(ctx);
       const handledAgent = await handleAgentSelect(ctx);
@@ -946,13 +953,14 @@ export function createBot(): Bot<Context> {
       const handledCommands = await handleCommandsCallback(ctx, { bot, ensureEventSubscription });
 
       logger.debug(
-        `[Bot] Callback handled: inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}`,
+        `[Bot] Callback handled: inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, open=${handledOpen}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}`,
       );
 
       if (
         !handledInlineCancel &&
         !handledSession &&
         !handledProject &&
+        !handledOpen &&
         !handledQuestion &&
         !handledPermission &&
         !handledAgent &&

--- a/src/bot/utils/browser-roots.ts
+++ b/src/bot/utils/browser-roots.ts
@@ -20,10 +20,24 @@ function isWindows(): boolean {
 }
 
 /**
- * Normalize a path for comparison: resolve, then lowercase on Windows.
+ * Expand a leading `~` or `~/` to the user's home directory.
+ * Does not handle `~user/` syntax — only the current user's home.
+ */
+function expandTilde(p: string): string {
+  if (p === "~") {
+    return os.homedir();
+  }
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Normalize a path for comparison: expand tilde, resolve, then lowercase on Windows.
  */
 function normalizePath(p: string): string {
-  const resolved = path.resolve(p);
+  const resolved = path.resolve(expandTilde(p));
   return isWindows() ? resolved.toLowerCase() : resolved;
 }
 

--- a/src/bot/utils/browser-roots.ts
+++ b/src/bot/utils/browser-roots.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { realpath } from "node:fs/promises";
+import os from "node:os";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Allowed root directories for the `/open` command.
+ *
+ * Configured via `OPEN_BROWSER_ROOTS` env var (comma-separated absolute paths).
+ * Defaults to `[os.homedir()]` when the variable is not set.
+ *
+ * All navigation in the directory browser is restricted to stay within one
+ * of the configured roots. This prevents the bot from browsing arbitrary
+ * locations on the filesystem.
+ */
+let resolvedRoots: string[] | null = null;
+
+function isWindows(): boolean {
+  return process.platform === "win32";
+}
+
+/**
+ * Normalize a path for comparison: resolve, then lowercase on Windows.
+ */
+function normalizePath(p: string): string {
+  const resolved = path.resolve(p);
+  return isWindows() ? resolved.toLowerCase() : resolved;
+}
+
+/**
+ * Initialize (or re-initialize) the allowed browser roots from the raw
+ * env string. Each entry is resolved to an absolute path via `path.resolve`.
+ *
+ * Entries that cannot be resolved are logged and skipped.
+ */
+export function initBrowserRoots(raw?: string): void {
+  if (!raw || raw.trim() === "") {
+    resolvedRoots = [normalizePath(os.homedir())];
+    logger.debug(
+      `[BrowserRoots] No OPEN_BROWSER_ROOTS configured, defaulting to home: ${resolvedRoots[0]}`,
+    );
+    return;
+  }
+
+  const entries = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const roots: string[] = [];
+  for (const entry of entries) {
+    const normalized = normalizePath(entry);
+    roots.push(normalized);
+  }
+
+  if (roots.length === 0) {
+    resolvedRoots = [normalizePath(os.homedir())];
+    logger.warn("[BrowserRoots] All configured roots were invalid, falling back to home directory");
+  } else {
+    resolvedRoots = roots;
+    logger.info(`[BrowserRoots] Configured roots: ${roots.join(", ")}`);
+  }
+}
+
+/**
+ * Return the configured browser roots. Lazily initializes from env if
+ * `initBrowserRoots` was never called.
+ */
+export function getBrowserRoots(): string[] {
+  if (resolvedRoots === null) {
+    initBrowserRoots(process.env.OPEN_BROWSER_ROOTS);
+  }
+  return resolvedRoots!;
+}
+
+/**
+ * Return the original (non-normalized) root paths for display/navigation.
+ * On Windows the display roots are lowercased because `normalizePath` is
+ * used during init — this is acceptable for button labels.
+ */
+export function getBrowserRootPaths(): string[] {
+  return getBrowserRoots();
+}
+
+/**
+ * Check whether a target path is inside one of the allowed roots.
+ *
+ * Uses `path.resolve` on the target for consistent comparison, then
+ * checks that the target equals a root or is a descendant (starts with
+ * root + separator).
+ *
+ * For full symlink-proof validation, callers can optionally resolve the
+ * target with `fs.realpath` before calling this function.
+ */
+export function isWithinAllowedRoot(targetPath: string): boolean {
+  const normalizedTarget = normalizePath(targetPath);
+  const roots = getBrowserRoots();
+
+  for (const root of roots) {
+    if (normalizedTarget === root) {
+      return true;
+    }
+    // Check both separators — `path.sep` is always `/` on Unix but a
+    // lowercased Windows path may contain either `\` or `/`.
+    if (normalizedTarget.startsWith(root + "/") || normalizedTarget.startsWith(root + "\\")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Like `isWithinAllowedRoot` but resolves symlinks first using `realpath`.
+ * Falls back to the plain path if `realpath` fails (e.g. ENOENT).
+ */
+export async function isWithinAllowedRootSafe(targetPath: string): Promise<boolean> {
+  let resolved = targetPath;
+  try {
+    resolved = await realpath(targetPath);
+  } catch {
+    // Path doesn't exist yet or can't be resolved — use as-is
+  }
+  return isWithinAllowedRoot(resolved);
+}
+
+/**
+ * Check whether a path is exactly one of the allowed roots (not a descendant).
+ */
+export function isAllowedRoot(targetPath: string): boolean {
+  const normalizedTarget = normalizePath(targetPath);
+  return getBrowserRoots().includes(normalizedTarget);
+}
+
+/** Reset state — for testing only. */
+export function __resetBrowserRootsForTests(): void {
+  resolvedRoots = null;
+}

--- a/src/bot/utils/file-tree.ts
+++ b/src/bot/utils/file-tree.ts
@@ -1,0 +1,128 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { t } from "../../i18n/index.js";
+
+export interface DirectoryEntry {
+  name: string;
+  fullPath: string;
+}
+
+export interface DirectoryScanResult {
+  entries: DirectoryEntry[];
+  totalCount: number;
+  currentPath: string;
+  displayPath: string;
+  hasParent: boolean;
+  parentPath: string | null;
+}
+
+export interface DirectoryScanError {
+  error: string;
+  code: "ENOENT" | "EACCES" | "ENOTDIR" | "UNKNOWN";
+}
+
+export const MAX_ENTRIES_PER_PAGE = 8;
+
+export function getHomeDirectory(): string {
+  return os.homedir();
+}
+
+export function pathToDisplayPath(absolutePath: string): string {
+  const home = getHomeDirectory();
+  if (absolutePath === home) {
+    return "~";
+  }
+
+  if (absolutePath.startsWith(home + path.sep)) {
+    return "~" + absolutePath.slice(home.length);
+  }
+
+  return absolutePath;
+}
+
+export async function scanDirectory(
+  dirPath: string,
+  page: number = 0,
+): Promise<DirectoryScanResult | DirectoryScanError> {
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const subdirs: DirectoryEntry[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory() && !entry.name.startsWith(".")) {
+        subdirs.push({
+          name: entry.name,
+          fullPath: path.join(dirPath, entry.name),
+        });
+      }
+    }
+
+    subdirs.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+
+    const parentPath = path.dirname(dirPath);
+    const hasParent = dirPath !== path.parse(dirPath).root;
+
+    const start = page * MAX_ENTRIES_PER_PAGE;
+    const pageEntries = subdirs.slice(start, start + MAX_ENTRIES_PER_PAGE);
+
+    return {
+      entries: pageEntries,
+      totalCount: subdirs.length,
+      currentPath: dirPath,
+      displayPath: pathToDisplayPath(dirPath),
+      hasParent,
+      parentPath: hasParent ? parentPath : null,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      if ("code" in error) {
+        const code = error.code as string;
+        if (code === "ENOENT" || code === "ELOOP") {
+          return { error: `Directory not found: ${dirPath}`, code: "ENOENT" };
+        }
+        if (code === "EACCES" || code === "EPERM") {
+          return { error: `Permission denied: ${dirPath}`, code: "EACCES" };
+        }
+        if (code === "ENOTDIR") {
+          return { error: `Not a directory: ${dirPath}`, code: "ENOTDIR" };
+        }
+      }
+    }
+
+    return {
+      error: error instanceof Error ? error.message : "Unknown error",
+      code: "UNKNOWN",
+    };
+  }
+}
+
+export function buildEntryLabel(entry: DirectoryEntry): string {
+  return `📁 ${entry.name}`;
+}
+
+export function buildTreeHeader(
+  displayPath: string,
+  totalCount: number,
+  page: number,
+  totalPages: number,
+): string {
+  let header = `📂 ${displayPath}`;
+  if (totalPages > 1) {
+    header += `  (${page + 1}/${totalPages})`;
+  }
+  if (totalCount === 0) {
+    header += `\n${t("open.no_subfolders")}`;
+  } else if (totalCount === 1) {
+    header += `\n${t("open.subfolder_count", { count: String(totalCount) })}`;
+  } else {
+    header += `\n${t("open.subfolders_count", { count: String(totalCount) })}`;
+  }
+  return header;
+}
+
+export function isScanError(
+  result: DirectoryScanResult | DirectoryScanError,
+): result is DirectoryScanError {
+  return "error" in result;
+}

--- a/src/bot/utils/file-tree.ts
+++ b/src/bot/utils/file-tree.ts
@@ -11,6 +11,7 @@ export interface DirectoryEntry {
 export interface DirectoryScanResult {
   entries: DirectoryEntry[];
   totalCount: number;
+  page: number;
   currentPath: string;
   displayPath: string;
   hasParent: boolean;
@@ -63,12 +64,18 @@ export async function scanDirectory(
     const parentPath = path.dirname(dirPath);
     const hasParent = dirPath !== path.parse(dirPath).root;
 
-    const start = page * MAX_ENTRIES_PER_PAGE;
+    // Clamp page to valid range so stale or crafted callbacks never produce
+    // an out-of-bounds page indicator like "(4/2)".
+    const totalPages = Math.max(1, Math.ceil(subdirs.length / MAX_ENTRIES_PER_PAGE));
+    const safePage = Math.max(0, Math.min(page, totalPages - 1));
+
+    const start = safePage * MAX_ENTRIES_PER_PAGE;
     const pageEntries = subdirs.slice(start, start + MAX_ENTRIES_PER_PAGE);
 
     return {
       entries: pageEntries,
       totalCount: subdirs.length,
+      page: safePage,
       currentPath: dirPath,
       displayPath: pathToDisplayPath(dirPath),
       hasParent,

--- a/src/bot/utils/switch-project.ts
+++ b/src/bot/utils/switch-project.ts
@@ -1,0 +1,55 @@
+import type { Context } from "grammy";
+import type { ProjectInfo } from "../../settings/manager.js";
+import { setCurrentProject } from "../../settings/manager.js";
+import { clearSession } from "../../session/manager.js";
+import { summaryAggregator } from "../../summary/aggregator.js";
+import { pinnedMessageManager } from "../../pinned/manager.js";
+import { keyboardManager } from "../../keyboard/manager.js";
+import { getStoredAgent, resolveProjectAgent } from "../../agent/manager.js";
+import { getStoredModel } from "../../model/manager.js";
+import { formatVariantForButton } from "../../variant/manager.js";
+import { clearAllInteractionState } from "../../interaction/cleanup.js";
+import { createMainKeyboard } from "./keyboard.js";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Shared logic for switching the active project.
+ *
+ * Called by both `/projects` (selecting an existing project) and `/open`
+ * (browsing and adding a new directory). Performs the full state transition:
+ * persists the project, clears the session, resets the pinned message and
+ * keyboard, and returns a fresh reply keyboard for the caller to attach to
+ * its confirmation message.
+ *
+ * @param ctx       grammY callback context (used for `ctx.chat` / `ctx.api`)
+ * @param project   the project to switch to
+ * @param reason    short tag for `clearAllInteractionState` (e.g. "project_switched")
+ */
+export async function switchToProject(ctx: Context, project: ProjectInfo, reason: string) {
+  setCurrentProject(project);
+  clearSession();
+  summaryAggregator.clear();
+  clearAllInteractionState(reason);
+
+  try {
+    await pinnedMessageManager.clear();
+  } catch (err) {
+    logger.error("[Bot] Error clearing pinned message:", err);
+  }
+
+  if (ctx.chat) {
+    keyboardManager.initialize(ctx.api, ctx.chat.id);
+  }
+
+  await pinnedMessageManager.refreshContextLimit();
+  const contextLimit = pinnedMessageManager.getContextLimit();
+  keyboardManager.updateContext(0, contextLimit);
+
+  const currentAgent = await resolveProjectAgent(getStoredAgent());
+  const currentModel = getStoredModel();
+  const contextInfo = { tokensUsed: 0, tokensLimit: contextLimit };
+  const variantName = formatVariantForButton(currentModel.variant || "default");
+  keyboardManager.updateAgent(currentAgent);
+
+  return createMainKeyboard(currentAgent, currentModel, contextInfo, variantName);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,9 @@ export const config = {
   files: {
     maxFileSizeKb: parseInt(getEnvVar("CODE_FILE_MAX_SIZE_KB", false) || "100", 10),
   },
+  open: {
+    browserRoots: getEnvVar("OPEN_BROWSER_ROOTS", false),
+  },
   stt: {
     apiUrl: getEnvVar("STT_API_URL", false),
     apiKey: getEnvVar("STT_API_KEY", false),

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -463,4 +463,19 @@ export const de: I18nDictionary = {
     "🎤 Spracherkennung ist nicht konfiguriert.\n\nSetze STT_API_URL und STT_API_KEY in .env, um sie zu aktivieren.",
   "stt.error": "🔴 Audio konnte nicht erkannt werden: {error}",
   "stt.empty_result": "🎤 Keine Sprache in der Audionachricht erkannt.",
+
+  "cmd.description.open": "Projekt durch Ordner-Auswahl hinzufügen",
+  "open.back": "⬆️ Hoch",
+  "open.home": "🏠 Home",
+  "open.prev_page": "⬅️ Zurück",
+  "open.next_page": "Weiter ➡️",
+  "open.select_current": "✅ Diesen Ordner wählen",
+  "open.scan_error": "🔴 Verzeichnis kann nicht durchsucht werden: {error}",
+  "open.open_error": "🔴 Verzeichnisbrowser konnte nicht geöffnet werden.",
+  "open.selected":
+    "✅ Projekt hinzugefügt: {project}\n\n📋 Verwende /sessions oder /new zum Arbeiten.",
+  "open.select_error": "🔴 Projekt konnte nicht hinzugefügt werden.",
+  "open.no_subfolders": "📭 Keine Unterordner",
+  "open.subfolder_count": "{count} Unterordner",
+  "open.subfolders_count": "{count} Unterordner",
 };

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -466,10 +466,12 @@ export const de: I18nDictionary = {
 
   "cmd.description.open": "Projekt durch Ordner-Auswahl hinzufügen",
   "open.back": "⬆️ Hoch",
-  "open.home": "🏠 Home",
+  "open.roots": "📋 Zurück zur Auswahl",
   "open.prev_page": "⬅️ Zurück",
   "open.next_page": "Weiter ➡️",
   "open.select_current": "✅ Diesen Ordner wählen",
+  "open.select_root": "📂 Stammverzeichnis zum Durchsuchen wählen:",
+  "open.access_denied": "⛔ Zugriff verweigert: Pfad liegt außerhalb erlaubter Verzeichnisse",
   "open.scan_error": "🔴 Verzeichnis kann nicht durchsucht werden: {error}",
   "open.open_error": "🔴 Verzeichnisbrowser konnte nicht geöffnet werden.",
   "open.selected":

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -449,10 +449,12 @@ export const en = {
 
   "cmd.description.open": "Add a project by browsing directories",
   "open.back": "⬆️ Up",
-  "open.home": "🏠 Home",
+  "open.roots": "📋 Back to roots",
   "open.prev_page": "⬅️ Previous",
   "open.next_page": "Next ➡️",
   "open.select_current": "✅ Select this folder",
+  "open.select_root": "📂 Select a root directory to browse:",
+  "open.access_denied": "⛔ Access denied: path is outside allowed roots",
   "open.scan_error": "🔴 Cannot browse directory: {error}",
   "open.open_error": "🔴 Failed to open directory browser.",
   "open.selected": "✅ Project added: {project}\n\n📋 Use /sessions or /new to start working.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -446,6 +446,20 @@ export const en = {
     "🎤 Voice recognition is not configured.\n\nSet STT_API_URL and STT_API_KEY in .env to enable it.",
   "stt.error": "🔴 Failed to recognize audio: {error}",
   "stt.empty_result": "🎤 No speech detected in the audio message.",
+
+  "cmd.description.open": "Add a project by browsing directories",
+  "open.back": "⬆️ Up",
+  "open.home": "🏠 Home",
+  "open.prev_page": "⬅️ Previous",
+  "open.next_page": "Next ➡️",
+  "open.select_current": "✅ Select this folder",
+  "open.scan_error": "🔴 Cannot browse directory: {error}",
+  "open.open_error": "🔴 Failed to open directory browser.",
+  "open.selected": "✅ Project added: {project}\n\n📋 Use /sessions or /new to start working.",
+  "open.select_error": "🔴 Failed to add project.",
+  "open.no_subfolders": "📭 No subfolders",
+  "open.subfolder_count": "{count} subfolder",
+  "open.subfolders_count": "{count} subfolders",
 } as const;
 
 export type I18nKey = keyof typeof en;

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -465,10 +465,12 @@ export const es: I18nDictionary = {
 
   "cmd.description.open": "Añadir proyecto navegando directorios",
   "open.back": "⬆️ Subir",
-  "open.home": "🏠 Inicio",
+  "open.roots": "📋 Volver a raíces",
   "open.prev_page": "⬅️ Anterior",
   "open.next_page": "Siguiente ➡️",
   "open.select_current": "✅ Seleccionar esta carpeta",
+  "open.select_root": "📂 Selecciona un directorio raíz para explorar:",
+  "open.access_denied": "⛔ Acceso denegado: la ruta está fuera de los directorios permitidos",
   "open.scan_error": "🔴 No se puede explorar el directorio: {error}",
   "open.open_error": "🔴 No se pudo abrir el explorador de directorios.",
   "open.selected":

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -462,4 +462,19 @@ export const es: I18nDictionary = {
     "🎤 El reconocimiento de voz no está configurado.\n\nConfigura STT_API_URL y STT_API_KEY en .env para habilitarlo.",
   "stt.error": "🔴 No se pudo reconocer el audio: {error}",
   "stt.empty_result": "🎤 No se detectó voz en el mensaje de audio.",
+
+  "cmd.description.open": "Añadir proyecto navegando directorios",
+  "open.back": "⬆️ Subir",
+  "open.home": "🏠 Inicio",
+  "open.prev_page": "⬅️ Anterior",
+  "open.next_page": "Siguiente ➡️",
+  "open.select_current": "✅ Seleccionar esta carpeta",
+  "open.scan_error": "🔴 No se puede explorar el directorio: {error}",
+  "open.open_error": "🔴 No se pudo abrir el explorador de directorios.",
+  "open.selected":
+    "✅ Proyecto añadido: {project}\n\n📋 Usa /sessions o /new para empezar a trabajar.",
+  "open.select_error": "🔴 No se pudo añadir el proyecto.",
+  "open.no_subfolders": "📭 Sin subcarpetas",
+  "open.subfolder_count": "{count} subcarpeta",
+  "open.subfolders_count": "{count} subcarpetas",
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -467,10 +467,12 @@ export const fr: I18nDictionary = {
 
   "cmd.description.open": "Ajouter un projet en parcourant les dossiers",
   "open.back": "⬆️ Remonter",
-  "open.home": "🏠 Accueil",
+  "open.roots": "📋 Retour aux racines",
   "open.prev_page": "⬅️ Précédent",
   "open.next_page": "Suivant ➡️",
   "open.select_current": "✅ Sélectionner ce dossier",
+  "open.select_root": "📂 Sélectionnez un répertoire racine à parcourir :",
+  "open.access_denied": "⛔ Accès refusé : le chemin est en dehors des répertoires autorisés",
   "open.scan_error": "🔴 Impossible de parcourir le répertoire : {error}",
   "open.open_error": "🔴 Impossible d'ouvrir l'explorateur de répertoires.",
   "open.selected": "✅ Projet ajouté : {project}\n\n📋 Utilisez /sessions ou /new pour commencer.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -464,4 +464,18 @@ export const fr: I18nDictionary = {
     "🎤 La reconnaissance vocale n'est pas configurée.\n\nDéfinissez STT_API_URL et STT_API_KEY dans .env pour l'activer.",
   "stt.error": "🔴 Impossible de reconnaître l'audio : {error}",
   "stt.empty_result": "🎤 Aucune parole détectée dans le message audio.",
+
+  "cmd.description.open": "Ajouter un projet en parcourant les dossiers",
+  "open.back": "⬆️ Remonter",
+  "open.home": "🏠 Accueil",
+  "open.prev_page": "⬅️ Précédent",
+  "open.next_page": "Suivant ➡️",
+  "open.select_current": "✅ Sélectionner ce dossier",
+  "open.scan_error": "🔴 Impossible de parcourir le répertoire : {error}",
+  "open.open_error": "🔴 Impossible d'ouvrir l'explorateur de répertoires.",
+  "open.selected": "✅ Projet ajouté : {project}\n\n📋 Utilisez /sessions ou /new pour commencer.",
+  "open.select_error": "🔴 Impossible d'ajouter le projet.",
+  "open.no_subfolders": "📭 Aucun sous-dossier",
+  "open.subfolder_count": "{count} sous-dossier",
+  "open.subfolders_count": "{count} sous-dossiers",
 };

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -450,4 +450,19 @@ export const ru: I18nDictionary = {
     "🎤 Распознавание голоса не настроено.\n\nУстановите STT_API_URL и STT_API_KEY в .env для включения.",
   "stt.error": "🔴 Не удалось распознать аудио: {error}",
   "stt.empty_result": "🎤 В аудиосообщении не обнаружена речь.",
+
+  "cmd.description.open": "Добавить проект через обзор папок",
+  "open.back": "⬆️ Наверх",
+  "open.home": "🏠 Домой",
+  "open.prev_page": "⬅️ Назад",
+  "open.next_page": "Далее ➡️",
+  "open.select_current": "✅ Выбрать эту папку",
+  "open.scan_error": "🔴 Не удалось открыть каталог: {error}",
+  "open.open_error": "🔴 Не удалось открыть обозреватель каталогов.",
+  "open.selected":
+    "✅ Проект добавлен: {project}\n\n📋 Используйте /sessions или /new для начала работы.",
+  "open.select_error": "🔴 Не удалось добавить проект.",
+  "open.no_subfolders": "📭 Нет подпапок",
+  "open.subfolder_count": "{count} подпапка",
+  "open.subfolders_count": "{count} подпапок",
 };

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -453,10 +453,12 @@ export const ru: I18nDictionary = {
 
   "cmd.description.open": "Добавить проект через обзор папок",
   "open.back": "⬆️ Наверх",
-  "open.home": "🏠 Домой",
+  "open.roots": "📋 К списку корней",
   "open.prev_page": "⬅️ Назад",
   "open.next_page": "Далее ➡️",
   "open.select_current": "✅ Выбрать эту папку",
+  "open.select_root": "📂 Выберите корневой каталог для просмотра:",
+  "open.access_denied": "⛔ Доступ запрещён: путь за пределами разрешённых каталогов",
   "open.scan_error": "🔴 Не удалось открыть каталог: {error}",
   "open.open_error": "🔴 Не удалось открыть обозреватель каталогов.",
   "open.selected":

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -408,4 +408,18 @@ export const zh: I18nDictionary = {
     "🎤 语音识别尚未配置。\n\n在 .env 中设置 STT_API_URL 和 STT_API_KEY 以启用。",
   "stt.error": "🔴 识别音频失败：{error}",
   "stt.empty_result": "🎤 音频消息中未检测到语音。",
+
+  "cmd.description.open": "通过浏览目录添加项目",
+  "open.back": "⬆️ 上级",
+  "open.home": "🏠 主目录",
+  "open.prev_page": "⬅️ 上一页",
+  "open.next_page": "下一页 ➡️",
+  "open.select_current": "✅ 选择此文件夹",
+  "open.scan_error": "🔴 无法浏览目录：{error}",
+  "open.open_error": "🔴 无法打开目录浏览器。",
+  "open.selected": "✅ 项目已添加：{project}\n\n📋 使用 /sessions 或 /new 开始工作。",
+  "open.select_error": "🔴 添加项目失败。",
+  "open.no_subfolders": "📭 无子文件夹",
+  "open.subfolder_count": "{count} 个子文件夹",
+  "open.subfolders_count": "{count} 个子文件夹",
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -411,10 +411,12 @@ export const zh: I18nDictionary = {
 
   "cmd.description.open": "通过浏览目录添加项目",
   "open.back": "⬆️ 上级",
-  "open.home": "🏠 主目录",
+  "open.roots": "📋 返回根目录",
   "open.prev_page": "⬅️ 上一页",
   "open.next_page": "下一页 ➡️",
   "open.select_current": "✅ 选择此文件夹",
+  "open.select_root": "📂 选择要浏览的根目录：",
+  "open.access_denied": "⛔ 访问被拒绝：路径超出允许的目录范围",
   "open.scan_error": "🔴 无法浏览目录：{error}",
   "open.open_error": "🔴 无法打开目录浏览器。",
   "open.selected": "✅ 项目已添加：{project}\n\n📋 使用 /sessions 或 /new 开始工作。",

--- a/src/project/manager.ts
+++ b/src/project/manager.ts
@@ -113,7 +113,8 @@ export async function getProjectById(id: string): Promise<ProjectInfo> {
 
 export async function getProjectByWorktree(worktree: string): Promise<ProjectInfo> {
   const projects = await getProjects();
-  const project = projects.find((p) => p.worktree === worktree);
+  const key = worktreeKey(worktree);
+  const project = projects.find((p) => worktreeKey(p.worktree) === key);
   if (!project) {
     throw new Error(`Project with worktree ${worktree} not found`);
   }

--- a/tests/bot/commands/open.test.ts
+++ b/tests/bot/commands/open.test.ts
@@ -289,19 +289,33 @@ describe("open command", () => {
 
       expect(result).toBe(true);
       // Verify full selection flow
-      expect(mocked.upsertSessionDirectoryMock).toHaveBeenCalledWith(dirPath, expect.any(Number));
       expect(mocked.getProjectByWorktreeMock).toHaveBeenCalledWith(dirPath);
       expect(mocked.switchToProjectMock).toHaveBeenCalledWith(
         ctx,
         expect.objectContaining({ id: "proj-1", worktree: "/home/user/my-project" }),
         "open_project_selected",
       );
+      // upsertSessionDirectory must be called AFTER switchToProject succeeds
+      expect(mocked.upsertSessionDirectoryMock).toHaveBeenCalledWith(dirPath, expect.any(Number));
+      const switchOrder = mocked.switchToProjectMock.mock.invocationCallOrder[0];
+      const upsertOrder = mocked.upsertSessionDirectoryMock.mock.invocationCallOrder[0];
+      expect(switchOrder).toBeLessThan(upsertOrder);
+
       expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
       expect(ctx.reply).toHaveBeenCalledWith(
         expect.stringContaining("~"),
         expect.objectContaining({ reply_markup: expect.anything() }),
       );
       expect(ctx.deleteMessage).toHaveBeenCalled();
+    });
+
+    it("should not upsert session directory when switchToProject fails", async () => {
+      mocked.switchToProjectMock.mockRejectedValue(new Error("switch failed"));
+
+      const ctx = createCallbackContext("open:sel:/home/user/fail-dir");
+      await handleOpenCallback(ctx);
+
+      expect(mocked.upsertSessionDirectoryMock).not.toHaveBeenCalled();
     });
 
     it("should show error on select failure", async () => {

--- a/tests/bot/commands/open.test.ts
+++ b/tests/bot/commands/open.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "grammy";
+import { t } from "../../../src/i18n/index.js";
+
+const mocked = vi.hoisted(() => ({
+  scanDirectoryMock: vi.fn(),
+  getHomeDirectoryMock: vi.fn(() => "/home/user"),
+  pathToDisplayPathMock: vi.fn((p: string) => p.replace("/home/user", "~")),
+  buildEntryLabelMock: vi.fn((entry: { name: string }) => `📁 ${entry.name}`),
+  buildTreeHeaderMock: vi.fn(
+    (display: string, _count: number, page: number, totalPages: number) => {
+      let h = `📂 ${display}`;
+      if (totalPages > 1) h += `  (${page + 1}/${totalPages})`;
+      return h;
+    },
+  ),
+  isScanErrorMock: vi.fn(
+    (result: unknown) => typeof result === "object" && result !== null && "error" in result,
+  ),
+  ensureActiveInlineMenuMock: vi.fn().mockResolvedValue(true),
+  isForegroundBusyMock: vi.fn(() => false),
+  replyBusyBlockedMock: vi.fn().mockResolvedValue(undefined),
+  upsertSessionDirectoryMock: vi.fn().mockResolvedValue(undefined),
+  getProjectByWorktreeMock: vi.fn().mockResolvedValue({
+    id: "proj-1",
+    worktree: "/home/user/my-project",
+    name: "my-project",
+  }),
+  switchToProjectMock: vi.fn().mockResolvedValue({ keyboard: [[{ text: "mock" }]] }),
+  interactionStartMock: vi.fn(),
+}));
+
+vi.mock("../../../src/bot/utils/file-tree.js", () => ({
+  getHomeDirectory: mocked.getHomeDirectoryMock,
+  pathToDisplayPath: mocked.pathToDisplayPathMock,
+  scanDirectory: mocked.scanDirectoryMock,
+  buildEntryLabel: mocked.buildEntryLabelMock,
+  buildTreeHeader: mocked.buildTreeHeaderMock,
+  isScanError: mocked.isScanErrorMock,
+  MAX_ENTRIES_PER_PAGE: 8,
+}));
+
+vi.mock("../../../src/bot/handlers/inline-menu.js", () => ({
+  appendInlineMenuCancelButton: vi.fn((kb: unknown) => kb),
+  ensureActiveInlineMenu: mocked.ensureActiveInlineMenuMock,
+}));
+
+vi.mock("../../../src/interaction/manager.js", () => ({
+  interactionManager: {
+    start: mocked.interactionStartMock,
+    getSnapshot: vi.fn(() => null),
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock("../../../src/bot/utils/busy-guard.js", () => ({
+  isForegroundBusy: mocked.isForegroundBusyMock,
+  replyBusyBlocked: mocked.replyBusyBlockedMock,
+}));
+
+vi.mock("../../../src/session/cache-manager.js", () => ({
+  upsertSessionDirectory: mocked.upsertSessionDirectoryMock,
+  __resetSessionDirectoryCacheForTests: vi.fn(),
+  syncSessionDirectoryCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/project/manager.js", () => ({
+  getProjectByWorktree: mocked.getProjectByWorktreeMock,
+}));
+
+vi.mock("../../../src/bot/utils/switch-project.js", () => ({
+  switchToProject: mocked.switchToProjectMock,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  openCommand,
+  handleOpenCallback,
+  clearOpenPathIndex,
+} from "../../../src/bot/commands/open.js";
+
+// --- Context factories ---
+
+function createCommandContext(): Context {
+  return {
+    chat: { id: 123 },
+    reply: vi.fn().mockResolvedValue({ message_id: 42 }),
+  } as unknown as Context;
+}
+
+function createCallbackContext(data: string, messageId: number = 42): Context {
+  return {
+    chat: { id: 123 },
+    callbackQuery: {
+      data,
+      message: { message_id: messageId },
+    } as Context["callbackQuery"],
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    api: {},
+  } as unknown as Context;
+}
+
+// --- Test data helpers ---
+
+function makeScanResult(
+  entries: Array<{ name: string; fullPath: string }>,
+  currentPath: string,
+  hasParent: boolean = true,
+) {
+  return {
+    entries,
+    totalCount: entries.length,
+    currentPath,
+    displayPath: currentPath.replace("/home/user", "~"),
+    hasParent,
+    parentPath: hasParent ? currentPath.replace(/\/[^/]+$/, "") || "/" : null,
+  };
+}
+
+// --- Tests ---
+
+describe("open command", () => {
+  beforeEach(() => {
+    clearOpenPathIndex();
+    // Reset hoisted mocks that need custom return values
+    mocked.scanDirectoryMock.mockReset();
+    mocked.ensureActiveInlineMenuMock.mockReset().mockResolvedValue(true);
+    mocked.isForegroundBusyMock.mockReset().mockReturnValue(false);
+    mocked.getProjectByWorktreeMock.mockReset().mockResolvedValue({
+      id: "proj-1",
+      worktree: "/home/user/my-project",
+      name: "my-project",
+    });
+    mocked.switchToProjectMock.mockReset().mockResolvedValue({ keyboard: [[{ text: "mock" }]] });
+    mocked.upsertSessionDirectoryMock.mockReset().mockResolvedValue(undefined);
+    mocked.interactionStartMock.mockReset();
+  });
+
+  describe("openCommand", () => {
+    it("should show directory browser on success", async () => {
+      const entries = [
+        { name: "projects", fullPath: "/home/user/projects" },
+        { name: "documents", fullPath: "/home/user/documents" },
+      ];
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult(entries, "/home/user"));
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      expect(mocked.scanDirectoryMock).toHaveBeenCalledWith("/home/user", 0);
+      expect(ctx.reply).toHaveBeenCalledTimes(1);
+      // Verify interaction was registered
+      expect(mocked.interactionStartMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "inline",
+          expectedInput: "callback",
+          metadata: expect.objectContaining({ menuKind: "open" }),
+        }),
+      );
+    });
+
+    it("should block when foreground is busy", async () => {
+      mocked.isForegroundBusyMock.mockReturnValue(true);
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      expect(mocked.replyBusyBlockedMock).toHaveBeenCalledWith(ctx);
+      expect(mocked.scanDirectoryMock).not.toHaveBeenCalled();
+    });
+
+    it("should show error message when scanDirectory returns error", async () => {
+      mocked.scanDirectoryMock.mockResolvedValue({ error: "Permission denied", code: "EACCES" });
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      expect(ctx.reply).toHaveBeenCalledWith(t("open.scan_error", { error: "Permission denied" }));
+    });
+
+    it("should handle unexpected errors gracefully", async () => {
+      mocked.scanDirectoryMock.mockRejectedValue(new Error("unexpected"));
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      expect(ctx.reply).toHaveBeenCalledWith(t("open.open_error"));
+    });
+  });
+
+  describe("handleOpenCallback", () => {
+    it("should return false for non-open callback data", async () => {
+      const ctx = createCallbackContext("project:abc");
+      const result = await handleOpenCallback(ctx);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when callback data is undefined", async () => {
+      const ctx = { callbackQuery: {} } as unknown as Context;
+      const result = await handleOpenCallback(ctx);
+      expect(result).toBe(false);
+    });
+
+    it("should block when foreground is busy", async () => {
+      mocked.isForegroundBusyMock.mockReturnValue(true);
+      const ctx = createCallbackContext("open:home");
+
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(mocked.replyBusyBlockedMock).toHaveBeenCalledWith(ctx);
+    });
+
+    it("should return true when ensureActiveInlineMenu returns false (stale menu)", async () => {
+      mocked.ensureActiveInlineMenuMock.mockResolvedValue(false);
+      const ctx = createCallbackContext("open:home");
+
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      // Should NOT call editMessageText or navigateTo
+      expect(ctx.editMessageText).not.toHaveBeenCalled();
+    });
+
+    it("should navigate to home directory on open:home callback", async () => {
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult([], "/home/user", false));
+
+      const ctx = createCallbackContext("open:home");
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+      expect(ctx.editMessageText).toHaveBeenCalled();
+    });
+
+    it("should navigate into subdirectory on open:nav: callback", async () => {
+      const targetPath = "/home/user/projects";
+      mocked.scanDirectoryMock.mockResolvedValue(
+        makeScanResult([{ name: "my-app", fullPath: "/home/user/projects/my-app" }], targetPath),
+      );
+
+      const ctx = createCallbackContext(`open:nav:${targetPath}`);
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(mocked.scanDirectoryMock).toHaveBeenCalledWith(targetPath, 0);
+      expect(ctx.editMessageText).toHaveBeenCalled();
+    });
+
+    it("should navigate up to parent on open:nav: with parent path", async () => {
+      const parentPath = "/home/user";
+      mocked.scanDirectoryMock.mockResolvedValue(
+        makeScanResult([{ name: "projects", fullPath: "/home/user/projects" }], parentPath),
+      );
+
+      const ctx = createCallbackContext(`open:nav:${parentPath}`);
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(mocked.scanDirectoryMock).toHaveBeenCalledWith(parentPath, 0);
+    });
+
+    it("should handle pagination callback", async () => {
+      const currentPath = "/home/user";
+      mocked.scanDirectoryMock.mockResolvedValue(
+        makeScanResult([{ name: "z-dir", fullPath: "/home/user/z-dir" }], currentPath),
+      );
+
+      const ctx = createCallbackContext(`open:pg:${currentPath}|1`);
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(mocked.scanDirectoryMock).toHaveBeenCalledWith(currentPath, 1);
+    });
+
+    it("should select directory as project on open:sel: callback", async () => {
+      const dirPath = "/home/user/my-project";
+
+      const ctx = createCallbackContext(`open:sel:${dirPath}`);
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      // Verify full selection flow
+      expect(mocked.upsertSessionDirectoryMock).toHaveBeenCalledWith(dirPath, expect.any(Number));
+      expect(mocked.getProjectByWorktreeMock).toHaveBeenCalledWith(dirPath);
+      expect(mocked.switchToProjectMock).toHaveBeenCalledWith(
+        ctx,
+        expect.objectContaining({ id: "proj-1", worktree: "/home/user/my-project" }),
+        "open_project_selected",
+      );
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining("~"),
+        expect.objectContaining({ reply_markup: expect.anything() }),
+      );
+      expect(ctx.deleteMessage).toHaveBeenCalled();
+    });
+
+    it("should show error on select failure", async () => {
+      mocked.getProjectByWorktreeMock.mockRejectedValue(new Error("not found"));
+
+      const ctx = createCallbackContext("open:sel:/home/user/bad-dir");
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+        text: t("callback.processing_error"),
+      });
+      expect(ctx.reply).toHaveBeenCalledWith(t("open.select_error"));
+    });
+
+    it("should show error when navigation scan fails", async () => {
+      mocked.scanDirectoryMock.mockResolvedValue({ error: "Permission denied", code: "EACCES" });
+
+      const ctx = createCallbackContext("open:nav:/root/forbidden");
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      // Navigation error is shown as callback query answer
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: "Permission denied" });
+    });
+  });
+
+  describe("clearOpenPathIndex", () => {
+    it("should invalidate previously encoded indexed paths", async () => {
+      // Use a very long path to force index encoding (> 64 bytes with prefix)
+      const longPath = "/home/user/" + "a".repeat(60);
+      const entries = [{ name: "a".repeat(60), fullPath: longPath }];
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult(entries, "/home/user"));
+
+      // openCommand builds keyboard with encoded paths
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      // Extract callback_data from the keyboard built by ctx.reply
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup;
+      const firstRow = keyboard?.inline_keyboard?.[0];
+      const callbackData = firstRow?.[0]?.callback_data as string;
+
+      // Verify it uses indexed encoding (contains #)
+      expect(callbackData).toMatch(/open:nav:#\d+/);
+
+      // Now clear the index
+      clearOpenPathIndex();
+
+      // Trying to handle the now-stale callback should not navigate
+      // (decodePathFromCallback returns null for unknown index)
+      const navCtx = createCallbackContext(callbackData);
+      const result = await handleOpenCallback(navCtx);
+
+      // Should return false because the indexed path can't be resolved
+      // and no other prefix matches
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("path encoding (indirect via keyboard inspection)", () => {
+    it("should encode short paths directly in callback_data", async () => {
+      const shortPath = "/home/user/proj";
+      const entries = [{ name: "proj", fullPath: shortPath }];
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult(entries, "/home/user"));
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup;
+      const firstRow = keyboard?.inline_keyboard?.[0];
+      const callbackData = firstRow?.[0]?.callback_data as string;
+
+      // Short path should be encoded directly (no # index)
+      expect(callbackData).toBe(`open:nav:${shortPath}`);
+    });
+
+    it("should encode long paths with index in callback_data", async () => {
+      const longPath = "/home/user/" + "x".repeat(60);
+      const entries = [{ name: "x".repeat(60), fullPath: longPath }];
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult(entries, "/home/user"));
+
+      const ctx = createCommandContext();
+      await openCommand(ctx as never);
+
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup;
+      const firstRow = keyboard?.inline_keyboard?.[0];
+      const callbackData = firstRow?.[0]?.callback_data as string;
+
+      // Long path should use indexed encoding
+      expect(callbackData).toMatch(/^open:nav:#\d+$/);
+      expect(callbackData).not.toContain(longPath);
+    });
+
+    it("should round-trip indexed path through navigate callback", async () => {
+      const longPath = "/home/user/" + "y".repeat(60);
+      const entries = [{ name: "y".repeat(60), fullPath: longPath }];
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult(entries, "/home/user"));
+
+      // Build keyboard to get encoded callback_data
+      const cmdCtx = createCommandContext();
+      await openCommand(cmdCtx as never);
+
+      const replyCall = (cmdCtx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const callbackData = replyCall[1]?.reply_markup?.inline_keyboard?.[0]?.[0]
+        ?.callback_data as string;
+      expect(callbackData).toMatch(/^open:nav:#\d+$/);
+
+      // Now feed the encoded callback_data back into handleOpenCallback
+      mocked.scanDirectoryMock.mockReset();
+      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult([], longPath));
+
+      const navCtx = createCallbackContext(callbackData);
+      const result = await handleOpenCallback(navCtx);
+
+      expect(result).toBe(true);
+      // Prove the path was decoded correctly — scanDirectory received the original long path
+      expect(mocked.scanDirectoryMock).toHaveBeenCalledWith(longPath, 0);
+    });
+  });
+});

--- a/tests/bot/commands/open.test.ts
+++ b/tests/bot/commands/open.test.ts
@@ -311,18 +311,18 @@ describe("open command", () => {
       const result = await handleOpenCallback(ctx);
 
       expect(result).toBe(true);
-      // Verify full selection flow
+      // Verify full selection flow: upsert first so getProjectByWorktree can
+      // find the directory, then switch.
+      expect(mocked.upsertSessionDirectoryMock).toHaveBeenCalledWith(dirPath, expect.any(Number));
       expect(mocked.getProjectByWorktreeMock).toHaveBeenCalledWith(dirPath);
       expect(mocked.switchToProjectMock).toHaveBeenCalledWith(
         ctx,
         expect.objectContaining({ id: "proj-1", worktree: "/home/user/my-project" }),
         "open_project_selected",
       );
-      // upsertSessionDirectory must be called AFTER switchToProject succeeds
-      expect(mocked.upsertSessionDirectoryMock).toHaveBeenCalledWith(dirPath, expect.any(Number));
-      const switchOrder = mocked.switchToProjectMock.mock.invocationCallOrder[0];
       const upsertOrder = mocked.upsertSessionDirectoryMock.mock.invocationCallOrder[0];
-      expect(switchOrder).toBeLessThan(upsertOrder);
+      const getProjectOrder = mocked.getProjectByWorktreeMock.mock.invocationCallOrder[0];
+      expect(upsertOrder).toBeLessThan(getProjectOrder);
 
       expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
       expect(ctx.reply).toHaveBeenCalledWith(
@@ -330,15 +330,6 @@ describe("open command", () => {
         expect.objectContaining({ reply_markup: expect.anything() }),
       );
       expect(ctx.deleteMessage).toHaveBeenCalled();
-    });
-
-    it("should not upsert session directory when switchToProject fails", async () => {
-      mocked.switchToProjectMock.mockRejectedValue(new Error("switch failed"));
-
-      const ctx = createCallbackContext("open:sel:/home/user/fail-dir");
-      await handleOpenCallback(ctx);
-
-      expect(mocked.upsertSessionDirectoryMock).not.toHaveBeenCalled();
     });
 
     it("should show error on select failure", async () => {

--- a/tests/bot/commands/open.test.ts
+++ b/tests/bot/commands/open.test.ts
@@ -112,10 +112,12 @@ function makeScanResult(
   entries: Array<{ name: string; fullPath: string }>,
   currentPath: string,
   hasParent: boolean = true,
+  page: number = 0,
 ) {
   return {
     entries,
     totalCount: entries.length,
+    page,
     currentPath,
     displayPath: currentPath.replace("/home/user", "~"),
     hasParent,

--- a/tests/bot/commands/open.test.ts
+++ b/tests/bot/commands/open.test.ts
@@ -4,7 +4,6 @@ import { t } from "../../../src/i18n/index.js";
 
 const mocked = vi.hoisted(() => ({
   scanDirectoryMock: vi.fn(),
-  getHomeDirectoryMock: vi.fn(() => "/home/user"),
   pathToDisplayPathMock: vi.fn((p: string) => p.replace("/home/user", "~")),
   buildEntryLabelMock: vi.fn((entry: { name: string }) => `📁 ${entry.name}`),
   buildTreeHeaderMock: vi.fn(
@@ -17,6 +16,9 @@ const mocked = vi.hoisted(() => ({
   isScanErrorMock: vi.fn(
     (result: unknown) => typeof result === "object" && result !== null && "error" in result,
   ),
+  getBrowserRootsMock: vi.fn(() => ["/home/user"]),
+  isWithinAllowedRootMock: vi.fn(() => true),
+  isAllowedRootMock: vi.fn(() => false),
   ensureActiveInlineMenuMock: vi.fn().mockResolvedValue(true),
   isForegroundBusyMock: vi.fn(() => false),
   replyBusyBlockedMock: vi.fn().mockResolvedValue(undefined),
@@ -31,13 +33,18 @@ const mocked = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../src/bot/utils/file-tree.js", () => ({
-  getHomeDirectory: mocked.getHomeDirectoryMock,
   pathToDisplayPath: mocked.pathToDisplayPathMock,
   scanDirectory: mocked.scanDirectoryMock,
   buildEntryLabel: mocked.buildEntryLabelMock,
   buildTreeHeader: mocked.buildTreeHeaderMock,
   isScanError: mocked.isScanErrorMock,
   MAX_ENTRIES_PER_PAGE: 8,
+}));
+
+vi.mock("../../../src/bot/utils/browser-roots.js", () => ({
+  getBrowserRoots: mocked.getBrowserRootsMock,
+  isWithinAllowedRoot: mocked.isWithinAllowedRootMock,
+  isAllowedRoot: mocked.isAllowedRootMock,
 }));
 
 vi.mock("../../../src/bot/handlers/inline-menu.js", () => ({
@@ -132,6 +139,9 @@ describe("open command", () => {
     clearOpenPathIndex();
     // Reset hoisted mocks that need custom return values
     mocked.scanDirectoryMock.mockReset();
+    mocked.getBrowserRootsMock.mockReset().mockReturnValue(["/home/user"]);
+    mocked.isWithinAllowedRootMock.mockReset().mockReturnValue(true);
+    mocked.isAllowedRootMock.mockReset().mockReturnValue(false);
     mocked.ensureActiveInlineMenuMock.mockReset().mockResolvedValue(true);
     mocked.isForegroundBusyMock.mockReset().mockReturnValue(false);
     mocked.getProjectByWorktreeMock.mockReset().mockResolvedValue({
@@ -211,7 +221,7 @@ describe("open command", () => {
 
     it("should block when foreground is busy", async () => {
       mocked.isForegroundBusyMock.mockReturnValue(true);
-      const ctx = createCallbackContext("open:home");
+      const ctx = createCallbackContext("open:roots");
 
       const result = await handleOpenCallback(ctx);
 
@@ -221,7 +231,7 @@ describe("open command", () => {
 
     it("should return true when ensureActiveInlineMenu returns false (stale menu)", async () => {
       mocked.ensureActiveInlineMenuMock.mockResolvedValue(false);
-      const ctx = createCallbackContext("open:home");
+      const ctx = createCallbackContext("open:roots");
 
       const result = await handleOpenCallback(ctx);
 
@@ -230,15 +240,28 @@ describe("open command", () => {
       expect(ctx.editMessageText).not.toHaveBeenCalled();
     });
 
-    it("should navigate to home directory on open:home callback", async () => {
-      mocked.scanDirectoryMock.mockResolvedValue(makeScanResult([], "/home/user", false));
+    it("should show root selection on open:roots callback", async () => {
+      mocked.getBrowserRootsMock.mockReturnValue(["/home/user", "/opt/repos"]);
 
-      const ctx = createCallbackContext("open:home");
+      const ctx = createCallbackContext("open:roots");
       const result = await handleOpenCallback(ctx);
 
       expect(result).toBe(true);
       expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
       expect(ctx.editMessageText).toHaveBeenCalled();
+    });
+
+    it("should deny navigation to path outside allowed roots", async () => {
+      mocked.isWithinAllowedRootMock.mockReturnValue(false);
+
+      const ctx = createCallbackContext("open:nav:/etc/passwd");
+      const result = await handleOpenCallback(ctx);
+
+      expect(result).toBe(true);
+      expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+        text: t("open.access_denied"),
+      });
+      expect(mocked.scanDirectoryMock).not.toHaveBeenCalled();
     });
 
     it("should navigate into subdirectory on open:nav: callback", async () => {

--- a/tests/bot/utils/browser-roots.test.ts
+++ b/tests/bot/utils/browser-roots.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  initBrowserRoots,
+  getBrowserRoots,
+  isWithinAllowedRoot,
+  isAllowedRoot,
+  __resetBrowserRootsForTests,
+} from "../../../src/bot/utils/browser-roots.js";
+
+describe("browser-roots", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    __resetBrowserRootsForTests();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    __resetBrowserRootsForTests();
+  });
+
+  describe("initBrowserRoots", () => {
+    it("should default to home directory when no env value is provided", () => {
+      initBrowserRoots(undefined);
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(1);
+      expect(roots[0]).toBe(path.resolve(os.homedir()));
+    });
+
+    it("should default to home directory for empty string", () => {
+      initBrowserRoots("");
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(1);
+    });
+
+    it("should parse comma-separated paths", () => {
+      initBrowserRoots("/home/user/projects,/opt/repos");
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(2);
+      expect(roots[0]).toBe(path.resolve("/home/user/projects"));
+      expect(roots[1]).toBe(path.resolve("/opt/repos"));
+    });
+
+    it("should trim whitespace from entries", () => {
+      initBrowserRoots("  /home/user/projects , /opt/repos  ");
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(2);
+    });
+
+    it("should skip empty entries after splitting", () => {
+      initBrowserRoots("/home/user/projects,,/opt/repos,");
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(2);
+    });
+
+    it("should resolve relative paths", () => {
+      initBrowserRoots("./relative-dir");
+      const roots = getBrowserRoots();
+      expect(roots[0]).toBe(path.resolve("./relative-dir"));
+    });
+  });
+
+  describe("getBrowserRoots (lazy init)", () => {
+    it("should lazily initialize from env when never explicitly called", () => {
+      // Set env before calling getBrowserRoots
+      process.env.OPEN_BROWSER_ROOTS = "/tmp/test-root";
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(1);
+      expect(roots[0]).toBe(path.resolve("/tmp/test-root"));
+      delete process.env.OPEN_BROWSER_ROOTS;
+    });
+  });
+
+  describe("isWithinAllowedRoot", () => {
+    it("should return true for exact root path", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isWithinAllowedRoot("/home/user/projects")).toBe(true);
+    });
+
+    it("should return true for path inside root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isWithinAllowedRoot("/home/user/projects/my-app")).toBe(true);
+    });
+
+    it("should return true for deeply nested path inside root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isWithinAllowedRoot("/home/user/projects/a/b/c/d")).toBe(true);
+    });
+
+    it("should return false for path outside root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isWithinAllowedRoot("/home/user/documents")).toBe(false);
+    });
+
+    it("should return false for parent of root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isWithinAllowedRoot("/home/user")).toBe(false);
+    });
+
+    it("should return false for path that shares a prefix but is not a descendant", () => {
+      initBrowserRoots("/home/user/projects");
+      // /home/user/projects-backup is NOT inside /home/user/projects
+      expect(isWithinAllowedRoot("/home/user/projects-backup")).toBe(false);
+    });
+
+    it("should work with multiple roots", () => {
+      initBrowserRoots("/home/user/projects,/opt/repos");
+      expect(isWithinAllowedRoot("/home/user/projects/app")).toBe(true);
+      expect(isWithinAllowedRoot("/opt/repos/lib")).toBe(true);
+      expect(isWithinAllowedRoot("/etc/config")).toBe(false);
+    });
+
+    it("should match case-insensitively on Windows", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      __resetBrowserRootsForTests();
+      // Use forward-slash paths so path.resolve works on all test platforms
+      initBrowserRoots("/home/User/Projects");
+      expect(isWithinAllowedRoot("/home/user/projects/my-app")).toBe(true);
+      expect(isWithinAllowedRoot("/HOME/USER/PROJECTS")).toBe(true);
+    });
+
+    it("should match case-sensitively on non-Windows", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      __resetBrowserRootsForTests();
+      initBrowserRoots("/home/User/Projects");
+      expect(isWithinAllowedRoot("/home/User/Projects/app")).toBe(true);
+      expect(isWithinAllowedRoot("/home/user/projects/app")).toBe(false);
+    });
+  });
+
+  describe("isAllowedRoot", () => {
+    it("should return true for exact root match", () => {
+      initBrowserRoots("/home/user/projects,/opt/repos");
+      expect(isAllowedRoot("/home/user/projects")).toBe(true);
+      expect(isAllowedRoot("/opt/repos")).toBe(true);
+    });
+
+    it("should return false for child of root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isAllowedRoot("/home/user/projects/child")).toBe(false);
+    });
+
+    it("should return false for parent of root", () => {
+      initBrowserRoots("/home/user/projects");
+      expect(isAllowedRoot("/home/user")).toBe(false);
+    });
+  });
+});

--- a/tests/bot/utils/browser-roots.test.ts
+++ b/tests/bot/utils/browser-roots.test.ts
@@ -65,6 +65,33 @@ describe("browser-roots", () => {
       const roots = getBrowserRoots();
       expect(roots[0]).toBe(path.resolve("./relative-dir"));
     });
+
+    it("should expand ~ to home directory", () => {
+      initBrowserRoots("~/projects");
+      const roots = getBrowserRoots();
+      expect(roots[0]).toBe(path.resolve(path.join(os.homedir(), "projects")));
+    });
+
+    it("should expand bare ~ to home directory", () => {
+      initBrowserRoots("~");
+      const roots = getBrowserRoots();
+      expect(roots[0]).toBe(path.resolve(os.homedir()));
+    });
+
+    it("should expand ~ in multiple comma-separated entries", () => {
+      initBrowserRoots("~/projects,~/work,/opt/repos");
+      const roots = getBrowserRoots();
+      expect(roots).toHaveLength(3);
+      expect(roots[0]).toBe(path.resolve(path.join(os.homedir(), "projects")));
+      expect(roots[1]).toBe(path.resolve(path.join(os.homedir(), "work")));
+      expect(roots[2]).toBe(path.resolve("/opt/repos"));
+    });
+
+    it("should not expand ~ in the middle of a path", () => {
+      initBrowserRoots("/home/~user/projects");
+      const roots = getBrowserRoots();
+      expect(roots[0]).toBe(path.resolve("/home/~user/projects"));
+    });
   });
 
   describe("getBrowserRoots (lazy init)", () => {

--- a/tests/bot/utils/file-tree.test.ts
+++ b/tests/bot/utils/file-tree.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import {
+  getHomeDirectory,
+  pathToDisplayPath,
+  scanDirectory,
+  buildEntryLabel,
+  buildTreeHeader,
+  isScanError,
+  MAX_ENTRIES_PER_PAGE,
+} from "../../../src/bot/utils/file-tree.js";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("file-tree", () => {
+  describe("getHomeDirectory", () => {
+    it("should return os.homedir()", () => {
+      expect(getHomeDirectory()).toBe(os.homedir());
+    });
+  });
+
+  describe("pathToDisplayPath", () => {
+    it("should replace home directory with ~", () => {
+      const home = os.homedir();
+      expect(pathToDisplayPath(home)).toBe("~");
+    });
+
+    it("should replace home prefix with ~", () => {
+      const home = os.homedir();
+      const subdir = path.join(home, "projects", "my-app");
+      const result = pathToDisplayPath(subdir);
+      expect(result).toBe(`~${path.sep}projects${path.sep}my-app`);
+    });
+
+    it("should return absolute path unchanged if not under home", () => {
+      expect(pathToDisplayPath("/tmp/something")).toBe("/tmp/something");
+    });
+  });
+
+  describe("scanDirectory", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), "file-tree-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("should list subdirectories sorted alphabetically", async () => {
+      await mkdir(path.join(tempDir, "charlie"));
+      await mkdir(path.join(tempDir, "alpha"));
+      await mkdir(path.join(tempDir, "bravo"));
+
+      const result = await scanDirectory(tempDir);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.entries).toHaveLength(3);
+      expect(result.entries[0].name).toBe("alpha");
+      expect(result.entries[1].name).toBe("bravo");
+      expect(result.entries[2].name).toBe("charlie");
+      expect(result.totalCount).toBe(3);
+    });
+
+    it("should skip hidden directories", async () => {
+      await mkdir(path.join(tempDir, ".hidden"));
+      await mkdir(path.join(tempDir, "visible"));
+
+      const result = await scanDirectory(tempDir);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].name).toBe("visible");
+    });
+
+    it("should skip files (only list directories)", async () => {
+      await mkdir(path.join(tempDir, "subdir"));
+      await fs.writeFile(path.join(tempDir, "file.txt"), "content");
+
+      const result = await scanDirectory(tempDir);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].name).toBe("subdir");
+    });
+
+    it("should paginate entries", async () => {
+      // Create more entries than one page
+      for (let i = 0; i < MAX_ENTRIES_PER_PAGE + 3; i++) {
+        await mkdir(path.join(tempDir, `dir-${String(i).padStart(2, "0")}`));
+      }
+
+      const page0 = await scanDirectory(tempDir, 0);
+      expect(isScanError(page0)).toBe(false);
+      if (isScanError(page0)) return;
+
+      expect(page0.entries).toHaveLength(MAX_ENTRIES_PER_PAGE);
+      expect(page0.totalCount).toBe(MAX_ENTRIES_PER_PAGE + 3);
+
+      const page1 = await scanDirectory(tempDir, 1);
+      expect(isScanError(page1)).toBe(false);
+      if (isScanError(page1)) return;
+
+      expect(page1.entries).toHaveLength(3);
+    });
+
+    it("should return hasParent=true for non-root directories", async () => {
+      const result = await scanDirectory(tempDir);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.hasParent).toBe(true);
+      expect(result.parentPath).toBe(path.dirname(tempDir));
+    });
+
+    it("should return error for non-existent directory", async () => {
+      const result = await scanDirectory(path.join(tempDir, "nonexistent"));
+      expect(isScanError(result)).toBe(true);
+      if (!isScanError(result)) return;
+
+      expect(result.code).toBe("ENOENT");
+    });
+
+    it("should return empty entries for empty directory", async () => {
+      const result = await scanDirectory(tempDir);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.entries).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+  });
+
+  describe("buildEntryLabel", () => {
+    it("should format entry with folder emoji", () => {
+      const entry = { name: "my-project", fullPath: "/home/user/my-project" };
+      expect(buildEntryLabel(entry)).toBe("📁 my-project");
+    });
+  });
+
+  describe("buildTreeHeader", () => {
+    it("should show path and count for single page", () => {
+      const header = buildTreeHeader("~/projects", 3, 0, 1);
+      expect(header).toContain("~/projects");
+      expect(header).toContain("3");
+      expect(header).not.toContain("(");
+    });
+
+    it("should show page indicator for multiple pages", () => {
+      const header = buildTreeHeader("~/projects", 15, 1, 2);
+      expect(header).toContain("(2/2)");
+    });
+
+    it("should show empty message when no subfolders", () => {
+      const header = buildTreeHeader("~/empty", 0, 0, 1);
+      // Localized — English default contains the "No subfolders" emoji indicator
+      expect(header).toContain("📭");
+    });
+
+    it("should use singular form for 1 subfolder", () => {
+      const header = buildTreeHeader("~/one", 1, 0, 1);
+      expect(header).toContain("1 subfolder");
+    });
+
+    it("should use plural form for multiple subfolders", () => {
+      const header = buildTreeHeader("~/many", 5, 0, 1);
+      expect(header).toContain("5 subfolders");
+    });
+  });
+
+  describe("isScanError", () => {
+    it("should return true for error results", () => {
+      expect(isScanError({ error: "test", code: "ENOENT" })).toBe(true);
+    });
+
+    it("should return false for success results", () => {
+      const result = {
+        entries: [],
+        totalCount: 0,
+        currentPath: "/tmp",
+        displayPath: "/tmp",
+        hasParent: true,
+        parentPath: "/",
+      };
+      expect(isScanError(result)).toBe(false);
+    });
+  });
+});

--- a/tests/bot/utils/file-tree.test.ts
+++ b/tests/bot/utils/file-tree.test.ts
@@ -113,6 +113,43 @@ describe("file-tree", () => {
       expect(page1.entries).toHaveLength(3);
     });
 
+    it("should clamp page number to last valid page when page exceeds total", async () => {
+      await mkdir(path.join(tempDir, "alpha"));
+      await mkdir(path.join(tempDir, "bravo"));
+
+      const result = await scanDirectory(tempDir, 99);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      // Only 2 entries → 1 page → page should be clamped to 0
+      expect(result.page).toBe(0);
+      expect(result.entries).toHaveLength(2);
+    });
+
+    it("should clamp negative page number to 0", async () => {
+      await mkdir(path.join(tempDir, "alpha"));
+
+      const result = await scanDirectory(tempDir, -5);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.page).toBe(0);
+      expect(result.entries).toHaveLength(1);
+    });
+
+    it("should return clamped page in result for valid pagination", async () => {
+      for (let i = 0; i < MAX_ENTRIES_PER_PAGE + 3; i++) {
+        await mkdir(path.join(tempDir, `dir-${String(i).padStart(2, "0")}`));
+      }
+
+      const result = await scanDirectory(tempDir, 1);
+      expect(isScanError(result)).toBe(false);
+      if (isScanError(result)) return;
+
+      expect(result.page).toBe(1);
+      expect(result.entries).toHaveLength(3);
+    });
+
     it("should return hasParent=true for non-root directories", async () => {
       const result = await scanDirectory(tempDir);
       expect(isScanError(result)).toBe(false);
@@ -186,6 +223,7 @@ describe("file-tree", () => {
       const result = {
         entries: [],
         totalCount: 0,
+        page: 0,
         currentPath: "/tmp",
         displayPath: "/tmp",
         hasParent: true,

--- a/tests/bot/utils/switch-project.test.ts
+++ b/tests/bot/utils/switch-project.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "grammy";
+
+const mocked = vi.hoisted(() => ({
+  setCurrentProjectMock: vi.fn(),
+  clearSessionMock: vi.fn(),
+  summaryAggregatorClearMock: vi.fn(),
+  clearAllInteractionStateMock: vi.fn(),
+  pinnedClearMock: vi.fn().mockResolvedValue(undefined),
+  pinnedRefreshMock: vi.fn().mockResolvedValue(undefined),
+  pinnedGetLimitMock: vi.fn(() => 128000),
+  keyboardInitMock: vi.fn(),
+  keyboardUpdateMock: vi.fn(),
+  keyboardUpdateAgentMock: vi.fn(),
+  getStoredAgentMock: vi.fn(() => "code"),
+  resolveProjectAgentMock: vi.fn(async (agent: string) => agent),
+  getStoredModelMock: vi.fn(() => ({
+    providerID: "anthropic",
+    modelID: "claude-4",
+    variant: "default",
+  })),
+  formatVariantMock: vi.fn(() => "Default"),
+  createMainKeyboardMock: vi.fn(() => ({ keyboard: [[{ text: "mock" }]] })),
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  setCurrentProject: mocked.setCurrentProjectMock,
+}));
+vi.mock("../../../src/session/manager.js", () => ({
+  clearSession: mocked.clearSessionMock,
+}));
+vi.mock("../../../src/summary/aggregator.js", () => ({
+  summaryAggregator: { clear: mocked.summaryAggregatorClearMock },
+}));
+vi.mock("../../../src/interaction/cleanup.js", () => ({
+  clearAllInteractionState: mocked.clearAllInteractionStateMock,
+}));
+vi.mock("../../../src/pinned/manager.js", () => ({
+  pinnedMessageManager: {
+    clear: mocked.pinnedClearMock,
+    refreshContextLimit: mocked.pinnedRefreshMock,
+    getContextLimit: mocked.pinnedGetLimitMock,
+  },
+}));
+vi.mock("../../../src/keyboard/manager.js", () => ({
+  keyboardManager: {
+    initialize: mocked.keyboardInitMock,
+    updateContext: mocked.keyboardUpdateMock,
+    updateAgent: mocked.keyboardUpdateAgentMock,
+  },
+}));
+vi.mock("../../../src/agent/manager.js", () => ({
+  getStoredAgent: mocked.getStoredAgentMock,
+  resolveProjectAgent: mocked.resolveProjectAgentMock,
+}));
+vi.mock("../../../src/model/manager.js", () => ({
+  getStoredModel: mocked.getStoredModelMock,
+}));
+vi.mock("../../../src/variant/manager.js", () => ({
+  formatVariantForButton: mocked.formatVariantMock,
+}));
+vi.mock("../../../src/bot/utils/keyboard.js", () => ({
+  createMainKeyboard: mocked.createMainKeyboardMock,
+}));
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { switchToProject } from "../../../src/bot/utils/switch-project.js";
+
+function createCtx(chatId: number = 123): Context {
+  return {
+    chat: { id: chatId },
+    api: { sendMessage: vi.fn() },
+  } as unknown as Context;
+}
+
+const testProject = { id: "proj-1", worktree: "/home/user/my-app", name: "My App" };
+
+describe("switch-project", () => {
+  beforeEach(() => {
+    mocked.pinnedClearMock.mockReset().mockResolvedValue(undefined);
+    mocked.pinnedRefreshMock.mockReset().mockResolvedValue(undefined);
+    mocked.pinnedGetLimitMock.mockReset().mockReturnValue(128000);
+    mocked.getStoredAgentMock.mockReset().mockReturnValue("code");
+    mocked.getStoredModelMock.mockReset().mockReturnValue({
+      providerID: "anthropic",
+      modelID: "claude-4",
+      variant: "default",
+    });
+    mocked.formatVariantMock.mockReset().mockReturnValue("Default");
+    mocked.createMainKeyboardMock.mockReset().mockReturnValue({ keyboard: [[{ text: "mock" }]] });
+  });
+
+  it("should call state-clearing functions with correct arguments", async () => {
+    const ctx = createCtx();
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.setCurrentProjectMock).toHaveBeenCalledWith(testProject);
+    expect(mocked.clearSessionMock).toHaveBeenCalled();
+    expect(mocked.summaryAggregatorClearMock).toHaveBeenCalled();
+    expect(mocked.clearAllInteractionStateMock).toHaveBeenCalledWith("test_reason");
+  });
+
+  it("should clear pinned message and refresh context limit", async () => {
+    const ctx = createCtx();
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.pinnedClearMock).toHaveBeenCalled();
+    expect(mocked.pinnedRefreshMock).toHaveBeenCalled();
+    expect(mocked.pinnedGetLimitMock).toHaveBeenCalled();
+  });
+
+  it("should initialize keyboard manager when ctx.chat exists", async () => {
+    const ctx = createCtx(456);
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.keyboardInitMock).toHaveBeenCalledWith(ctx.api, 456);
+    expect(mocked.keyboardUpdateMock).toHaveBeenCalledWith(0, 128000);
+  });
+
+  it("should skip keyboard initialization when ctx.chat is undefined", async () => {
+    const ctx = { api: {} } as unknown as Context;
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.keyboardInitMock).not.toHaveBeenCalled();
+    expect(mocked.keyboardUpdateMock).toHaveBeenCalledWith(0, 128000);
+  });
+
+  it("should return keyboard from createMainKeyboard", async () => {
+    const ctx = createCtx();
+    const result = await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.createMainKeyboardMock).toHaveBeenCalled();
+    expect(result).toEqual({ keyboard: [[{ text: "mock" }]] });
+  });
+
+  it("should pass model variant to formatVariantForButton", async () => {
+    const ctx = createCtx();
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.formatVariantMock).toHaveBeenCalledWith("default");
+  });
+
+  it("should use 'default' when model variant is undefined", async () => {
+    mocked.getStoredModelMock.mockReturnValue({
+      providerID: "openai",
+      modelID: "gpt-5",
+      variant: undefined,
+    });
+    const ctx = createCtx();
+    await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.formatVariantMock).toHaveBeenCalledWith("default");
+  });
+
+  it("should not throw if pinnedMessageManager.clear rejects", async () => {
+    mocked.pinnedClearMock.mockRejectedValue(new Error("unpin failed"));
+    const ctx = createCtx();
+
+    const result = await switchToProject(ctx, testProject, "test_reason");
+
+    expect(mocked.createMainKeyboardMock).toHaveBeenCalled();
+    expect(result).toEqual({ keyboard: [[{ text: "mock" }]] });
+  });
+});

--- a/tests/project/manager.test.ts
+++ b/tests/project/manager.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../src/session/cache-manager.js", () => ({
   __resetSessionDirectoryCacheForTests: vi.fn(),
 }));
 
-import { getProjects } from "../../src/project/manager.js";
+import { getProjects, getProjectByWorktree } from "../../src/project/manager.js";
 
 describe("project/manager", () => {
   let tempRoot = "";
@@ -97,5 +97,52 @@ describe("project/manager", () => {
     const projects = await getProjects();
 
     expect(projects).toEqual([{ id: "main", worktree: mainWorktree, name: "Main" }]);
+  });
+
+  describe("getProjectByWorktree", () => {
+    it("should find project by exact worktree path", async () => {
+      projectListMock.mockResolvedValueOnce({
+        data: [{ id: "p1", worktree: "/home/user/repo", name: "Repo" }],
+        error: null,
+      });
+      cachedSessionProjectsMock.mockResolvedValueOnce([]);
+
+      const project = await getProjectByWorktree("/home/user/repo");
+      expect(project).toEqual({ id: "p1", worktree: "/home/user/repo", name: "Repo" });
+    });
+
+    it("should throw when worktree is not found", async () => {
+      projectListMock.mockResolvedValueOnce({
+        data: [{ id: "p1", worktree: "/home/user/repo", name: "Repo" }],
+        error: null,
+      });
+      cachedSessionProjectsMock.mockResolvedValueOnce([]);
+
+      await expect(getProjectByWorktree("/home/user/other")).rejects.toThrow(
+        "Project with worktree /home/user/other not found",
+      );
+    });
+
+    it("should match case-insensitively on Windows", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      try {
+        projectListMock.mockResolvedValueOnce({
+          data: [{ id: "p1", worktree: "C:\\Users\\Dev\\Repo", name: "Repo" }],
+          error: null,
+        });
+        cachedSessionProjectsMock.mockResolvedValueOnce([]);
+
+        const project = await getProjectByWorktree("c:\\users\\dev\\repo");
+        expect(project).toEqual({
+          id: "p1",
+          worktree: "C:\\Users\\Dev\\Repo",
+          name: "Repo",
+        });
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
   });
 });


### PR DESCRIPTION
## Description of changes
- **New `/open` command**: Adds a directory browser via Telegram inline keyboard, allowing users to navigate the local filesystem and select a folder as a project — without needing to know the exact path upfront.
- **`switchToProject` extraction**: Refactors the project-switching state logic (clear session, reset pinned message, refresh keyboard) out of `projects.ts` into a shared `src/bot/utils/switch-project.ts` utility, eliminating duplication between `/projects` and `/open`.
- **`file-tree` utility**: Adds `src/bot/utils/file-tree.ts` with pure functions for directory scanning, pagination (8 entries/page), hidden-directory filtering, tilde-based display paths, and i18n-aware subfolder counts.
- **Callback-data path encoding**: Handles Telegram's 64-byte `callback_data` limit by transparently switching to compact indexed references (`#0`, `#1`, …) for long absolute paths.
- **i18n**: All new user-facing strings added to all 6 locales (en, de, es, fr, ru, zh).
## Closes issue (optional)
- #69 
## How it was tested
- 73 new unit tests across 3 test files:
  - `tests/bot/commands/open.test.ts` — command, callback routing, busy guard, error paths, path encoding round-trips, stale index invalidation
  - `tests/bot/utils/switch-project.test.ts` — all state-clearing branches, keyboard rebuild, pinned message failure resilience
  - `tests/bot/utils/file-tree.test.ts` — real temp-directory integration tests for scanning, pagination, hidden-dir filtering, error codes
- `npm run build` — clean
- `npm run lint` — clean
- `npm test` — all pass
## Checklist
- [x] PR title follows Conventional Commits: `feat: add /open command for browsing and adding project directories`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [x] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described
> **OS note:** Directory scanning uses `node:fs` and `node:path` — works on all platforms. The `pathToDisplayPath` function uses `path.sep` for correct tilde substitution on both Unix and Windows. Hidden-directory filtering (`.`-prefixed) follows Unix convention; on Windows, system/hidden directories without a dot prefix will still appear in the listing.

Closes #69 