### PR TITLE
feat(telegram): use entities-first markdown rendering in replies and streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,12 @@
         "dotenv": "^17.2.3",
         "grammy": "^1.39.2",
         "https-proxy-agent": "^7.0.6",
+        "mdast-util-to-string": "^4.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
         "socks-proxy-agent": "^8.0.5",
-        "telegram-markdown-v2": "^0.0.4"
+        "telegram-markdown-v2": "^0.0.4",
+        "unified": "^11.0.5"
       },
       "bin": {
         "opencode-telegram": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,12 @@
     "dotenv": "^17.2.3",
     "grammy": "^1.39.2",
     "https-proxy-agent": "^7.0.6",
+    "mdast-util-to-string": "^4.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "socks-proxy-agent": "^8.0.5",
-    "telegram-markdown-v2": "^0.0.4"
+    "telegram-markdown-v2": "^0.0.4",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -50,11 +50,7 @@ import { clearAllInteractionState } from "../interaction/cleanup.js";
 import { keyboardManager } from "../keyboard/manager.js";
 import { subscribeToEvents } from "../opencode/events.js";
 import { summaryAggregator } from "../summary/aggregator.js";
-import {
-  formatSummaryWithMode,
-  formatToolInfo,
-  getAssistantParseMode,
-} from "../summary/formatter.js";
+import { formatToolInfo } from "../summary/formatter.js";
 import { renderSubagentCards } from "../summary/subagent-formatter.js";
 import { ToolMessageBatcher } from "../summary/tool-message-batcher.js";
 import { getCurrentSession } from "../session/manager.js";
@@ -71,7 +67,12 @@ import { downloadTelegramFile, toDataUri } from "./utils/file-download.js";
 import { finalizeAssistantResponse } from "./utils/finalize-assistant-response.js";
 import { sendTtsResponseForSession } from "./utils/send-tts-response.js";
 import { deliverThinkingMessage } from "./utils/thinking-message.js";
-import { sendBotText, sendRenderedBotPart } from "./utils/telegram-text.js";
+import {
+  editRenderedBotPart,
+  getTelegramRenderedPartSignature,
+  sendBotText,
+  sendRenderedBotPart,
+} from "./utils/telegram-text.js";
 import { formatAssistantRunFooter } from "./utils/assistant-run-footer.js";
 import { getModelCapabilities, supportsInput } from "../model/capabilities.js";
 import { getStoredModel } from "../model/manager.js";
@@ -82,11 +83,9 @@ import { assistantRunState } from "./assistant-run-state.js";
 import { ResponseStreamer } from "./streaming/response-streamer.js";
 import type { StreamingMessagePayload } from "./streaming/response-streamer.js";
 import { ToolCallStreamer, type ToolStreamKey } from "./streaming/tool-call-streamer.js";
-import {
-  editMessageWithMarkdownFallback,
-  sendMessageWithMarkdownFallback,
-} from "./utils/send-with-markdown-fallback.js";
-import { renderTelegramParts } from "../telegram/render/pipeline.js";
+import { chunkTelegramRenderedBlocks } from "../telegram/render/chunker.js";
+import { renderTelegramBlocks, renderTelegramParts } from "../telegram/render/pipeline.js";
+import type { TelegramRenderedBlock, TelegramRenderedPart } from "../telegram/render/types.js";
 
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
@@ -123,32 +122,93 @@ function prepareDocumentCaption(caption: string): string {
   return `${normalizedCaption.slice(0, TELEGRAM_DOCUMENT_CAPTION_MAX_LENGTH - 3)}...`;
 }
 
+function createPlainRenderedBlock(text: string): TelegramRenderedBlock {
+  return {
+    blockType: "plain",
+    mode: "plain",
+    text,
+    fallbackText: text,
+    source: "plain",
+  };
+}
+
+function createPlainRenderedParts(text: string, maxPartLength: number): TelegramRenderedPart[] {
+  return chunkTelegramRenderedBlocks([createPlainRenderedBlock(text)], { maxPartLength });
+}
+
+function renderAssistantBlocksSafe(text: string): TelegramRenderedBlock[] {
+  if (!text) {
+    return [];
+  }
+
+  try {
+    return renderTelegramBlocks(text);
+  } catch (error) {
+    logger.warn(
+      "[Bot] Assistant block rendering failed, falling back to plain streaming block",
+      error,
+    );
+    return [createPlainRenderedBlock(text)];
+  }
+}
+
+function renderAssistantPartsSafe(text: string, maxPartLength = 4096): TelegramRenderedPart[] {
+  if (!text) {
+    return [];
+  }
+
+  try {
+    return renderTelegramParts(text, { maxPartLength });
+  } catch (error) {
+    logger.warn("[Bot] Assistant part rendering failed, falling back to plain text parts", error);
+    return createPlainRenderedParts(text, maxPartLength);
+  }
+}
+
+function getStableStreamingBoundary(messageText: string): number {
+  if (!messageText) {
+    return 0;
+  }
+
+  if (messageText.endsWith("\n\n")) {
+    return messageText.length;
+  }
+
+  const lastBlockSeparatorIndex = messageText.lastIndexOf("\n\n");
+  return lastBlockSeparatorIndex >= 0 ? lastBlockSeparatorIndex + 2 : 0;
+}
+
 function prepareStreamingPayload(messageText: string): StreamingMessagePayload | null {
-  const parts = formatSummaryWithMode(messageText, "raw", RESPONSE_STREAM_TEXT_LIMIT);
+  const stableBoundary = getStableStreamingBoundary(messageText);
+  const blocks: TelegramRenderedBlock[] = [];
+
+  if (stableBoundary > 0) {
+    blocks.push(...renderAssistantBlocksSafe(messageText.slice(0, stableBoundary)));
+  }
+
+  const unstableTail = stableBoundary > 0 ? messageText.slice(stableBoundary) : messageText;
+  if (unstableTail) {
+    blocks.push(createPlainRenderedBlock(unstableTail));
+  }
+
+  const parts = chunkTelegramRenderedBlocks(blocks, { maxPartLength: RESPONSE_STREAM_TEXT_LIMIT });
   if (parts.length === 0) {
     return null;
   }
 
   return {
     parts,
-    format: "raw",
   };
 }
 
 function prepareFinalStreamingPayload(messageText: string): StreamingMessagePayload | null {
-  const format = getAssistantParseMode() === "MarkdownV2" ? "markdown_v2" : "raw";
-  const parts = formatSummaryWithMode(
-    messageText,
-    format === "markdown_v2" ? "markdown" : "raw",
-    RESPONSE_STREAM_TEXT_LIMIT,
-  );
+  const parts = renderAssistantPartsSafe(messageText, RESPONSE_STREAM_TEXT_LIMIT);
   if (parts.length === 0) {
     return null;
   }
 
   return {
     parts,
-    format,
   };
 }
 
@@ -220,43 +280,38 @@ const toolMessageBatcher = new ToolMessageBatcher({
 
 const responseStreamer = new ResponseStreamer({
   throttleMs: RESPONSE_STREAM_THROTTLE_MS,
-  sendText: async (text, format, options) => {
+  sendPart: async (part, options) => {
     if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
       throw new Error("Bot context missing for streamed send");
     }
 
-    const parseMode = format === "markdown_v2" ? "MarkdownV2" : undefined;
-    const sentMessage = await sendMessageWithMarkdownFallback({
+    return sendRenderedBotPart({
       api: botInstance.api,
       chatId: chatIdInstance,
-      text,
+      part,
       options,
-      parseMode,
     });
-
-    return sentMessage.message_id;
   },
-  editText: async (messageId, text, format, options) => {
+  editPart: async (messageId, part, options) => {
     if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
       throw new Error("Bot context missing for streamed edit");
     }
 
-    const parseMode = format === "markdown_v2" ? "MarkdownV2" : undefined;
-
     try {
-      await editMessageWithMarkdownFallback({
+      return await editRenderedBotPart({
         api: botInstance.api,
         chatId: chatIdInstance,
         messageId,
-        text,
+        part,
         options,
-        parseMode,
       });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
       if (errorMessage.includes("message is not modified")) {
-        return;
+        return {
+          deliveredSignature: getTelegramRenderedPartSignature(part),
+        };
       }
 
       throw error;
@@ -464,7 +519,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
               toolCallStreamer.breakSession(sessionId, "assistant_message_completed"),
             ]).then(() => undefined),
           prepareStreamingPayload: prepareFinalStreamingPayload,
-          renderFinalParts: (text) => renderTelegramParts(text),
+          renderFinalParts: (text) => renderAssistantPartsSafe(text),
           getReplyKeyboard: getCurrentReplyKeyboard,
           sendRenderedPart: async (part, options) => {
             await sendRenderedBotPart({

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -51,7 +51,6 @@ import { keyboardManager } from "../keyboard/manager.js";
 import { subscribeToEvents } from "../opencode/events.js";
 import { summaryAggregator } from "../summary/aggregator.js";
 import {
-  formatSummary,
   formatSummaryWithMode,
   formatToolInfo,
   getAssistantParseMode,
@@ -72,7 +71,7 @@ import { downloadTelegramFile, toDataUri } from "./utils/file-download.js";
 import { finalizeAssistantResponse } from "./utils/finalize-assistant-response.js";
 import { sendTtsResponseForSession } from "./utils/send-tts-response.js";
 import { deliverThinkingMessage } from "./utils/thinking-message.js";
-import { sendBotText } from "./utils/telegram-text.js";
+import { sendBotText, sendRenderedBotPart } from "./utils/telegram-text.js";
 import { formatAssistantRunFooter } from "./utils/assistant-run-footer.js";
 import { getModelCapabilities, supportsInput } from "../model/capabilities.js";
 import { getStoredModel } from "../model/manager.js";
@@ -87,6 +86,7 @@ import {
   editMessageWithMarkdownFallback,
   sendMessageWithMarkdownFallback,
 } from "./utils/send-with-markdown-fallback.js";
+import { renderTelegramParts } from "../telegram/render/pipeline.js";
 
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
@@ -464,18 +464,14 @@ async function ensureEventSubscription(directory: string): Promise<void> {
               toolCallStreamer.breakSession(sessionId, "assistant_message_completed"),
             ]).then(() => undefined),
           prepareStreamingPayload: prepareFinalStreamingPayload,
-          formatSummary,
-          formatRawSummary: (text) => formatSummaryWithMode(text, "raw"),
-          resolveFormat: () => (getAssistantParseMode() === "MarkdownV2" ? "markdown_v2" : "raw"),
+          renderFinalParts: (text) => renderTelegramParts(text),
           getReplyKeyboard: getCurrentReplyKeyboard,
-          sendText: async (text, rawFallbackText, options, format) => {
-            await sendBotText({
+          sendRenderedPart: async (part, options) => {
+            await sendRenderedBotPart({
               api: botApi,
               chatId,
-              text,
-              rawFallbackText,
+              part,
               options: options as Parameters<typeof sendBotText>[0]["options"],
-              format,
             });
           },
         });

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -83,9 +83,11 @@ import { assistantRunState } from "./assistant-run-state.js";
 import { ResponseStreamer } from "./streaming/response-streamer.js";
 import type { StreamingMessagePayload } from "./streaming/response-streamer.js";
 import { ToolCallStreamer, type ToolStreamKey } from "./streaming/tool-call-streamer.js";
-import { chunkTelegramRenderedBlocks } from "../telegram/render/chunker.js";
-import { renderTelegramBlocks, renderTelegramParts } from "../telegram/render/pipeline.js";
-import type { TelegramRenderedBlock, TelegramRenderedPart } from "../telegram/render/types.js";
+import {
+  prepareAssistantFinalStreamingPayload,
+  prepareAssistantStreamingPayload,
+  renderAssistantFinalPartsSafe,
+} from "./utils/assistant-rendering.js";
 
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
@@ -122,94 +124,12 @@ function prepareDocumentCaption(caption: string): string {
   return `${normalizedCaption.slice(0, TELEGRAM_DOCUMENT_CAPTION_MAX_LENGTH - 3)}...`;
 }
 
-function createPlainRenderedBlock(text: string): TelegramRenderedBlock {
-  return {
-    blockType: "plain",
-    mode: "plain",
-    text,
-    fallbackText: text,
-    source: "plain",
-  };
-}
-
-function createPlainRenderedParts(text: string, maxPartLength: number): TelegramRenderedPart[] {
-  return chunkTelegramRenderedBlocks([createPlainRenderedBlock(text)], { maxPartLength });
-}
-
-function renderAssistantBlocksSafe(text: string): TelegramRenderedBlock[] {
-  if (!text) {
-    return [];
-  }
-
-  try {
-    return renderTelegramBlocks(text);
-  } catch (error) {
-    logger.warn(
-      "[Bot] Assistant block rendering failed, falling back to plain streaming block",
-      error,
-    );
-    return [createPlainRenderedBlock(text)];
-  }
-}
-
-function renderAssistantPartsSafe(text: string, maxPartLength = 4096): TelegramRenderedPart[] {
-  if (!text) {
-    return [];
-  }
-
-  try {
-    return renderTelegramParts(text, { maxPartLength });
-  } catch (error) {
-    logger.warn("[Bot] Assistant part rendering failed, falling back to plain text parts", error);
-    return createPlainRenderedParts(text, maxPartLength);
-  }
-}
-
-function getStableStreamingBoundary(messageText: string): number {
-  if (!messageText) {
-    return 0;
-  }
-
-  if (messageText.endsWith("\n\n")) {
-    return messageText.length;
-  }
-
-  const lastBlockSeparatorIndex = messageText.lastIndexOf("\n\n");
-  return lastBlockSeparatorIndex >= 0 ? lastBlockSeparatorIndex + 2 : 0;
-}
-
 function prepareStreamingPayload(messageText: string): StreamingMessagePayload | null {
-  const stableBoundary = getStableStreamingBoundary(messageText);
-  const blocks: TelegramRenderedBlock[] = [];
-
-  if (stableBoundary > 0) {
-    blocks.push(...renderAssistantBlocksSafe(messageText.slice(0, stableBoundary)));
-  }
-
-  const unstableTail = stableBoundary > 0 ? messageText.slice(stableBoundary) : messageText;
-  if (unstableTail) {
-    blocks.push(createPlainRenderedBlock(unstableTail));
-  }
-
-  const parts = chunkTelegramRenderedBlocks(blocks, { maxPartLength: RESPONSE_STREAM_TEXT_LIMIT });
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return {
-    parts,
-  };
+  return prepareAssistantStreamingPayload(messageText, RESPONSE_STREAM_TEXT_LIMIT);
 }
 
 function prepareFinalStreamingPayload(messageText: string): StreamingMessagePayload | null {
-  const parts = renderAssistantPartsSafe(messageText, RESPONSE_STREAM_TEXT_LIMIT);
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return {
-    parts,
-  };
+  return prepareAssistantFinalStreamingPayload(messageText, RESPONSE_STREAM_TEXT_LIMIT);
 }
 
 function enqueueSessionCompletionTask(sessionId: string, task: () => Promise<void>): Promise<void> {
@@ -519,7 +439,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
               toolCallStreamer.breakSession(sessionId, "assistant_message_completed"),
             ]).then(() => undefined),
           prepareStreamingPayload: prepareFinalStreamingPayload,
-          renderFinalParts: (text) => renderAssistantPartsSafe(text),
+          renderFinalParts: (text) => renderAssistantFinalPartsSafe(text),
           getReplyKeyboard: getCurrentReplyKeyboard,
           sendRenderedPart: async (part, options) => {
             await sendRenderedBotPart({

--- a/src/bot/streaming/response-streamer.ts
+++ b/src/bot/streaming/response-streamer.ts
@@ -1,5 +1,6 @@
 import type { Api, RawApi } from "grammy";
 import { logger } from "../../utils/logger.js";
+import type { TelegramRenderedPart } from "../../telegram/render/types.js";
 
 type SendMessageApi = Pick<Api<RawApi>, "sendMessage">;
 type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
@@ -7,11 +8,8 @@ type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
 type TelegramSendMessageOptions = Parameters<SendMessageApi["sendMessage"]>[2];
 type TelegramEditMessageOptions = Parameters<EditMessageApi["editMessageText"]>[3];
 
-export type StreamingMessageFormat = "raw" | "markdown_v2";
-
 export interface StreamingMessagePayload {
-  parts: string[];
-  format: StreamingMessageFormat;
+  parts: TelegramRenderedPart[];
   sendOptions?: TelegramSendMessageOptions;
   editOptions?: TelegramEditMessageOptions;
 }
@@ -27,17 +25,15 @@ interface ResponseStreamerCompleteOptions {
 
 interface ResponseStreamerOptions {
   throttleMs: number;
-  sendText: (
-    text: string,
-    format: StreamingMessageFormat,
+  sendPart: (
+    part: TelegramRenderedPart,
     options?: TelegramSendMessageOptions,
-  ) => Promise<number>;
-  editText: (
+  ) => Promise<{ messageId: number; deliveredSignature: string }>;
+  editPart: (
     messageId: number,
-    text: string,
-    format: StreamingMessageFormat,
+    part: TelegramRenderedPart,
     options?: TelegramEditMessageOptions,
-  ) => Promise<void>;
+  ) => Promise<{ deliveredSignature: string }>;
   deleteText: (messageId: number) => Promise<void>;
 }
 
@@ -60,17 +56,23 @@ function buildStateKey(sessionId: string, messageId: string): string {
   return `${sessionId}:${messageId}`;
 }
 
+function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
+  return {
+    text: part.text,
+    entities: part.entities ? [...part.entities] : undefined,
+    fallbackText: part.fallbackText,
+    source: part.source,
+  };
+}
+
 function normalizePayload(payload: StreamingMessagePayload): StreamingMessagePayload | null {
-  const normalizedParts = payload.parts
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
+  const normalizedParts = payload.parts.map(clonePart).filter((part) => part.text.length > 0);
   if (normalizedParts.length === 0) {
     return null;
   }
 
   return {
     parts: normalizedParts,
-    format: payload.format,
     sendOptions: payload.sendOptions,
     editOptions: payload.editOptions,
   };
@@ -103,8 +105,8 @@ function getRetryAfterMs(error: unknown): number | null {
   return seconds * 1000;
 }
 
-function createSignature(text: string, format: StreamingMessageFormat): string {
-  return `${format}\n${text}`;
+function createSignature(part: Pick<TelegramRenderedPart, "text" | "entities">): string {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
 }
 
 function delay(ms: number): Promise<void> {
@@ -115,15 +117,15 @@ function delay(ms: number): Promise<void> {
 
 export class ResponseStreamer {
   private readonly throttleMs: number;
-  private readonly sendText: ResponseStreamerOptions["sendText"];
-  private readonly editText: ResponseStreamerOptions["editText"];
+  private readonly sendPart: ResponseStreamerOptions["sendPart"];
+  private readonly editPart: ResponseStreamerOptions["editPart"];
   private readonly deleteText: ResponseStreamerOptions["deleteText"];
   private readonly states: Map<string, StreamState> = new Map();
 
   constructor(options: ResponseStreamerOptions) {
     this.throttleMs = Math.max(0, Math.floor(options.throttleMs));
-    this.sendText = options.sendText;
-    this.editText = options.editText;
+    this.sendPart = options.sendPart;
+    this.editPart = options.editPart;
     this.deleteText = options.deleteText;
   }
 
@@ -324,7 +326,7 @@ export class ResponseStreamer {
         return state.telegramMessageIds.length > 0;
       }
 
-      const targetSignatures = payload.parts.map((part) => createSignature(part, payload.format));
+      const targetSignatures = payload.parts.map((part) => createSignature(part));
       const unchanged =
         targetSignatures.length === state.lastSentSignatures.length &&
         targetSignatures.every((signature, index) => signature === state.lastSentSignatures[index]);
@@ -407,7 +409,7 @@ export class ResponseStreamer {
     targetSignatures: string[],
   ): Promise<void> {
     for (let index = 0; index < payload.parts.length; index++) {
-      const text = payload.parts[index];
+      const part = payload.parts[index];
       const nextSignature = targetSignatures[index];
       const currentMessageId = state.telegramMessageIds[index];
 
@@ -416,14 +418,14 @@ export class ResponseStreamer {
           continue;
         }
 
-        await this.editText(currentMessageId, text, payload.format, payload.editOptions);
-        state.lastSentSignatures[index] = nextSignature;
+        const result = await this.editPart(currentMessageId, part, payload.editOptions);
+        state.lastSentSignatures[index] = result.deliveredSignature;
         continue;
       }
 
-      const messageId = await this.sendText(text, payload.format, payload.sendOptions);
-      state.telegramMessageIds[index] = messageId;
-      state.lastSentSignatures[index] = nextSignature;
+      const result = await this.sendPart(part, payload.sendOptions);
+      state.telegramMessageIds[index] = result.messageId;
+      state.lastSentSignatures[index] = result.deliveredSignature;
     }
 
     for (let index = state.telegramMessageIds.length - 1; index >= payload.parts.length; index--) {

--- a/src/bot/streaming/response-streamer.ts
+++ b/src/bot/streaming/response-streamer.ts
@@ -68,6 +68,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
 function normalizePayload(payload: StreamingMessagePayload): StreamingMessagePayload | null {
   const normalizedParts = payload.parts.map(clonePart).filter((part) => part.text.length > 0);
   if (normalizedParts.length === 0) {
+    logger.debug("[ResponseStreamer] Dropped empty streaming payload after normalization");
     return null;
   }
 
@@ -154,6 +155,9 @@ export class ResponseStreamer {
 
     const state = this.states.get(buildStateKey(sessionId, messageId));
     if (!state) {
+      logger.debug(
+        `[ResponseStreamer] Complete skipped, no active stream state: session=${sessionId}, message=${messageId}`,
+      );
       return notStreamed;
     }
 
@@ -176,6 +180,9 @@ export class ResponseStreamer {
     }
 
     if (state.telegramMessageIds.length === 0) {
+      logger.debug(
+        `[ResponseStreamer] Complete returned not streamed: session=${sessionId}, message=${messageId}, reason=no_visible_partials`,
+      );
       this.cancelState(state);
       this.states.delete(state.key);
       return notStreamed;
@@ -332,6 +339,9 @@ export class ResponseStreamer {
         targetSignatures.every((signature, index) => signature === state.lastSentSignatures[index]);
 
       if (unchanged) {
+        logger.debug(
+          `[ResponseStreamer] Skipped unchanged payload: session=${state.sessionId}, message=${state.messageId}, parts=${payload.parts.length}`,
+        );
         return state.telegramMessageIds.length > 0;
       }
 

--- a/src/bot/utils/assistant-rendering.ts
+++ b/src/bot/utils/assistant-rendering.ts
@@ -1,0 +1,153 @@
+import { config } from "../../config.js";
+import { logger } from "../../utils/logger.js";
+import { chunkTelegramRenderedBlocks } from "../../telegram/render/chunker.js";
+import { renderTelegramBlocks, renderTelegramParts } from "../../telegram/render/pipeline.js";
+import type { TelegramRenderedBlock, TelegramRenderedPart } from "../../telegram/render/types.js";
+import type { StreamingMessagePayload } from "../streaming/response-streamer.js";
+
+export function createPlainRenderedBlock(text: string): TelegramRenderedBlock {
+  return {
+    blockType: "plain",
+    mode: "plain",
+    text,
+    fallbackText: text,
+    source: "plain",
+  };
+}
+
+export function createPlainRenderedParts(
+  text: string,
+  maxPartLength: number,
+): TelegramRenderedPart[] {
+  return chunkTelegramRenderedBlocks([createPlainRenderedBlock(text)], { maxPartLength });
+}
+
+function useAssistantEntitiesFormat(): boolean {
+  return config.bot.messageFormatMode === "markdown";
+}
+
+function renderAssistantBlocksSafe(text: string): TelegramRenderedBlock[] {
+  if (!text) {
+    return [];
+  }
+
+  try {
+    return renderTelegramBlocks(text);
+  } catch (error) {
+    logger.warn(
+      "[AssistantRender] Block rendering failed, falling back to plain streaming block",
+      error,
+    );
+    return [createPlainRenderedBlock(text)];
+  }
+}
+
+export function renderAssistantFinalPartsSafe(
+  text: string,
+  maxPartLength = 4096,
+): TelegramRenderedPart[] {
+  if (!text) {
+    return [];
+  }
+
+  const formatMode = useAssistantEntitiesFormat() ? "entities" : "raw";
+
+  if (!useAssistantEntitiesFormat()) {
+    const parts = createPlainRenderedParts(text, maxPartLength);
+    logger.debug("[AssistantRender] Built final assistant parts in raw mode", {
+      formatMode,
+      textLength: text.length,
+      partCount: parts.length,
+    });
+    return parts;
+  }
+
+  try {
+    const parts = renderTelegramParts(text, { maxPartLength });
+    logger.debug("[AssistantRender] Built final assistant parts in entities mode", {
+      formatMode,
+      textLength: text.length,
+      partCount: parts.length,
+      richParts: parts.filter((part) => part.source === "entities").length,
+      plainParts: parts.filter((part) => part.source === "plain").length,
+    });
+    return parts;
+  } catch (error) {
+    logger.warn("[AssistantRender] Part rendering failed, falling back to plain text parts", error);
+    const parts = createPlainRenderedParts(text, maxPartLength);
+    logger.debug("[AssistantRender] Built final assistant parts in raw fallback mode", {
+      formatMode,
+      textLength: text.length,
+      partCount: parts.length,
+    });
+    return parts;
+  }
+}
+
+function getStableStreamingBoundary(messageText: string): number {
+  if (!messageText) {
+    return 0;
+  }
+
+  if (messageText.endsWith("\n\n")) {
+    return messageText.length;
+  }
+
+  const lastBlockSeparatorIndex = messageText.lastIndexOf("\n\n");
+  return lastBlockSeparatorIndex >= 0 ? lastBlockSeparatorIndex + 2 : 0;
+}
+
+export function prepareAssistantStreamingPayload(
+  messageText: string,
+  maxPartLength: number,
+): StreamingMessagePayload | null {
+  if (!messageText) {
+    return null;
+  }
+
+  const formatMode = useAssistantEntitiesFormat() ? "entities" : "raw";
+
+  if (!useAssistantEntitiesFormat()) {
+    const parts = createPlainRenderedParts(messageText, maxPartLength);
+    logger.debug("[AssistantRender] Built streaming assistant payload in raw mode", {
+      formatMode,
+      textLength: messageText.length,
+      partCount: parts.length,
+    });
+    return parts.length > 0 ? { parts } : null;
+  }
+
+  const stableBoundary = getStableStreamingBoundary(messageText);
+  const blocks: TelegramRenderedBlock[] = [];
+
+  if (stableBoundary > 0) {
+    blocks.push(...renderAssistantBlocksSafe(messageText.slice(0, stableBoundary)));
+  }
+
+  const unstableTail = stableBoundary > 0 ? messageText.slice(stableBoundary) : messageText;
+  if (unstableTail) {
+    blocks.push(createPlainRenderedBlock(unstableTail));
+  }
+
+  const parts = chunkTelegramRenderedBlocks(blocks, { maxPartLength });
+  logger.debug("[AssistantRender] Built streaming assistant payload in entities mode", {
+    formatMode,
+    textLength: messageText.length,
+    stableBoundary,
+    tailLength: unstableTail.length,
+    blockCount: blocks.length,
+    partCount: parts.length,
+    richParts: parts.filter((part) => part.source === "entities").length,
+    plainParts: parts.filter((part) => part.source === "plain").length,
+  });
+
+  return parts.length > 0 ? { parts } : null;
+}
+
+export function prepareAssistantFinalStreamingPayload(
+  messageText: string,
+  maxPartLength: number,
+): StreamingMessagePayload | null {
+  const parts = renderAssistantFinalPartsSafe(messageText, maxPartLength);
+  return parts.length > 0 ? { parts } : null;
+}

--- a/src/bot/utils/finalize-assistant-response.ts
+++ b/src/bot/utils/finalize-assistant-response.ts
@@ -1,6 +1,6 @@
 import type { StreamingMessagePayload, ResponseStreamer } from "../streaming/response-streamer.js";
-import type { TelegramTextFormat } from "./telegram-text.js";
 import { logger } from "../../utils/logger.js";
+import type { TelegramRenderedPart } from "../../telegram/render/types.js";
 
 interface FinalizeAssistantResponseOptions {
   sessionId: string;
@@ -9,20 +9,16 @@ interface FinalizeAssistantResponseOptions {
   responseStreamer: Pick<ResponseStreamer, "complete">;
   flushPendingServiceMessages: () => Promise<void>;
   prepareStreamingPayload: (messageText: string) => StreamingMessagePayload | null;
-  formatSummary: (messageText: string) => string[];
-  formatRawSummary: (messageText: string) => string[];
-  resolveFormat: () => TelegramTextFormat;
+  renderFinalParts: (messageText: string) => TelegramRenderedPart[];
   getReplyKeyboard: () => unknown;
-  sendText: (
-    text: string,
-    rawFallbackText: string | undefined,
+  sendRenderedPart: (
+    part: TelegramRenderedPart,
     options:
       | {
           reply_markup?: unknown;
           disable_notification?: boolean;
         }
       | undefined,
-    format: TelegramTextFormat,
   ) => Promise<void>;
 }
 
@@ -33,11 +29,9 @@ export async function finalizeAssistantResponse({
   responseStreamer,
   flushPendingServiceMessages,
   prepareStreamingPayload,
-  formatSummary,
-  formatRawSummary,
-  resolveFormat,
+  renderFinalParts,
   getReplyKeyboard,
-  sendText,
+  sendRenderedPart,
 }: FinalizeAssistantResponseOptions): Promise<boolean> {
   const keyboard = getReplyKeyboard();
   const replyOptions = keyboard ? { reply_markup: keyboard } : undefined;
@@ -70,14 +64,10 @@ export async function finalizeAssistantResponse({
     return true;
   }
 
-  const parts = formatSummary(messageText);
-  const rawParts = formatRawSummary(messageText);
-  const format = resolveFormat();
+  const parts = renderFinalParts(messageText);
 
-  for (let partIndex = 0; partIndex < parts.length; partIndex++) {
-    const part = parts[partIndex];
-    const rawFallbackText = rawParts[partIndex];
-    await sendText(part, rawFallbackText, silentReplyOptions, format);
+  for (const part of parts) {
+    await sendRenderedPart(part, silentReplyOptions);
   }
 
   return false;

--- a/src/bot/utils/finalize-assistant-response.ts
+++ b/src/bot/utils/finalize-assistant-response.ts
@@ -33,6 +33,11 @@ export async function finalizeAssistantResponse({
   getReplyKeyboard,
   sendRenderedPart,
 }: FinalizeAssistantResponseOptions): Promise<boolean> {
+  logger.debug(
+    `[FinalizeResponse] Final assistant raw text received: session=${sessionId}, message=${messageId}`,
+    messageText,
+  );
+
   const keyboard = getReplyKeyboard();
   const replyOptions = keyboard ? { reply_markup: keyboard } : undefined;
   const silentReplyOptions = {

--- a/src/bot/utils/send-with-markdown-fallback.ts
+++ b/src/bot/utils/send-with-markdown-fallback.ts
@@ -176,10 +176,7 @@ export async function sendMessageWithMarkdownFallback({
     if (parseMode === "MarkdownV2") {
       const escapedText = escapeTelegramMarkdownV2(text);
       if (escapedText !== text) {
-        logger.warn(
-          "[Bot] Markdown parse failed, retrying assistant message with escaped MarkdownV2",
-          error,
-        );
+        logger.warn("[Bot] Markdown parse failed, retrying message with escaped MarkdownV2", error);
 
         try {
           return await api.sendMessage(chatId, escapedText, markdownOptions);
@@ -189,7 +186,7 @@ export async function sendMessageWithMarkdownFallback({
           }
 
           logger.warn(
-            "[Bot] Escaped Markdown parse failed, retrying assistant message in raw mode",
+            "[Bot] Escaped Markdown parse failed, retrying message in raw mode",
             escapedError,
           );
           return api.sendMessage(chatId, fallbackText, stripMarkdownFormattingOptions(options));
@@ -197,7 +194,7 @@ export async function sendMessageWithMarkdownFallback({
       }
     }
 
-    logger.warn("[Bot] Markdown parse failed, retrying assistant message in raw mode", error);
+    logger.warn("[Bot] Markdown parse failed, retrying message in raw mode", error);
     return api.sendMessage(chatId, fallbackText, stripMarkdownFormattingOptions(options));
   }
 }

--- a/src/bot/utils/telegram-text.ts
+++ b/src/bot/utils/telegram-text.ts
@@ -117,6 +117,13 @@ export async function sendRenderedBotPart({
 }: SendRenderedBotPartParams): Promise<RenderedPartSendResult> {
   const rawOptions = stripRichFormattingOptions(options);
 
+  logger.debug("[Bot] Sending rendered Telegram part", {
+    source: part.source,
+    textLength: part.text.length,
+    fallbackTextLength: part.fallbackText.length,
+    entityCount: part.entities?.length ?? 0,
+  });
+
   if (!part.entities?.length) {
     const sentMessage = await api.sendMessage(chatId, part.text, rawOptions);
     return {
@@ -145,6 +152,9 @@ export async function sendRenderedBotPart({
       error,
     );
     const sentMessage = await api.sendMessage(chatId, part.fallbackText, rawOptions);
+    logger.debug("[Bot] Assistant message part sent in raw fallback mode", {
+      fallbackTextLength: part.fallbackText.length,
+    });
     return {
       messageId: sentMessage.message_id,
       deliveredSignature: getTelegramRenderedPartSignature({ text: part.fallbackText }),
@@ -160,6 +170,14 @@ export async function editRenderedBotPart({
   options,
 }: EditRenderedBotPartParams): Promise<RenderedPartDeliveryResult> {
   const rawOptions = stripRichFormattingOptions(options);
+
+  logger.debug("[Bot] Editing rendered Telegram part", {
+    messageId,
+    source: part.source,
+    textLength: part.text.length,
+    fallbackTextLength: part.fallbackText.length,
+    entityCount: part.entities?.length ?? 0,
+  });
 
   if (!part.entities?.length) {
     await api.editMessageText(chatId, messageId, part.text, rawOptions);
@@ -184,6 +202,10 @@ export async function editRenderedBotPart({
 
     logger.warn("[Bot] Entity payload rejected, retrying assistant edit part in raw mode", error);
     await api.editMessageText(chatId, messageId, part.fallbackText, rawOptions);
+    logger.debug("[Bot] Assistant edit part applied in raw fallback mode", {
+      messageId,
+      fallbackTextLength: part.fallbackText.length,
+    });
     return {
       deliveredSignature: getTelegramRenderedPartSignature({ text: part.fallbackText }),
     };

--- a/src/bot/utils/telegram-text.ts
+++ b/src/bot/utils/telegram-text.ts
@@ -1,8 +1,11 @@
 import type { Api, RawApi } from "grammy";
+import { logger } from "../../utils/logger.js";
 import {
   editMessageWithMarkdownFallback,
+  isTelegramMarkdownParseError,
   sendMessageWithMarkdownFallback,
 } from "./send-with-markdown-fallback.js";
+import type { TelegramRenderedPart } from "../../telegram/render/types.js";
 
 type SendMessageApi = Pick<Api<RawApi>, "sendMessage">;
 type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
@@ -31,12 +34,39 @@ interface EditBotTextParams {
   format?: TelegramTextFormat;
 }
 
+interface SendRenderedBotPartParams {
+  api: SendMessageApi;
+  chatId: Parameters<SendMessageApi["sendMessage"]>[0];
+  part: TelegramRenderedPart;
+  options?: TelegramSendMessageOptions;
+}
+
 function resolveParseMode(format: TelegramTextFormat | undefined): "MarkdownV2" | undefined {
   if (format === "markdown_v2") {
     return "MarkdownV2";
   }
 
   return undefined;
+}
+
+function stripRichFormattingOptions<T extends TelegramSendMessageOptions | undefined>(
+  options: T,
+): T {
+  if (!options) {
+    return options;
+  }
+
+  const rawOptions = {
+    ...options,
+  } as NonNullable<T> & {
+    parse_mode?: unknown;
+    entities?: unknown;
+  };
+
+  delete rawOptions.parse_mode;
+  delete rawOptions.entities;
+
+  return rawOptions as T;
 }
 
 export async function sendBotText({
@@ -55,6 +85,37 @@ export async function sendBotText({
     options,
     parseMode: resolveParseMode(format),
   });
+}
+
+export async function sendRenderedBotPart({
+  api,
+  chatId,
+  part,
+  options,
+}: SendRenderedBotPartParams): Promise<void> {
+  const rawOptions = stripRichFormattingOptions(options);
+
+  if (!part.entities?.length) {
+    await api.sendMessage(chatId, part.text, rawOptions);
+    return;
+  }
+
+  try {
+    await api.sendMessage(chatId, part.text, {
+      ...(rawOptions || {}),
+      entities: part.entities,
+    });
+  } catch (error) {
+    if (!isTelegramMarkdownParseError(error)) {
+      throw error;
+    }
+
+    logger.warn(
+      "[Bot] Entity payload rejected, retrying assistant message part in raw mode",
+      error,
+    );
+    await api.sendMessage(chatId, part.fallbackText, rawOptions);
+  }
 }
 
 export async function editBotText({

--- a/src/bot/utils/telegram-text.ts
+++ b/src/bot/utils/telegram-text.ts
@@ -41,6 +41,22 @@ interface SendRenderedBotPartParams {
   options?: TelegramSendMessageOptions;
 }
 
+interface EditRenderedBotPartParams {
+  api: EditMessageApi;
+  chatId: Parameters<EditMessageApi["editMessageText"]>[0];
+  messageId: Parameters<EditMessageApi["editMessageText"]>[1];
+  part: TelegramRenderedPart;
+  options?: TelegramEditMessageOptions;
+}
+
+interface RenderedPartDeliveryResult {
+  deliveredSignature: string;
+}
+
+interface RenderedPartSendResult extends RenderedPartDeliveryResult {
+  messageId: number;
+}
+
 function resolveParseMode(format: TelegramTextFormat | undefined): "MarkdownV2" | undefined {
   if (format === "markdown_v2") {
     return "MarkdownV2";
@@ -69,6 +85,12 @@ function stripRichFormattingOptions<T extends TelegramSendMessageOptions | undef
   return rawOptions as T;
 }
 
+export function getTelegramRenderedPartSignature(
+  part: Pick<TelegramRenderedPart, "text" | "entities">,
+): string {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
+}
+
 export async function sendBotText({
   api,
   chatId,
@@ -92,19 +114,27 @@ export async function sendRenderedBotPart({
   chatId,
   part,
   options,
-}: SendRenderedBotPartParams): Promise<void> {
+}: SendRenderedBotPartParams): Promise<RenderedPartSendResult> {
   const rawOptions = stripRichFormattingOptions(options);
 
   if (!part.entities?.length) {
-    await api.sendMessage(chatId, part.text, rawOptions);
-    return;
+    const sentMessage = await api.sendMessage(chatId, part.text, rawOptions);
+    return {
+      messageId: sentMessage.message_id,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: part.text }),
+    };
   }
 
   try {
-    await api.sendMessage(chatId, part.text, {
+    const sentMessage = await api.sendMessage(chatId, part.text, {
       ...(rawOptions || {}),
       entities: part.entities,
     });
+
+    return {
+      messageId: sentMessage.message_id,
+      deliveredSignature: getTelegramRenderedPartSignature(part),
+    };
   } catch (error) {
     if (!isTelegramMarkdownParseError(error)) {
       throw error;
@@ -114,7 +144,49 @@ export async function sendRenderedBotPart({
       "[Bot] Entity payload rejected, retrying assistant message part in raw mode",
       error,
     );
-    await api.sendMessage(chatId, part.fallbackText, rawOptions);
+    const sentMessage = await api.sendMessage(chatId, part.fallbackText, rawOptions);
+    return {
+      messageId: sentMessage.message_id,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: part.fallbackText }),
+    };
+  }
+}
+
+export async function editRenderedBotPart({
+  api,
+  chatId,
+  messageId,
+  part,
+  options,
+}: EditRenderedBotPartParams): Promise<RenderedPartDeliveryResult> {
+  const rawOptions = stripRichFormattingOptions(options);
+
+  if (!part.entities?.length) {
+    await api.editMessageText(chatId, messageId, part.text, rawOptions);
+    return {
+      deliveredSignature: getTelegramRenderedPartSignature({ text: part.text }),
+    };
+  }
+
+  try {
+    await api.editMessageText(chatId, messageId, part.text, {
+      ...(rawOptions || {}),
+      entities: part.entities,
+    });
+
+    return {
+      deliveredSignature: getTelegramRenderedPartSignature(part),
+    };
+  } catch (error) {
+    if (!isTelegramMarkdownParseError(error)) {
+      throw error;
+    }
+
+    logger.warn("[Bot] Entity payload rejected, retrying assistant edit part in raw mode", error);
+    await api.editMessageText(chatId, messageId, part.fallbackText, rawOptions);
+    return {
+      deliveredSignature: getTelegramRenderedPartSignature({ text: part.fallbackText }),
+    };
   }
 }
 

--- a/src/summary/formatter.ts
+++ b/src/summary/formatter.ts
@@ -123,14 +123,6 @@ export function formatSummary(text: string): string[] {
   return formatSummaryWithMode(text, config.bot.messageFormatMode);
 }
 
-export function getAssistantParseMode(): "MarkdownV2" | undefined {
-  if (config.bot.messageFormatMode === "markdown") {
-    return "MarkdownV2";
-  }
-
-  return undefined;
-}
-
 export function escapePlainTextForTelegramMarkdownV2(text: string): string {
   return text.replace(MARKDOWN_V2_RESERVED_CHARS, "\\$1");
 }

--- a/src/summary/formatter.ts
+++ b/src/summary/formatter.ts
@@ -6,6 +6,7 @@ import type { MessageFormatMode } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { t } from "../i18n/index.js";
 import { getCurrentProject } from "../settings/manager.js";
+import { normalizeMarkdownForTelegramRendering } from "../telegram/render/markdown-normalizer.js";
 
 const TELEGRAM_MESSAGE_LIMIT = 4096;
 const MARKDOWN_V2_RESERVED_CHARS = /([_\*\[\]\(\)~`>#+\-=|{}.!\\])/g;
@@ -88,109 +89,6 @@ function splitText(text: string, maxLength: number, options?: SplitTextOptions):
   return parts;
 }
 
-function isCodeFenceLine(line: string): boolean {
-  return line.trimStart().startsWith("```");
-}
-
-function isHorizontalRuleLine(line: string): boolean {
-  const normalized = line.trim();
-  if (!normalized) {
-    return false;
-  }
-
-  return /^([-*_])(?:\s*\1){2,}$/.test(normalized);
-}
-
-function isHeadingLine(line: string): boolean {
-  return /^\s{0,3}#{1,6}\s+\S/.test(line);
-}
-
-function normalizeHeadingLine(line: string): string {
-  const match = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*$/);
-  if (!match) {
-    return line;
-  }
-
-  return `**${match[1]}**`;
-}
-
-function normalizeChecklistLine(line: string): string | null {
-  const match = line.match(/^(\s*)(?:[-+*]|\d+\.)\s+\[( |x|X)\]\s+(.*)$/);
-  if (!match) {
-    return null;
-  }
-
-  const marker = match[2].toLowerCase() === "x" ? "✅" : "🔲";
-  return `${match[1]}${marker} ${match[3]}`;
-}
-
-function preprocessMarkdownForTelegram(text: string): string {
-  const lines = text.split("\n");
-  const output: string[] = [];
-  let inCodeFence = false;
-  let inQuote = false;
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index];
-
-    if (isCodeFenceLine(line)) {
-      inCodeFence = !inCodeFence;
-      inQuote = false;
-      output.push(line);
-      continue;
-    }
-
-    if (inCodeFence) {
-      output.push(line);
-      continue;
-    }
-
-    if (!line.trim()) {
-      inQuote = false;
-      output.push(line);
-      continue;
-    }
-
-    if (isHeadingLine(line)) {
-      output.push(normalizeHeadingLine(line));
-      inQuote = false;
-      continue;
-    }
-
-    if (isHorizontalRuleLine(line)) {
-      output.push("──────────");
-      inQuote = false;
-      continue;
-    }
-
-    const trimmedLeft = line.trimStart();
-    if (trimmedLeft.startsWith(">")) {
-      inQuote = true;
-      const quoteContent = trimmedLeft.replace(/^>\s?/, "");
-      const normalizedChecklistInQuote = normalizeChecklistLine(quoteContent);
-      output.push(
-        normalizedChecklistInQuote ? `> ${normalizedChecklistInQuote.trimStart()}` : trimmedLeft,
-      );
-      continue;
-    }
-
-    const normalizedChecklist = normalizeChecklistLine(line);
-    if (normalizedChecklist) {
-      output.push(inQuote ? `> ${normalizedChecklist.trimStart()}` : normalizedChecklist);
-      continue;
-    }
-
-    if (inQuote) {
-      output.push(`> ${trimmedLeft}`);
-      continue;
-    }
-
-    output.push(line);
-  }
-
-  return output.join("\n");
-}
-
 export function normalizePathForDisplay(filePath: string): string {
   const normalizedPath = filePath.replace(/\\/g, "/");
   const project = getCurrentProject();
@@ -239,7 +137,7 @@ export function escapePlainTextForTelegramMarkdownV2(text: string): string {
 
 function formatMarkdownForTelegram(text: string): string {
   try {
-    const preprocessed = preprocessMarkdownForTelegram(text);
+    const preprocessed = normalizeMarkdownForTelegramRendering(text);
     return escapeMarkdownV2PipesOutsideCode(convert(preprocessed, "keep"));
   } catch (error) {
     logger.warn("[Formatter] Failed to convert markdown summary, falling back to raw text", error);

--- a/src/telegram/render/block-fallback.ts
+++ b/src/telegram/render/block-fallback.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../utils/logger.js";
 import type { TelegramBlock, TelegramRenderedBlock } from "./types.js";
 import * as blockRenderer from "./block-renderer.js";
 
@@ -5,12 +6,26 @@ const BLOCK_RENDER_ORDER = ["full", "simplified", "line-by-line", "plain"] as co
 
 export function renderTelegramBlockWithFallback(block: TelegramBlock): TelegramRenderedBlock {
   let lastError: unknown;
+  const failures: Array<{ mode: (typeof BLOCK_RENDER_ORDER)[number]; reason: string }> = [];
 
   for (const mode of BLOCK_RENDER_ORDER) {
     try {
-      return blockRenderer.renderTelegramBlock(block, mode);
+      const renderedBlock = blockRenderer.renderTelegramBlock(block, mode);
+      if (failures.length > 0) {
+        logger.debug("[TelegramRender] Block fallback applied", {
+          blockType: block.type,
+          selectedMode: renderedBlock.mode,
+          failures,
+        });
+      }
+
+      return renderedBlock;
     } catch (error) {
       lastError = error;
+      failures.push({
+        mode,
+        reason: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/telegram/render/block-fallback.ts
+++ b/src/telegram/render/block-fallback.ts
@@ -1,0 +1,18 @@
+import type { TelegramBlock, TelegramRenderedBlock } from "./types.js";
+import * as blockRenderer from "./block-renderer.js";
+
+const BLOCK_RENDER_ORDER = ["full", "simplified", "line-by-line", "plain"] as const;
+
+export function renderTelegramBlockWithFallback(block: TelegramBlock): TelegramRenderedBlock {
+  let lastError: unknown;
+
+  for (const mode of BLOCK_RENDER_ORDER) {
+    try {
+      return blockRenderer.renderTelegramBlock(block, mode);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Failed to render Telegram block");
+}

--- a/src/telegram/render/block-parser.ts
+++ b/src/telegram/render/block-parser.ts
@@ -1,0 +1,363 @@
+import { toString } from "mdast-util-to-string";
+import type {
+  Blockquote,
+  Code,
+  Heading,
+  List,
+  ListItem,
+  Paragraph,
+  PhrasingContent,
+  Root,
+  RootContent,
+  Table,
+  TableCell,
+} from "mdast";
+import { unified } from "unified";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { normalizeMarkdownForTelegramBlockParsing } from "./markdown-normalizer.js";
+import type { InlineNode, TelegramBlock } from "./types.js";
+
+const markdownProcessor = unified().use(remarkParse).use(remarkGfm);
+
+function pushTextNode(nodes: InlineNode[], text: string): void {
+  if (!text) {
+    return;
+  }
+
+  const previous = nodes.at(-1);
+  if (previous?.type === "text") {
+    previous.text += text;
+    return;
+  }
+
+  nodes.push({ type: "text", text });
+}
+
+function appendInlineNodes(target: InlineNode[], additions: InlineNode[]): void {
+  for (const node of additions) {
+    if (node.type === "text") {
+      pushTextNode(target, node.text);
+      continue;
+    }
+
+    target.push(node);
+  }
+}
+
+function prefixLines(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => `${prefix}${line}`)
+    .join("\n");
+}
+
+function createPlainBlock(text: string): TelegramBlock[] {
+  const normalized = text.trim();
+  if (!normalized) {
+    return [];
+  }
+
+  return [{ type: "plain", text: normalized }];
+}
+
+function extractInlinePlainText(nodes: PhrasingContent[]): string {
+  let result = "";
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        result += node.value;
+        break;
+      case "strong":
+      case "emphasis":
+      case "delete":
+      case "link":
+        result += extractInlinePlainText(node.children);
+        break;
+      case "inlineCode":
+        result += node.value;
+        break;
+      case "break":
+        result += "\n";
+        break;
+      case "image":
+        result += node.alt ?? "";
+        break;
+      case "imageReference":
+        result += node.alt ?? "";
+        break;
+      case "linkReference":
+        result += extractInlinePlainText(node.children);
+        break;
+      case "html":
+        result += node.value;
+        break;
+      case "footnoteReference":
+        result += `[^${node.identifier}]`;
+        break;
+      default:
+        result += toString(node);
+        break;
+    }
+  }
+
+  return result;
+}
+
+function extractTableCellPlainText(cell: TableCell): string {
+  return extractInlinePlainText(cell.children);
+}
+
+function extractListItemPlainText(item: ListItem, index: number, ordered: boolean): string {
+  const prefix = item.checked === true ? "✅ " : item.checked === false ? "🔲 " : "";
+  const marker = ordered ? `${index + 1}. ` : "- ";
+  const body = item.children.map(extractBlockPlainText).filter(Boolean).join("\n");
+
+  return `${marker}${prefix}${body}`.trimEnd();
+}
+
+function extractBlockPlainText(node: RootContent | ListItem): string {
+  switch (node.type) {
+    case "paragraph":
+    case "heading":
+      return extractInlinePlainText(node.children);
+    case "blockquote":
+      return node.children
+        .map(extractBlockPlainText)
+        .filter(Boolean)
+        .map((text) => prefixLines(text, "> "))
+        .join("\n");
+    case "list":
+      return node.children
+        .map((item, index) => extractListItemPlainText(item, index, Boolean(node.ordered)))
+        .filter(Boolean)
+        .join("\n");
+    case "listItem":
+      return node.children.map(extractBlockPlainText).filter(Boolean).join("\n");
+    case "code":
+      return node.value;
+    case "table":
+      return node.children
+        .map((row) => row.children.map(extractTableCellPlainText).join(" | "))
+        .join("\n");
+    case "thematicBreak":
+      return "──────────";
+    case "html":
+      return node.value;
+    default:
+      return toString(node);
+  }
+}
+
+function parseInlineNodes(nodes: PhrasingContent[]): InlineNode[] | null {
+  const result: InlineNode[] = [];
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        pushTextNode(result, node.value);
+        break;
+      case "strong": {
+        const children = parseInlineNodes(node.children);
+        if (!children) {
+          return null;
+        }
+
+        result.push({ type: "bold", children });
+        break;
+      }
+      case "emphasis": {
+        const children = parseInlineNodes(node.children);
+        if (!children) {
+          return null;
+        }
+
+        result.push({ type: "italic", children });
+        break;
+      }
+      case "delete": {
+        const children = parseInlineNodes(node.children);
+        if (!children) {
+          return null;
+        }
+
+        result.push({ type: "strike", children });
+        break;
+      }
+      case "inlineCode":
+        result.push({ type: "code", text: node.value });
+        break;
+      case "link": {
+        const children = parseInlineNodes(node.children);
+        if (!children) {
+          return null;
+        }
+
+        result.push({ type: "link", text: children, url: node.url });
+        break;
+      }
+      case "break":
+        pushTextNode(result, "\n");
+        break;
+      default:
+        return null;
+    }
+  }
+
+  return result;
+}
+
+function parseParagraphBlock(node: Paragraph): TelegramBlock[] {
+  const inlines = parseInlineNodes(node.children);
+  if (!inlines) {
+    return createPlainBlock(extractBlockPlainText(node));
+  }
+
+  return [{ type: "paragraph", inlines }];
+}
+
+function parseHeadingBlock(node: Heading): TelegramBlock[] {
+  const inlines = parseInlineNodes(node.children);
+  if (!inlines) {
+    return createPlainBlock(extractBlockPlainText(node));
+  }
+
+  return [
+    {
+      type: "heading",
+      level: Math.min(6, Math.max(1, Math.floor(node.depth))),
+      inlines,
+    },
+  ];
+}
+
+function parseBlockquoteBlock(node: Blockquote): TelegramBlock[] {
+  const lines: InlineNode[][] = [];
+
+  for (const child of node.children) {
+    if (child.type !== "paragraph" && child.type !== "heading") {
+      return createPlainBlock(extractBlockPlainText(node));
+    }
+
+    const inlines = parseInlineNodes(child.children);
+    if (!inlines) {
+      return createPlainBlock(extractBlockPlainText(node));
+    }
+
+    lines.push(inlines);
+  }
+
+  if (lines.length === 0) {
+    return [];
+  }
+
+  return [{ type: "blockquote", lines }];
+}
+
+function parseListItemInlines(item: ListItem): InlineNode[] | null {
+  const result: InlineNode[] = [];
+  const taskPrefix = item.checked === true ? "✅ " : item.checked === false ? "🔲 " : "";
+  if (taskPrefix) {
+    pushTextNode(result, taskPrefix);
+  }
+
+  for (let index = 0; index < item.children.length; index++) {
+    const child = item.children[index];
+    if (child.type !== "paragraph") {
+      return null;
+    }
+
+    const inlines = parseInlineNodes(child.children);
+    if (!inlines) {
+      return null;
+    }
+
+    if (index > 0) {
+      pushTextNode(result, "\n");
+    }
+
+    appendInlineNodes(result, inlines);
+  }
+
+  return result;
+}
+
+function parseListBlock(node: List): TelegramBlock[] {
+  const items: InlineNode[][] = [];
+
+  for (const item of node.children) {
+    const parsedItem = parseListItemInlines(item);
+    if (!parsedItem) {
+      return createPlainBlock(extractBlockPlainText(node));
+    }
+
+    items.push(parsedItem);
+  }
+
+  if (items.length === 0) {
+    return [];
+  }
+
+  return [{ type: "list", ordered: Boolean(node.ordered), items }];
+}
+
+function parseCodeBlock(node: Code): TelegramBlock[] {
+  return [{ type: "code", language: node.lang ?? undefined, text: node.value }];
+}
+
+function parseTableBlock(node: Table): TelegramBlock[] {
+  const rows = node.children.map((row) => row.children.map(extractTableCellPlainText));
+  if (rows.length === 0) {
+    return [];
+  }
+
+  return [{ type: "table", rows }];
+}
+
+function parseRootContent(node: RootContent): TelegramBlock[] {
+  switch (node.type) {
+    case "paragraph":
+      return parseParagraphBlock(node);
+    case "heading":
+      return parseHeadingBlock(node);
+    case "blockquote":
+      return parseBlockquoteBlock(node);
+    case "list":
+      return parseListBlock(node);
+    case "code":
+      return parseCodeBlock(node);
+    case "table":
+      return parseTableBlock(node);
+    case "thematicBreak":
+      return [{ type: "rule" }];
+    default:
+      return createPlainBlock(extractBlockPlainText(node));
+  }
+}
+
+function mergeAdjacentBlocks(blocks: TelegramBlock[]): TelegramBlock[] {
+  const merged: TelegramBlock[] = [];
+
+  for (const block of blocks) {
+    const previous = merged.at(-1);
+    if (previous?.type === "blockquote" && block.type === "blockquote") {
+      previous.lines.push(...block.lines);
+      continue;
+    }
+
+    merged.push(block);
+  }
+
+  return merged;
+}
+
+export function parseTelegramBlocks(markdown: string): TelegramBlock[] {
+  const normalized = normalizeMarkdownForTelegramBlockParsing(markdown).trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const tree = markdownProcessor.parse(normalized) as Root;
+  return mergeAdjacentBlocks(tree.children.flatMap(parseRootContent));
+}

--- a/src/telegram/render/block-renderer.ts
+++ b/src/telegram/render/block-renderer.ts
@@ -1,0 +1,604 @@
+import type { MessageEntity } from "grammy/types";
+import { renderInlineNodesValidated } from "./inline-renderer.js";
+import type { BlockRenderMode, InlineNode, TelegramBlock, TelegramRenderedBlock } from "./types.js";
+import { validateTelegramEntities } from "./validator.js";
+
+interface RenderedSegment {
+  text: string;
+  fallbackText: string;
+  entities?: MessageEntity[];
+  source: "entities" | "plain";
+}
+
+interface LineSpec {
+  prefix: string;
+  nodes: InlineNode[];
+}
+
+const ENTITY_TYPE_PRIORITY: Record<MessageEntity["type"], number> = {
+  bold: 1,
+  italic: 2,
+  underline: 3,
+  strikethrough: 4,
+  spoiler: 5,
+  code: 6,
+  pre: 7,
+  text_link: 8,
+  mention: 100,
+  hashtag: 101,
+  cashtag: 102,
+  bot_command: 103,
+  url: 104,
+  email: 105,
+  phone_number: 106,
+  blockquote: 107,
+  expandable_blockquote: 108,
+  text_mention: 109,
+  custom_emoji: 110,
+};
+
+function compareEntities(left: MessageEntity, right: MessageEntity): number {
+  if (left.offset !== right.offset) {
+    return left.offset - right.offset;
+  }
+
+  if (left.length !== right.length) {
+    return right.length - left.length;
+  }
+
+  return ENTITY_TYPE_PRIORITY[left.type] - ENTITY_TYPE_PRIORITY[right.type];
+}
+
+function sortEntities(entities: MessageEntity[]): MessageEntity[] {
+  return [...entities].sort(compareEntities);
+}
+
+function pushTextNode(target: InlineNode[], text: string): void {
+  if (!text) {
+    return;
+  }
+
+  const previous = target.at(-1);
+  if (previous?.type === "text") {
+    previous.text += text;
+    return;
+  }
+
+  target.push({ type: "text", text });
+}
+
+function appendInlineNode(target: InlineNode[], node: InlineNode): void {
+  if (node.type === "text") {
+    pushTextNode(target, node.text);
+    return;
+  }
+
+  target.push(node);
+}
+
+function appendInlineNodes(target: InlineNode[], nodes: InlineNode[]): void {
+  for (const node of nodes) {
+    appendInlineNode(target, node);
+  }
+}
+
+function rebaseEntities(entities: MessageEntity[] | undefined, offset: number): MessageEntity[] {
+  if (!entities?.length) {
+    return [];
+  }
+
+  return entities.map((entity) => ({
+    ...entity,
+    offset: entity.offset + offset,
+  }));
+}
+
+function extractInlinePlainText(nodes: InlineNode[]): string {
+  let result = "";
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        result += node.text;
+        break;
+      case "bold":
+      case "italic":
+      case "strike":
+      case "underline":
+      case "spoiler":
+        result += extractInlinePlainText(node.children);
+        break;
+      case "code":
+        result += node.text;
+        break;
+      case "link":
+        result += extractInlinePlainText(node.text);
+        break;
+      default: {
+        const exhaustiveCheck: never = node;
+        throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+      }
+    }
+  }
+
+  return result;
+}
+
+function containsCodeNode(nodes: InlineNode[]): boolean {
+  for (const node of nodes) {
+    switch (node.type) {
+      case "code":
+        return true;
+      case "bold":
+      case "italic":
+      case "strike":
+      case "underline":
+      case "spoiler":
+        if (containsCodeNode(node.children)) {
+          return true;
+        }
+        break;
+      case "link":
+        if (containsCodeNode(node.text)) {
+          return true;
+        }
+        break;
+      case "text":
+        break;
+      default: {
+        const exhaustiveCheck: never = node;
+        throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+      }
+    }
+  }
+
+  return false;
+}
+
+function simplifyInlineNodes(nodes: InlineNode[], insideLink = false): InlineNode[] {
+  const result: InlineNode[] = [];
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        pushTextNode(result, node.text);
+        break;
+      case "code":
+        result.push(node);
+        break;
+      case "link": {
+        const simplifiedChildren = simplifyInlineNodes(node.text, true);
+        if (insideLink) {
+          appendInlineNodes(result, simplifiedChildren);
+          break;
+        }
+
+        if (simplifiedChildren.length > 0) {
+          result.push({ type: "link", text: simplifiedChildren, url: node.url });
+        }
+        break;
+      }
+      case "bold":
+      case "italic":
+      case "strike":
+      case "underline":
+      case "spoiler": {
+        const simplifiedChildren = simplifyInlineNodes(node.children, insideLink);
+        if (simplifiedChildren.length === 0) {
+          break;
+        }
+
+        if (containsCodeNode(simplifiedChildren)) {
+          appendInlineNodes(result, simplifiedChildren);
+          break;
+        }
+
+        result.push({ ...node, children: simplifiedChildren });
+        break;
+      }
+      default: {
+        const exhaustiveCheck: never = node;
+        throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+      }
+    }
+  }
+
+  return result;
+}
+
+function wrapInlineNode(node: InlineNode, children: InlineNode[]): InlineNode | null {
+  if (children.length === 0) {
+    return null;
+  }
+
+  switch (node.type) {
+    case "bold":
+    case "italic":
+    case "strike":
+    case "underline":
+    case "spoiler":
+      return { ...node, children };
+    case "link":
+      return { ...node, text: children };
+    case "text":
+      return { type: "text", text: extractInlinePlainText(children) };
+    case "code":
+      return { type: "code", text: extractInlinePlainText(children) };
+    default: {
+      const exhaustiveCheck: never = node;
+      throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+}
+
+function splitInlineNodesByNewline(nodes: InlineNode[]): InlineNode[][] {
+  const lines: InlineNode[][] = [[]];
+
+  const pushLineBreak = (): void => {
+    lines.push([]);
+  };
+
+  const appendNodeWithLineSplit = (node: InlineNode): void => {
+    switch (node.type) {
+      case "text": {
+        const parts = node.text.split("\n");
+        for (let index = 0; index < parts.length; index++) {
+          pushTextNode(lines[lines.length - 1], parts[index]);
+          if (index < parts.length - 1) {
+            pushLineBreak();
+          }
+        }
+        break;
+      }
+      case "code": {
+        const parts = node.text.split("\n");
+        for (let index = 0; index < parts.length; index++) {
+          if (parts[index]) {
+            appendInlineNode(lines[lines.length - 1], { type: "code", text: parts[index] });
+          }
+          if (index < parts.length - 1) {
+            pushLineBreak();
+          }
+        }
+        break;
+      }
+      case "bold":
+      case "italic":
+      case "strike":
+      case "underline":
+      case "spoiler":
+      case "link": {
+        const childLines = splitInlineNodesByNewline(
+          node.type === "link" ? node.text : node.children,
+        );
+        for (let index = 0; index < childLines.length; index++) {
+          if (index > 0) {
+            pushLineBreak();
+          }
+
+          const wrapped = wrapInlineNode(node, childLines[index]);
+          if (wrapped) {
+            appendInlineNode(lines[lines.length - 1], wrapped);
+          }
+        }
+        break;
+      }
+      default: {
+        const exhaustiveCheck: never = node;
+        throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+      }
+    }
+  };
+
+  for (const node of nodes) {
+    appendNodeWithLineSplit(node);
+  }
+
+  return lines;
+}
+
+function applyWholeLineBold(
+  text: string,
+  entities: MessageEntity[] | undefined,
+): MessageEntity[] | undefined {
+  if (!text) {
+    return entities;
+  }
+
+  const nextEntities = sortEntities([
+    ...(entities ?? []),
+    { type: "bold", offset: 0, length: text.length },
+  ]);
+  const validation = validateTelegramEntities(text, nextEntities);
+  if (!validation.ok) {
+    throw new Error(validation.issues.map((issue) => issue.message).join("; "));
+  }
+
+  return nextEntities;
+}
+
+function createRenderedBlock(
+  blockType: TelegramBlock["type"],
+  mode: BlockRenderMode,
+  text: string,
+  fallbackText: string,
+  entities?: MessageEntity[],
+): TelegramRenderedBlock {
+  const normalizedEntities = entities?.length ? sortEntities(entities) : undefined;
+  if (normalizedEntities) {
+    const validation = validateTelegramEntities(text, normalizedEntities);
+    if (!validation.ok) {
+      throw new Error(validation.issues.map((issue) => issue.message).join("; "));
+    }
+  }
+
+  return {
+    blockType,
+    mode,
+    text,
+    entities: normalizedEntities,
+    fallbackText,
+    source: normalizedEntities?.length ? "entities" : "plain",
+  };
+}
+
+function renderInlineSegment(
+  nodes: InlineNode[],
+  simplify: boolean,
+  boldWholeLine = false,
+): RenderedSegment {
+  const effectiveNodes = simplify ? simplifyInlineNodes(nodes) : nodes;
+  const rendered = renderInlineNodesValidated(effectiveNodes);
+  const entities = boldWholeLine
+    ? applyWholeLineBold(rendered.text, rendered.entities)
+    : rendered.entities;
+
+  return {
+    text: rendered.text,
+    fallbackText: extractInlinePlainText(effectiveNodes),
+    entities,
+    source: entities?.length ? "entities" : "plain",
+  };
+}
+
+function renderInlineSegmentWithLocalFallback(
+  nodes: InlineNode[],
+  boldWholeLine = false,
+): RenderedSegment {
+  try {
+    return renderInlineSegment(nodes, false, boldWholeLine);
+  } catch {
+    try {
+      return renderInlineSegment(nodes, true, boldWholeLine);
+    } catch {
+      const text = extractInlinePlainText(nodes);
+      try {
+        const entities = boldWholeLine ? applyWholeLineBold(text, undefined) : undefined;
+        return {
+          text,
+          fallbackText: text,
+          entities,
+          source: entities?.length ? "entities" : "plain",
+        };
+      } catch {
+        return {
+          text,
+          fallbackText: text,
+          source: "plain",
+        };
+      }
+    }
+  }
+}
+
+function renderLineSpecs(
+  blockType: TelegramBlock["type"],
+  mode: Extract<BlockRenderMode, "full" | "simplified" | "line-by-line">,
+  lineSpecs: LineSpec[],
+  boldWholeLine = false,
+): TelegramRenderedBlock {
+  const textParts: string[] = [];
+  const fallbackParts: string[] = [];
+  const entities: MessageEntity[] = [];
+
+  let currentOffset = 0;
+  for (let index = 0; index < lineSpecs.length; index++) {
+    const lineSpec = lineSpecs[index];
+    const renderedLine =
+      mode === "line-by-line"
+        ? renderInlineSegmentWithLocalFallback(lineSpec.nodes, boldWholeLine)
+        : renderInlineSegment(lineSpec.nodes, mode === "simplified", boldWholeLine);
+
+    const lineText = `${lineSpec.prefix}${renderedLine.text}`;
+    const lineFallbackText = `${lineSpec.prefix}${renderedLine.fallbackText}`;
+
+    if (index > 0) {
+      currentOffset += 1;
+    }
+
+    textParts.push(lineText);
+    fallbackParts.push(lineFallbackText);
+    entities.push(...rebaseEntities(renderedLine.entities, currentOffset + lineSpec.prefix.length));
+    currentOffset += lineText.length;
+  }
+
+  return createRenderedBlock(
+    blockType,
+    mode,
+    textParts.join("\n"),
+    fallbackParts.join("\n"),
+    entities,
+  );
+}
+
+function renderPreformattedBlock(
+  blockType: TelegramBlock["type"],
+  mode: Extract<BlockRenderMode, "full" | "simplified">,
+  text: string,
+  language?: string,
+): TelegramRenderedBlock {
+  const entities = text
+    ? [
+        {
+          type: "pre",
+          offset: 0,
+          length: text.length,
+          ...(language ? { language } : {}),
+        } as MessageEntity,
+      ]
+    : undefined;
+
+  return createRenderedBlock(blockType, mode, text, text, entities);
+}
+
+function buildParagraphLineSpecs(inlines: InlineNode[]): LineSpec[] {
+  return splitInlineNodesByNewline(inlines).map((nodes) => ({ prefix: "", nodes }));
+}
+
+function buildBlockquoteLineSpecs(lines: InlineNode[][]): LineSpec[] {
+  return lines.flatMap((lineNodes) =>
+    splitInlineNodesByNewline(lineNodes).map((nodes) => ({
+      prefix: "> ",
+      nodes,
+    })),
+  );
+}
+
+function buildListLineSpecs(ordered: boolean, items: InlineNode[][]): LineSpec[] {
+  return items.flatMap((itemNodes, index) => {
+    const marker = ordered ? `${index + 1}. ` : "- ";
+    const continuationPrefix = " ".repeat(marker.length);
+
+    return splitInlineNodesByNewline(itemNodes).map((nodes, lineIndex) => ({
+      prefix: lineIndex === 0 ? marker : continuationPrefix,
+      nodes,
+    }));
+  });
+}
+
+function buildAlignedTableText(rows: string[][]): string {
+  const columnCount = Math.max(...rows.map((row) => row.length));
+  const normalizedRows = rows.map((row) =>
+    Array.from({ length: columnCount }, (_, index) => row[index] ?? ""),
+  );
+  const columnWidths = Array.from({ length: columnCount }, (_, index) =>
+    Math.max(...normalizedRows.map((row) => row[index].length)),
+  );
+
+  const formatRow = (row: string[]): string =>
+    row.map((cell, index) => cell.padEnd(columnWidths[index], " ")).join(" | ");
+
+  const divider = columnWidths.map((width) => "-".repeat(width)).join("-|-");
+  const formattedRows = normalizedRows.map(formatRow);
+
+  if (formattedRows.length <= 1) {
+    return formattedRows.join("\n");
+  }
+
+  return [formattedRows[0], divider, ...formattedRows.slice(1)].join("\n");
+}
+
+export function renderTelegramBlock(
+  block: TelegramBlock,
+  mode: BlockRenderMode = "full",
+): TelegramRenderedBlock {
+  switch (block.type) {
+    case "paragraph":
+      if (mode === "plain") {
+        const text = extractInlinePlainText(block.inlines);
+        return createRenderedBlock(block.type, mode, text, text);
+      }
+
+      if (mode === "line-by-line") {
+        return renderLineSpecs(block.type, mode, buildParagraphLineSpecs(block.inlines));
+      }
+
+      {
+        const segment = renderInlineSegment(block.inlines, mode === "simplified");
+        return createRenderedBlock(
+          block.type,
+          mode,
+          segment.text,
+          segment.fallbackText,
+          segment.entities,
+        );
+      }
+    case "heading":
+      if (mode === "plain") {
+        const text = extractInlinePlainText(block.inlines);
+        return createRenderedBlock(block.type, mode, text, text);
+      }
+
+      if (mode === "line-by-line") {
+        return renderLineSpecs(block.type, mode, buildParagraphLineSpecs(block.inlines), true);
+      }
+
+      {
+        const segment = renderInlineSegment(block.inlines, mode === "simplified", true);
+        return createRenderedBlock(
+          block.type,
+          mode,
+          segment.text,
+          segment.fallbackText,
+          segment.entities,
+        );
+      }
+    case "blockquote":
+      if (mode === "plain") {
+        const text = buildBlockquoteLineSpecs(block.lines)
+          .map((line) => `${line.prefix}${extractInlinePlainText(line.nodes)}`)
+          .join("\n");
+        return createRenderedBlock(block.type, mode, text, text);
+      }
+
+      return renderLineSpecs(
+        block.type,
+        mode === "line-by-line" ? mode : mode,
+        buildBlockquoteLineSpecs(
+          mode === "simplified"
+            ? block.lines.map((line) => simplifyInlineNodes(line))
+            : block.lines,
+        ),
+      );
+    case "list":
+      if (mode === "plain") {
+        const text = buildListLineSpecs(block.ordered, block.items)
+          .map((line) => `${line.prefix}${extractInlinePlainText(line.nodes)}`)
+          .join("\n");
+        return createRenderedBlock(block.type, mode, text, text);
+      }
+
+      return renderLineSpecs(
+        block.type,
+        mode === "line-by-line" ? mode : mode,
+        buildListLineSpecs(
+          block.ordered,
+          mode === "simplified"
+            ? block.items.map((item) => simplifyInlineNodes(item))
+            : block.items,
+        ),
+      );
+    case "code":
+      if (mode === "plain" || mode === "line-by-line") {
+        return createRenderedBlock(block.type, mode, block.text, block.text);
+      }
+
+      return renderPreformattedBlock(block.type, mode, block.text, block.language);
+    case "table": {
+      const text = buildAlignedTableText(block.rows);
+      if (mode === "plain" || mode === "line-by-line") {
+        return createRenderedBlock(block.type, mode, text, text);
+      }
+
+      return renderPreformattedBlock(block.type, mode, text);
+    }
+    case "rule":
+      return createRenderedBlock(block.type, mode, "──────────", "──────────");
+    case "plain":
+      return createRenderedBlock(block.type, mode, block.text, block.text);
+    default: {
+      const exhaustiveCheck: never = block;
+      throw new Error(`Unsupported Telegram block: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+}

--- a/src/telegram/render/chunker.ts
+++ b/src/telegram/render/chunker.ts
@@ -1,5 +1,6 @@
 import type { MessageEntity } from "grammy/types";
 import type { TelegramRenderedBlock, TelegramRenderedPart } from "./types.js";
+import { logger } from "../../utils/logger.js";
 import { validateTelegramEntities } from "./validator.js";
 
 const DEFAULT_MAX_PART_LENGTH = 4096;
@@ -233,6 +234,13 @@ function splitPreformattedBlock(
     start = end;
   }
 
+  logger.debug("[TelegramRender] Preformatted block chunked", {
+    blockType: block.blockType,
+    textLength: block.text.length,
+    maxLength,
+    partCount: parts.length,
+  });
+
   return parts;
 }
 
@@ -257,6 +265,16 @@ function splitRichBlock(
     const text = block.text.slice(start, end);
     parts.push(createRenderedPart(text, text, entities));
     start = end;
+  }
+
+  if (parts.length > 1) {
+    logger.debug("[TelegramRender] Rich block chunked", {
+      blockType: block.blockType,
+      textLength: block.text.length,
+      entityCount: block.entities.length,
+      maxLength,
+      partCount: parts.length,
+    });
   }
 
   return parts;
@@ -288,6 +306,13 @@ function splitBlockToParts(
     if (richParts) {
       return richParts;
     }
+
+    logger.debug("[TelegramRender] Rich block downgraded to plain during chunking", {
+      blockType: block.blockType,
+      textLength: block.text.length,
+      entityCount: block.entities.length,
+      maxLength,
+    });
   }
 
   return splitPlainText(block.fallbackText, maxLength).map((text) =>

--- a/src/telegram/render/chunker.ts
+++ b/src/telegram/render/chunker.ts
@@ -1,0 +1,373 @@
+import type { MessageEntity } from "grammy/types";
+import type { TelegramRenderedBlock, TelegramRenderedPart } from "./types.js";
+import { validateTelegramEntities } from "./validator.js";
+
+const DEFAULT_MAX_PART_LENGTH = 4096;
+const DEFAULT_BLOCK_SEPARATOR = "\n\n";
+
+export interface TelegramChunkerOptions {
+  maxPartLength?: number;
+  blockSeparator?: string;
+}
+
+interface TelegramRenderedPartBuilder {
+  text: string;
+  fallbackText: string;
+  entities: MessageEntity[];
+}
+
+const ENTITY_TYPE_PRIORITY: Record<MessageEntity["type"], number> = {
+  bold: 1,
+  italic: 2,
+  underline: 3,
+  strikethrough: 4,
+  spoiler: 5,
+  code: 6,
+  pre: 7,
+  text_link: 8,
+  mention: 100,
+  hashtag: 101,
+  cashtag: 102,
+  bot_command: 103,
+  url: 104,
+  email: 105,
+  phone_number: 106,
+  blockquote: 107,
+  expandable_blockquote: 108,
+  text_mention: 109,
+  custom_emoji: 110,
+};
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function isSafeUtf16Boundary(text: string, index: number): boolean {
+  if (index <= 0 || index >= text.length) {
+    return true;
+  }
+
+  return !(isHighSurrogate(text.charCodeAt(index - 1)) && isLowSurrogate(text.charCodeAt(index)));
+}
+
+function isEntityBoundary(entities: MessageEntity[] | undefined, index: number): boolean {
+  if (!entities?.length) {
+    return true;
+  }
+
+  return !entities.some((entity) => entity.offset < index && index < entity.offset + entity.length);
+}
+
+function compareEntities(left: MessageEntity, right: MessageEntity): number {
+  if (left.offset !== right.offset) {
+    return left.offset - right.offset;
+  }
+
+  if (left.length !== right.length) {
+    return right.length - left.length;
+  }
+
+  return ENTITY_TYPE_PRIORITY[left.type] - ENTITY_TYPE_PRIORITY[right.type];
+}
+
+function sortEntities(entities: MessageEntity[]): MessageEntity[] {
+  return [...entities].sort(compareEntities);
+}
+
+function normalizeOptions(options?: TelegramChunkerOptions): Required<TelegramChunkerOptions> {
+  return {
+    maxPartLength: Math.max(2, Math.floor(options?.maxPartLength ?? DEFAULT_MAX_PART_LENGTH)),
+    blockSeparator: options?.blockSeparator ?? DEFAULT_BLOCK_SEPARATOR,
+  };
+}
+
+function createRenderedPart(
+  text: string,
+  fallbackText: string,
+  entities?: MessageEntity[],
+): TelegramRenderedPart {
+  const normalizedEntities = entities?.length ? sortEntities(entities) : undefined;
+  if (normalizedEntities) {
+    const validation = validateTelegramEntities(text, normalizedEntities);
+    if (!validation.ok) {
+      throw new Error(validation.issues.map((issue) => issue.message).join("; "));
+    }
+  }
+
+  return {
+    text,
+    entities: normalizedEntities,
+    fallbackText,
+    source: normalizedEntities?.length ? "entities" : "plain",
+  };
+}
+
+function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
+  return {
+    text: part.text,
+    entities: part.entities ? [...part.entities] : undefined,
+    fallbackText: part.fallbackText,
+    source: part.source,
+  };
+}
+
+function isWhitespaceBoundary(text: string, index: number): boolean {
+  return index > 0 && /\s/.test(text[index - 1]);
+}
+
+function findSplitBoundary(
+  text: string,
+  start: number,
+  maxLength: number,
+  entities?: MessageEntity[],
+): number | null {
+  const hardEnd = Math.min(text.length, start + maxLength);
+  if (hardEnd >= text.length) {
+    return text.length;
+  }
+
+  let whitespaceBoundary: number | null = null;
+  let fallbackBoundary: number | null = null;
+
+  for (let index = hardEnd; index > start; index--) {
+    if (!isSafeUtf16Boundary(text, index) || !isEntityBoundary(entities, index)) {
+      continue;
+    }
+
+    if (text[index - 1] === "\n") {
+      return index;
+    }
+
+    if (whitespaceBoundary === null && isWhitespaceBoundary(text, index)) {
+      whitespaceBoundary = index;
+    }
+
+    if (fallbackBoundary === null) {
+      fallbackBoundary = index;
+    }
+  }
+
+  return whitespaceBoundary ?? fallbackBoundary;
+}
+
+function rebaseSliceEntities(
+  entities: MessageEntity[] | undefined,
+  start: number,
+  end: number,
+): MessageEntity[] {
+  if (!entities?.length) {
+    return [];
+  }
+
+  return entities
+    .filter((entity) => entity.offset >= start && entity.offset + entity.length <= end)
+    .map((entity) => ({
+      ...entity,
+      offset: entity.offset - start,
+    }));
+}
+
+function splitPlainText(text: string, maxLength: number): string[] {
+  if (!text) {
+    return [];
+  }
+
+  const chunks: string[] = [];
+  let start = 0;
+
+  while (start < text.length) {
+    const end = findSplitBoundary(text, start, maxLength);
+    if (!end || end <= start) {
+      throw new Error("Unable to split plain text on a safe UTF-16 boundary");
+    }
+
+    chunks.push(text.slice(start, end));
+    start = end;
+  }
+
+  return chunks;
+}
+
+function isFullRangePreEntity(block: TelegramRenderedBlock): MessageEntity | null {
+  if (block.entities?.length !== 1) {
+    return null;
+  }
+
+  const [entity] = block.entities;
+  if (entity.type !== "pre" || entity.offset !== 0 || entity.length !== block.text.length) {
+    return null;
+  }
+
+  return entity;
+}
+
+function splitPreformattedBlock(
+  block: TelegramRenderedBlock,
+  maxLength: number,
+  preEntity: Extract<MessageEntity, { type: "pre" }>,
+): TelegramRenderedPart[] {
+  const parts: TelegramRenderedPart[] = [];
+  let start = 0;
+
+  while (start < block.text.length) {
+    const end = findSplitBoundary(block.text, start, maxLength);
+    if (!end || end <= start) {
+      throw new Error(`Unable to split preformatted ${block.blockType} block`);
+    }
+
+    const text = block.text.slice(start, end);
+    parts.push(
+      createRenderedPart(text, text, [
+        {
+          type: "pre",
+          offset: 0,
+          length: text.length,
+          ...(preEntity.language ? { language: preEntity.language } : {}),
+        },
+      ]),
+    );
+    start = end;
+  }
+
+  return parts;
+}
+
+function splitRichBlock(
+  block: TelegramRenderedBlock,
+  maxLength: number,
+): TelegramRenderedPart[] | null {
+  if (!block.entities?.length) {
+    return null;
+  }
+
+  const parts: TelegramRenderedPart[] = [];
+  let start = 0;
+
+  while (start < block.text.length) {
+    const end = findSplitBoundary(block.text, start, maxLength, block.entities);
+    if (!end || end <= start) {
+      return null;
+    }
+
+    const entities = rebaseSliceEntities(block.entities, start, end);
+    const text = block.text.slice(start, end);
+    parts.push(createRenderedPart(text, text, entities));
+    start = end;
+  }
+
+  return parts;
+}
+
+function splitBlockToParts(
+  block: TelegramRenderedBlock,
+  maxLength: number,
+): TelegramRenderedPart[] {
+  if (!block.text) {
+    return [];
+  }
+
+  if (block.text.length <= maxLength) {
+    return [createRenderedPart(block.text, block.fallbackText, block.entities)];
+  }
+
+  const preEntity = isFullRangePreEntity(block);
+  if (preEntity) {
+    return splitPreformattedBlock(
+      block,
+      maxLength,
+      preEntity as Extract<MessageEntity, { type: "pre" }>,
+    );
+  }
+
+  if (block.entities?.length) {
+    const richParts = splitRichBlock(block, maxLength);
+    if (richParts) {
+      return richParts;
+    }
+  }
+
+  return splitPlainText(block.fallbackText, maxLength).map((text) =>
+    createRenderedPart(text, text),
+  );
+}
+
+function createBuilder(): TelegramRenderedPartBuilder {
+  return {
+    text: "",
+    fallbackText: "",
+    entities: [],
+  };
+}
+
+function appendToBuilder(
+  builder: TelegramRenderedPartBuilder,
+  chunk: TelegramRenderedPart,
+  prefix: string,
+): void {
+  const offset = builder.text.length + prefix.length;
+
+  builder.text += `${prefix}${chunk.text}`;
+  builder.fallbackText += `${prefix}${chunk.fallbackText}`;
+  if (chunk.entities?.length) {
+    builder.entities.push(
+      ...chunk.entities.map((entity) => ({
+        ...entity,
+        offset: entity.offset + offset,
+      })),
+    );
+  }
+}
+
+function finalizeBuilder(builder: TelegramRenderedPartBuilder | null): TelegramRenderedPart | null {
+  if (!builder || !builder.text) {
+    return null;
+  }
+
+  return createRenderedPart(builder.text, builder.fallbackText, builder.entities);
+}
+
+export function chunkTelegramRenderedBlocks(
+  blocks: TelegramRenderedBlock[],
+  options?: TelegramChunkerOptions,
+): TelegramRenderedPart[] {
+  const { maxPartLength, blockSeparator } = normalizeOptions(options);
+  const blockGroups = blocks
+    .map((block) => splitBlockToParts(block, maxPartLength))
+    .filter((group) => group.length > 0);
+  const parts: TelegramRenderedPart[] = [];
+  let current = createBuilder();
+
+  for (const blockParts of blockGroups) {
+    for (let index = 0; index < blockParts.length; index++) {
+      const chunk = blockParts[index];
+      const needsSeparator = index === 0 && current.text.length > 0;
+      const prefix = needsSeparator ? blockSeparator : "";
+
+      if (
+        current.text.length > 0 &&
+        current.text.length + prefix.length + chunk.text.length > maxPartLength
+      ) {
+        const finalized = finalizeBuilder(current);
+        if (finalized) {
+          parts.push(finalized);
+        }
+        current = createBuilder();
+        appendToBuilder(current, chunk, "");
+        continue;
+      }
+
+      appendToBuilder(current, chunk, prefix);
+    }
+  }
+
+  const finalized = finalizeBuilder(current);
+  if (finalized) {
+    parts.push(finalized);
+  }
+
+  return parts.map(clonePart);
+}

--- a/src/telegram/render/inline-renderer.ts
+++ b/src/telegram/render/inline-renderer.ts
@@ -1,0 +1,155 @@
+import type { MessageEntity } from "grammy/types";
+import type { InlineNode } from "./types.js";
+import { validateTelegramEntities } from "./validator.js";
+
+export interface InlineRenderResult {
+  text: string;
+  entities: MessageEntity[];
+}
+
+const ENTITY_TYPE_PRIORITY: Record<MessageEntity["type"], number> = {
+  bold: 1,
+  italic: 2,
+  underline: 3,
+  strikethrough: 4,
+  spoiler: 5,
+  code: 6,
+  text_link: 7,
+  mention: 100,
+  hashtag: 101,
+  cashtag: 102,
+  bot_command: 103,
+  url: 104,
+  email: 105,
+  phone_number: 106,
+  blockquote: 107,
+  expandable_blockquote: 108,
+  pre: 109,
+  text_mention: 110,
+  custom_emoji: 111,
+};
+
+interface InlineRenderState {
+  text: string;
+  entities: MessageEntity[];
+}
+
+function appendText(state: InlineRenderState, text: string): void {
+  if (!text) {
+    return;
+  }
+
+  state.text += text;
+}
+
+function pushEntity(state: InlineRenderState, entity: MessageEntity): void {
+  if (entity.length <= 0) {
+    return;
+  }
+
+  state.entities.push(entity);
+}
+
+function renderIntoState(state: InlineRenderState, nodes: InlineNode[]): void {
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        appendText(state, node.text);
+        break;
+      case "bold": {
+        const offset = state.text.length;
+        renderIntoState(state, node.children);
+        pushEntity(state, { type: "bold", offset, length: state.text.length - offset });
+        break;
+      }
+      case "italic": {
+        const offset = state.text.length;
+        renderIntoState(state, node.children);
+        pushEntity(state, { type: "italic", offset, length: state.text.length - offset });
+        break;
+      }
+      case "strike": {
+        const offset = state.text.length;
+        renderIntoState(state, node.children);
+        pushEntity(state, {
+          type: "strikethrough",
+          offset,
+          length: state.text.length - offset,
+        });
+        break;
+      }
+      case "underline": {
+        const offset = state.text.length;
+        renderIntoState(state, node.children);
+        pushEntity(state, { type: "underline", offset, length: state.text.length - offset });
+        break;
+      }
+      case "spoiler": {
+        const offset = state.text.length;
+        renderIntoState(state, node.children);
+        pushEntity(state, { type: "spoiler", offset, length: state.text.length - offset });
+        break;
+      }
+      case "code": {
+        const offset = state.text.length;
+        appendText(state, node.text);
+        pushEntity(state, { type: "code", offset, length: state.text.length - offset });
+        break;
+      }
+      case "link": {
+        const offset = state.text.length;
+        renderIntoState(state, node.text);
+        pushEntity(state, {
+          type: "text_link",
+          offset,
+          length: state.text.length - offset,
+          url: node.url,
+        });
+        break;
+      }
+      default: {
+        const exhaustiveCheck: never = node;
+        throw new Error(`Unsupported inline node: ${JSON.stringify(exhaustiveCheck)}`);
+      }
+    }
+  }
+}
+
+function compareEntities(left: MessageEntity, right: MessageEntity): number {
+  if (left.offset !== right.offset) {
+    return left.offset - right.offset;
+  }
+
+  if (left.length !== right.length) {
+    return right.length - left.length;
+  }
+
+  return ENTITY_TYPE_PRIORITY[left.type] - ENTITY_TYPE_PRIORITY[right.type];
+}
+
+export function renderInlineNodes(nodes: InlineNode[]): InlineRenderResult {
+  const state: InlineRenderState = {
+    text: "",
+    entities: [],
+  };
+
+  renderIntoState(state, nodes);
+  state.entities.sort(compareEntities);
+
+  return {
+    text: state.text,
+    entities: state.entities,
+  };
+}
+
+export function renderInlineNodesValidated(nodes: InlineNode[]): InlineRenderResult {
+  const rendered = renderInlineNodes(nodes);
+  const validation = validateTelegramEntities(rendered.text, rendered.entities);
+
+  if (!validation.ok) {
+    const summary = validation.issues.map((issue) => issue.message).join("; ");
+    throw new Error(`Invalid Telegram inline entities: ${summary}`);
+  }
+
+  return rendered;
+}

--- a/src/telegram/render/markdown-normalizer.ts
+++ b/src/telegram/render/markdown-normalizer.ts
@@ -1,3 +1,7 @@
+interface NormalizeMarkdownOptions {
+  preserveBlockMarkup: boolean;
+}
+
 function isCodeFenceLine(line: string): boolean {
   return line.trimStart().startsWith("```");
 }
@@ -34,7 +38,7 @@ function normalizeChecklistLine(line: string): string | null {
   return `${match[1]}${marker} ${match[3]}`;
 }
 
-export function normalizeMarkdownForTelegramRendering(text: string): string {
+function normalizeMarkdown(text: string, options: NormalizeMarkdownOptions): string {
   const lines = text.split("\n");
   const output: string[] = [];
   let inCodeFence = false;
@@ -62,13 +66,13 @@ export function normalizeMarkdownForTelegramRendering(text: string): string {
     }
 
     if (isHeadingLine(line)) {
-      output.push(normalizeHeadingLine(line));
+      output.push(options.preserveBlockMarkup ? line : normalizeHeadingLine(line));
       inQuote = false;
       continue;
     }
 
     if (isHorizontalRuleLine(line)) {
-      output.push("──────────");
+      output.push(options.preserveBlockMarkup ? line : "──────────");
       inQuote = false;
       continue;
     }
@@ -79,14 +83,20 @@ export function normalizeMarkdownForTelegramRendering(text: string): string {
       const quoteContent = trimmedLeft.replace(/^>\s?/, "");
       const normalizedChecklistInQuote = normalizeChecklistLine(quoteContent);
       output.push(
-        normalizedChecklistInQuote ? `> ${normalizedChecklistInQuote.trimStart()}` : trimmedLeft,
+        normalizedChecklistInQuote && !options.preserveBlockMarkup
+          ? `> ${normalizedChecklistInQuote.trimStart()}`
+          : `> ${quoteContent.trimStart()}`,
       );
       continue;
     }
 
     const normalizedChecklist = normalizeChecklistLine(line);
     if (normalizedChecklist) {
-      output.push(inQuote ? `> ${normalizedChecklist.trimStart()}` : normalizedChecklist);
+      if (options.preserveBlockMarkup) {
+        output.push(inQuote ? `> ${trimmedLeft}` : line);
+      } else {
+        output.push(inQuote ? `> ${normalizedChecklist.trimStart()}` : normalizedChecklist);
+      }
       continue;
     }
 
@@ -99,4 +109,12 @@ export function normalizeMarkdownForTelegramRendering(text: string): string {
   }
 
   return output.join("\n");
+}
+
+export function normalizeMarkdownForTelegramRendering(text: string): string {
+  return normalizeMarkdown(text, { preserveBlockMarkup: false });
+}
+
+export function normalizeMarkdownForTelegramBlockParsing(text: string): string {
+  return normalizeMarkdown(text, { preserveBlockMarkup: true });
 }

--- a/src/telegram/render/markdown-normalizer.ts
+++ b/src/telegram/render/markdown-normalizer.ts
@@ -1,0 +1,102 @@
+function isCodeFenceLine(line: string): boolean {
+  return line.trimStart().startsWith("```");
+}
+
+function isHorizontalRuleLine(line: string): boolean {
+  const normalized = line.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  return /^([-*_])(?:\s*\1){2,}$/.test(normalized);
+}
+
+function isHeadingLine(line: string): boolean {
+  return /^\s{0,3}#{1,6}\s+\S/.test(line);
+}
+
+function normalizeHeadingLine(line: string): string {
+  const match = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*$/);
+  if (!match) {
+    return line;
+  }
+
+  return `**${match[1]}**`;
+}
+
+function normalizeChecklistLine(line: string): string | null {
+  const match = line.match(/^(\s*)(?:[-+*]|\d+\.)\s+\[( |x|X)\]\s+(.*)$/);
+  if (!match) {
+    return null;
+  }
+
+  const marker = match[2].toLowerCase() === "x" ? "✅" : "🔲";
+  return `${match[1]}${marker} ${match[3]}`;
+}
+
+export function normalizeMarkdownForTelegramRendering(text: string): string {
+  const lines = text.split("\n");
+  const output: string[] = [];
+  let inCodeFence = false;
+  let inQuote = false;
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+
+    if (isCodeFenceLine(line)) {
+      inCodeFence = !inCodeFence;
+      inQuote = false;
+      output.push(line);
+      continue;
+    }
+
+    if (inCodeFence) {
+      output.push(line);
+      continue;
+    }
+
+    if (!line.trim()) {
+      inQuote = false;
+      output.push(line);
+      continue;
+    }
+
+    if (isHeadingLine(line)) {
+      output.push(normalizeHeadingLine(line));
+      inQuote = false;
+      continue;
+    }
+
+    if (isHorizontalRuleLine(line)) {
+      output.push("──────────");
+      inQuote = false;
+      continue;
+    }
+
+    const trimmedLeft = line.trimStart();
+    if (trimmedLeft.startsWith(">")) {
+      inQuote = true;
+      const quoteContent = trimmedLeft.replace(/^>\s?/, "");
+      const normalizedChecklistInQuote = normalizeChecklistLine(quoteContent);
+      output.push(
+        normalizedChecklistInQuote ? `> ${normalizedChecklistInQuote.trimStart()}` : trimmedLeft,
+      );
+      continue;
+    }
+
+    const normalizedChecklist = normalizeChecklistLine(line);
+    if (normalizedChecklist) {
+      output.push(inQuote ? `> ${normalizedChecklist.trimStart()}` : normalizedChecklist);
+      continue;
+    }
+
+    if (inQuote) {
+      output.push(`> ${trimmedLeft}`);
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  return output.join("\n");
+}

--- a/src/telegram/render/pipeline.ts
+++ b/src/telegram/render/pipeline.ts
@@ -1,0 +1,15 @@
+import { parseTelegramBlocks } from "./block-parser.js";
+import { renderTelegramBlockWithFallback } from "./block-fallback.js";
+import { chunkTelegramRenderedBlocks, type TelegramChunkerOptions } from "./chunker.js";
+import type { TelegramRenderedBlock, TelegramRenderedPart } from "./types.js";
+
+export function renderTelegramBlocks(markdown: string): TelegramRenderedBlock[] {
+  return parseTelegramBlocks(markdown).map(renderTelegramBlockWithFallback);
+}
+
+export function renderTelegramParts(
+  markdown: string,
+  options?: TelegramChunkerOptions,
+): TelegramRenderedPart[] {
+  return chunkTelegramRenderedBlocks(renderTelegramBlocks(markdown), options);
+}

--- a/src/telegram/render/types.ts
+++ b/src/telegram/render/types.ts
@@ -1,6 +1,17 @@
 import type { MessageEntity } from "grammy/types";
 
+export type BlockRenderMode = "full" | "simplified" | "line-by-line" | "plain";
+
 export interface TelegramRenderedPart {
+  text: string;
+  entities?: MessageEntity[];
+  fallbackText: string;
+  source: "entities" | "plain";
+}
+
+export interface TelegramRenderedBlock {
+  blockType: TelegramBlock["type"];
+  mode: BlockRenderMode;
   text: string;
   entities?: MessageEntity[];
   fallbackText: string;

--- a/src/telegram/render/types.ts
+++ b/src/telegram/render/types.ts
@@ -1,0 +1,28 @@
+import type { MessageEntity } from "grammy/types";
+
+export interface TelegramRenderedPart {
+  text: string;
+  entities?: MessageEntity[];
+  fallbackText: string;
+  source: "entities" | "plain";
+}
+
+export type TelegramBlock =
+  | { type: "paragraph"; inlines: InlineNode[] }
+  | { type: "heading"; level: number; inlines: InlineNode[] }
+  | { type: "blockquote"; lines: InlineNode[][] }
+  | { type: "list"; ordered: boolean; items: InlineNode[][] }
+  | { type: "code"; language?: string; text: string }
+  | { type: "table"; rows: string[][] }
+  | { type: "rule" }
+  | { type: "plain"; text: string };
+
+export type InlineNode =
+  | { type: "text"; text: string }
+  | { type: "bold"; children: InlineNode[] }
+  | { type: "italic"; children: InlineNode[] }
+  | { type: "strike"; children: InlineNode[] }
+  | { type: "underline"; children: InlineNode[] }
+  | { type: "spoiler"; children: InlineNode[] }
+  | { type: "code"; text: string }
+  | { type: "link"; text: InlineNode[]; url: string };

--- a/src/telegram/render/validator.ts
+++ b/src/telegram/render/validator.ts
@@ -18,6 +18,7 @@ const SUPPORTED_ENTITY_TYPES = new Set<MessageEntity["type"]>([
   "strikethrough",
   "spoiler",
   "code",
+  "pre",
   "text_link",
 ]);
 
@@ -153,11 +154,16 @@ function validateEntityPair(
     return issues;
   }
 
-  if (left.type === "code" || right.type === "code") {
+  if (
+    left.type === "code" ||
+    right.type === "code" ||
+    left.type === "pre" ||
+    right.type === "pre"
+  ) {
     issues.push({
-      code: "code_overlap",
-      message: `Code entities cannot overlap with ${left.type === "code" ? right.type : left.type}`,
-      entityIndex: left.type === "code" ? rightIndex : leftIndex,
+      code: left.type === "pre" || right.type === "pre" ? "pre_overlap" : "code_overlap",
+      message: `${left.type === "pre" || right.type === "pre" ? "Pre" : "Code"} entities cannot overlap with ${left.type === "code" || left.type === "pre" ? right.type : left.type}`,
+      entityIndex: left.type === "code" || left.type === "pre" ? rightIndex : leftIndex,
     });
     return issues;
   }

--- a/src/telegram/render/validator.ts
+++ b/src/telegram/render/validator.ts
@@ -1,0 +1,212 @@
+import type { MessageEntity } from "grammy/types";
+
+export interface EntityValidationIssue {
+  code: string;
+  message: string;
+  entityIndex?: number;
+}
+
+export interface EntityValidationResult {
+  ok: boolean;
+  issues: EntityValidationIssue[];
+}
+
+const SUPPORTED_ENTITY_TYPES = new Set<MessageEntity["type"]>([
+  "bold",
+  "italic",
+  "underline",
+  "strikethrough",
+  "spoiler",
+  "code",
+  "text_link",
+]);
+
+const STYLE_ENTITY_TYPES = new Set<MessageEntity["type"]>([
+  "bold",
+  "italic",
+  "underline",
+  "strikethrough",
+  "spoiler",
+]);
+
+function getRange(entity: MessageEntity): { start: number; end: number } {
+  return {
+    start: entity.offset,
+    end: entity.offset + entity.length,
+  };
+}
+
+function rangesEqual(left: MessageEntity, right: MessageEntity): boolean {
+  return left.offset === right.offset && left.length === right.length;
+}
+
+function rangesOverlap(left: MessageEntity, right: MessageEntity): boolean {
+  const leftRange = getRange(left);
+  const rightRange = getRange(right);
+  return leftRange.start < rightRange.end && rightRange.start < leftRange.end;
+}
+
+function isFullyNested(left: MessageEntity, right: MessageEntity): boolean {
+  const leftRange = getRange(left);
+  const rightRange = getRange(right);
+  return leftRange.start <= rightRange.start && leftRange.end >= rightRange.end;
+}
+
+function isPartialOverlap(left: MessageEntity, right: MessageEntity): boolean {
+  if (!rangesOverlap(left, right) || rangesEqual(left, right)) {
+    return false;
+  }
+
+  return !isFullyNested(left, right) && !isFullyNested(right, left);
+}
+
+function isStyleEntity(entity: MessageEntity): boolean {
+  return STYLE_ENTITY_TYPES.has(entity.type);
+}
+
+function isValidLinkUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ["http:", "https:", "tg:", "mailto:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function validateEntityShape(
+  textLength: number,
+  entity: MessageEntity,
+  entityIndex: number,
+): EntityValidationIssue[] {
+  const issues: EntityValidationIssue[] = [];
+
+  if (!SUPPORTED_ENTITY_TYPES.has(entity.type)) {
+    issues.push({
+      code: "unsupported_entity_type",
+      message: `Unsupported Telegram entity type: ${entity.type}`,
+      entityIndex,
+    });
+  }
+
+  if (!Number.isInteger(entity.offset) || entity.offset < 0) {
+    issues.push({
+      code: "invalid_offset",
+      message: `Entity offset must be a non-negative integer, got ${entity.offset}`,
+      entityIndex,
+    });
+  }
+
+  if (!Number.isInteger(entity.length) || entity.length <= 0) {
+    issues.push({
+      code: "invalid_length",
+      message: `Entity length must be a positive integer, got ${entity.length}`,
+      entityIndex,
+    });
+  }
+
+  if (entity.offset + entity.length > textLength) {
+    issues.push({
+      code: "range_out_of_bounds",
+      message: `Entity range ${entity.offset}-${entity.offset + entity.length} exceeds text length ${textLength}`,
+      entityIndex,
+    });
+  }
+
+  if (entity.type === "text_link" && !isValidLinkUrl(entity.url)) {
+    issues.push({
+      code: "invalid_link_url",
+      message: `Invalid Telegram text_link URL: ${entity.url}`,
+      entityIndex,
+    });
+  }
+
+  return issues;
+}
+
+function validateEntityPair(
+  left: MessageEntity,
+  leftIndex: number,
+  right: MessageEntity,
+  rightIndex: number,
+): EntityValidationIssue[] {
+  const issues: EntityValidationIssue[] = [];
+
+  if (!rangesOverlap(left, right)) {
+    return issues;
+  }
+
+  if (left.type === right.type && rangesEqual(left, right)) {
+    issues.push({
+      code: "duplicate_entity_range",
+      message: `Duplicate ${left.type} entities share the same range ${left.offset}-${left.offset + left.length}`,
+      entityIndex: rightIndex,
+    });
+    return issues;
+  }
+
+  if (isPartialOverlap(left, right)) {
+    issues.push({
+      code: "partial_overlap",
+      message: `Entities ${left.type} and ${right.type} partially overlap`,
+      entityIndex: rightIndex,
+    });
+    return issues;
+  }
+
+  if (left.type === "code" || right.type === "code") {
+    issues.push({
+      code: "code_overlap",
+      message: `Code entities cannot overlap with ${left.type === "code" ? right.type : left.type}`,
+      entityIndex: left.type === "code" ? rightIndex : leftIndex,
+    });
+    return issues;
+  }
+
+  if (left.type === "text_link" && right.type === "text_link") {
+    issues.push({
+      code: "nested_link",
+      message: "text_link entities cannot be nested or share the same range",
+      entityIndex: rightIndex,
+    });
+    return issues;
+  }
+
+  const styleAndLinkNestingAllowed =
+    (left.type === "text_link" && isStyleEntity(right)) ||
+    (right.type === "text_link" && isStyleEntity(left));
+
+  if (!styleAndLinkNestingAllowed && !(isStyleEntity(left) && isStyleEntity(right))) {
+    issues.push({
+      code: "unsupported_overlap",
+      message: `Unsupported overlap between ${left.type} and ${right.type}`,
+      entityIndex: rightIndex,
+    });
+  }
+
+  return issues;
+}
+
+export function validateTelegramEntities(
+  text: string,
+  entities: MessageEntity[],
+): EntityValidationResult {
+  const issues: EntityValidationIssue[] = [];
+  const textLength = text.length;
+
+  entities.forEach((entity, entityIndex) => {
+    issues.push(...validateEntityShape(textLength, entity, entityIndex));
+  });
+
+  for (let leftIndex = 0; leftIndex < entities.length; leftIndex++) {
+    for (let rightIndex = leftIndex + 1; rightIndex < entities.length; rightIndex++) {
+      issues.push(
+        ...validateEntityPair(entities[leftIndex], leftIndex, entities[rightIndex], rightIndex),
+      );
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  };
+}

--- a/tests/bot/streaming/response-streamer.test.ts
+++ b/tests/bot/streaming/response-streamer.test.ts
@@ -1,6 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ResponseStreamer } from "../../../src/bot/streaming/response-streamer.js";
 
+function plainPart(text: string) {
+  return {
+    text,
+    fallbackText: text,
+    source: "plain" as const,
+  };
+}
+
+function richPart(
+  text: string,
+  entities: { type: "bold" | "italic"; offset: number; length: number }[],
+) {
+  return {
+    text,
+    entities,
+    fallbackText: text,
+    source: "entities" as const,
+  };
+}
+
+function signature(part: { text: string; entities?: unknown[] }) {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
+}
+
 describe("bot/streaming/response-streamer", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -10,24 +34,27 @@ describe("bot/streaming/response-streamer", () => {
     vi.useFakeTimers();
 
     let nextMessageId = 1;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 500,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["first"], format: "raw" });
-    streamer.enqueue("s1", "m1", { parts: ["second"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("first")] });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("second")] });
 
     await vi.advanceTimersByTimeAsync(500);
 
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("second", "raw", undefined);
-    expect(editText).not.toHaveBeenCalled();
+    expect(sendPart).toHaveBeenCalledTimes(1);
+    expect(sendPart).toHaveBeenCalledWith(plainPart("second"), undefined);
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
   });
 
@@ -35,33 +62,35 @@ describe("bot/streaming/response-streamer", () => {
     vi.useFakeTimers();
 
     let nextMessageId = 101;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["part-1"], format: "markdown_v2" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("part-1")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
     streamer.enqueue("s1", "m1", {
-      parts: ["part-1", "part-2"],
-      format: "markdown_v2",
+      parts: [plainPart("part-1"), plainPart("part-2")],
     });
 
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(2);
+      expect(sendPart).toHaveBeenCalledTimes(2);
     });
 
-    expect(sendText).toHaveBeenNthCalledWith(1, "part-1", "markdown_v2", undefined);
-    expect(sendText).toHaveBeenNthCalledWith(2, "part-2", "markdown_v2", undefined);
-    expect(editText).not.toHaveBeenCalled();
+    expect(sendPart).toHaveBeenNthCalledWith(1, plainPart("part-1"), undefined);
+    expect(sendPart).toHaveBeenNthCalledWith(2, plainPart("part-2"), undefined);
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
   });
 
@@ -69,26 +98,29 @@ describe("bot/streaming/response-streamer", () => {
     vi.useFakeTimers();
 
     let nextMessageId = 1;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 500,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
     await vi.advanceTimersByTimeAsync(500);
 
-    const result = await streamer.complete("s1", "m1", { parts: ["final"], format: "raw" });
+    const result = await streamer.complete("s1", "m1", { parts: [plainPart("final")] });
 
     expect(result.streamed).toBe(true);
     expect(result.telegramMessageIds).toEqual([1]);
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(editText).toHaveBeenCalledTimes(1);
-    expect(editText).toHaveBeenCalledWith(1, "final", "raw", undefined);
+    expect(sendPart).toHaveBeenCalledTimes(1);
+    expect(editPart).toHaveBeenCalledTimes(1);
+    expect(editPart).toHaveBeenCalledWith(1, plainPart("final"), undefined);
     expect(deleteText).not.toHaveBeenCalled();
   });
 
@@ -96,22 +128,25 @@ describe("bot/streaming/response-streamer", () => {
     vi.useFakeTimers();
 
     let nextMessageId = 10;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["one", "two"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("one"), plainPart("two")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(2);
+      expect(sendPart).toHaveBeenCalledTimes(2);
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["one"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("one")] });
     await vi.waitFor(() => {
       expect(deleteText).toHaveBeenCalledTimes(1);
     });
@@ -122,129 +157,135 @@ describe("bot/streaming/response-streamer", () => {
   it("retries after Telegram rate limits", async () => {
     vi.useFakeTimers();
 
-    const sendText = vi
+    const sendPart = vi
       .fn()
       .mockRejectedValueOnce(new Error("429: retry after 1"))
-      .mockResolvedValueOnce(1);
-    const editText = vi.fn().mockResolvedValue(undefined);
+      .mockImplementationOnce(async (part) => ({
+        messageId: 1,
+        deliveredSignature: signature(part),
+      }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["hello"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("hello")] });
 
     await vi.advanceTimersByTimeAsync(1000);
 
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(2);
+      expect(sendPart).toHaveBeenCalledTimes(2);
     });
   });
 
   it("marks a stream as broken after fatal edit error and cleans up partial messages on complete", async () => {
     vi.useFakeTimers();
 
-    const sendText = vi.fn().mockResolvedValue(42);
-    const editText = vi
+    const sendPart = vi.fn(async (part) => ({
+      messageId: 42,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi
       .fn()
       .mockRejectedValue(new Error("400: Bad Request: message can't be edited"));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial updated"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial updated")] });
     await vi.waitFor(() => {
-      expect(editText).toHaveBeenCalledTimes(1);
+      expect(editPart).toHaveBeenCalledTimes(1);
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial updated again"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial updated again")] });
     await vi.advanceTimersByTimeAsync(50);
 
-    expect(editText).toHaveBeenCalledTimes(1);
+    expect(editPart).toHaveBeenCalledTimes(1);
 
-    const result = await streamer.complete("s1", "m1", { parts: ["final"], format: "raw" });
+    const result = await streamer.complete("s1", "m1", { parts: [plainPart("final")] });
 
     expect(result.streamed).toBe(false);
     expect(result.telegramMessageIds).toEqual([]);
     expect(deleteText).toHaveBeenCalledTimes(1);
     expect(deleteText).toHaveBeenCalledWith(42);
-    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendPart).toHaveBeenCalledTimes(1);
   });
 
   it("falls back cleanly when fatal send error happens before any partial is visible", async () => {
     vi.useFakeTimers();
 
-    const sendText = vi
+    const sendPart = vi
       .fn()
       .mockRejectedValue(new Error("403: Forbidden: bot was blocked by the user"));
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial again"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial again")] });
     await vi.advanceTimersByTimeAsync(50);
 
-    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendPart).toHaveBeenCalledTimes(1);
 
-    const result = await streamer.complete("s1", "m1", { parts: ["final"], format: "raw" });
+    const result = await streamer.complete("s1", "m1", { parts: [plainPart("final")] });
 
     expect(result.streamed).toBe(false);
     expect(result.telegramMessageIds).toEqual([]);
-    expect(editText).not.toHaveBeenCalled();
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
   });
 
   it("waits for an in-flight first streamed send before finalizing short responses", async () => {
     let resolveSend: ((messageId: number) => void) | null = null;
-    const sendText = vi.fn(
+    const sendPart = vi.fn(
       () =>
-        new Promise<number>((resolve) => {
-          resolveSend = resolve;
+        new Promise<{ messageId: number; deliveredSignature: string }>((resolve) => {
+          resolveSend = (messageId) =>
+            resolve({ messageId, deliveredSignature: signature(plainPart("short reply")) });
         }),
     );
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["short reply"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("short reply")] });
 
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
     const completionPromise = streamer.complete("s1", "m1", {
-      parts: ["short reply"],
-      format: "raw",
+      parts: [plainPart("short reply")],
     });
 
-    expect(editText).not.toHaveBeenCalled();
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
 
     resolveSend?.(1);
@@ -252,8 +293,8 @@ describe("bot/streaming/response-streamer", () => {
     const result = await completionPromise;
     expect(result.streamed).toBe(true);
     expect(result.telegramMessageIds).toEqual([1]);
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(editText).not.toHaveBeenCalled();
+    expect(sendPart).toHaveBeenCalledTimes(1);
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
   });
 
@@ -261,96 +302,135 @@ describe("bot/streaming/response-streamer", () => {
     vi.useFakeTimers();
 
     let nextMessageId = 100;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
     streamer.clearSession("s1", "session_error");
 
     const completedAfterClear = await streamer.complete("s1", "m1", {
-      parts: ["final"],
-      format: "raw",
+      parts: [plainPart("final")],
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["new partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("new partial")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(2);
+      expect(sendPart).toHaveBeenCalledTimes(2);
     });
 
     expect(completedAfterClear.streamed).toBe(false);
     expect(completedAfterClear.telegramMessageIds).toEqual([]);
-    expect(editText).not.toHaveBeenCalled();
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
-    expect(sendText).toHaveBeenNthCalledWith(2, "new partial", "raw", undefined);
+    expect(sendPart).toHaveBeenNthCalledWith(2, plainPart("new partial"), undefined);
   });
 
   it("keeps visible partial messages when clearing all streams", async () => {
     vi.useFakeTimers();
 
     let nextMessageId = 200;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 0,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
     await vi.waitFor(() => {
-      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendPart).toHaveBeenCalledTimes(1);
     });
 
     streamer.clearAll("summary_aggregator_clear");
 
     const completedAfterClear = await streamer.complete("s1", "m1", {
-      parts: ["final"],
-      format: "raw",
+      parts: [plainPart("final")],
     });
 
     expect(completedAfterClear.streamed).toBe(false);
     expect(completedAfterClear.telegramMessageIds).toEqual([]);
-    expect(editText).not.toHaveBeenCalled();
+    expect(editPart).not.toHaveBeenCalled();
     expect(deleteText).not.toHaveBeenCalled();
-    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendPart).toHaveBeenCalledTimes(1);
   });
 
   it("skips final sync when stream never emitted partial update", async () => {
     vi.useFakeTimers();
 
     let nextMessageId = 1;
-    const sendText = vi.fn(async () => nextMessageId++);
-    const editText = vi.fn().mockResolvedValue(undefined);
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature(part),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
     const deleteText = vi.fn().mockResolvedValue(undefined);
     const streamer = new ResponseStreamer({
       throttleMs: 500,
-      sendText,
-      editText,
+      sendPart,
+      editPart,
       deleteText,
     });
 
-    streamer.enqueue("s1", "m1", { parts: ["partial"], format: "raw" });
-    const synced = await streamer.complete("s1", "m1", { parts: ["final"], format: "raw" });
+    streamer.enqueue("s1", "m1", { parts: [plainPart("partial")] });
+    const synced = await streamer.complete("s1", "m1", { parts: [plainPart("final")] });
 
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(synced.streamed).toBe(false);
     expect(synced.telegramMessageIds).toEqual([]);
-    expect(sendText).not.toHaveBeenCalled();
-    expect(editText).not.toHaveBeenCalled();
+    expect(sendPart).not.toHaveBeenCalled();
+    expect(editPart).not.toHaveBeenCalled();
+    expect(deleteText).not.toHaveBeenCalled();
+  });
+
+  it("keeps stream healthy when a part is locally downgraded to plain", async () => {
+    vi.useFakeTimers();
+
+    let nextMessageId = 300;
+    const sendPart = vi.fn(async (part) => ({
+      messageId: nextMessageId++,
+      deliveredSignature: signature({ text: part.fallbackText }),
+    }));
+    const editPart = vi.fn(async (messageId, part) => ({ deliveredSignature: signature(part) }));
+    const deleteText = vi.fn().mockResolvedValue(undefined);
+    const streamer = new ResponseStreamer({
+      throttleMs: 0,
+      sendPart,
+      editPart,
+      deleteText,
+    });
+
+    const boldHello = richPart("hello", [{ type: "bold", offset: 0, length: 5 }]);
+    streamer.enqueue("s1", "m1", { parts: [boldHello] });
+
+    await vi.waitFor(() => {
+      expect(sendPart).toHaveBeenCalledTimes(1);
+    });
+
+    const result = await streamer.complete("s1", "m1", { parts: [boldHello] });
+
+    expect(result.streamed).toBe(true);
+    expect(editPart).toHaveBeenCalledTimes(1);
+    expect(editPart).toHaveBeenCalledWith(300, boldHello, undefined);
     expect(deleteText).not.toHaveBeenCalled();
   });
 });

--- a/tests/bot/utils/assistant-rendering.test.ts
+++ b/tests/bot/utils/assistant-rendering.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+function toPlainParts(
+  blocks: Array<{ text: string; fallbackText: string; source: "entities" | "plain" }>,
+) {
+  return blocks.map((block) => ({
+    text: block.text,
+    fallbackText: block.fallbackText,
+    source: block.source,
+  }));
+}
+
+async function loadAssistantRendering(mode: "raw" | "markdown") {
+  vi.resetModules();
+
+  const debug = vi.fn();
+  const warn = vi.fn();
+  const renderTelegramBlocks = vi.fn((text: string) => [
+    {
+      blockType: "paragraph" as const,
+      mode: "full" as const,
+      text: `rich:${text}`,
+      fallbackText: `rich:${text}`,
+      source: "plain" as const,
+    },
+  ]);
+  const renderTelegramParts = vi.fn((text: string) => [
+    {
+      text: `rich:${text}`,
+      entities: [{ type: "bold" as const, offset: 0, length: `rich:${text}`.length }],
+      fallbackText: `rich:${text}`,
+      source: "entities" as const,
+    },
+  ]);
+  const chunkTelegramRenderedBlocks = vi.fn(
+    (blocks: Array<{ text: string; fallbackText: string; source: "entities" | "plain" }>) =>
+      toPlainParts(blocks),
+  );
+
+  vi.doMock("../../../src/config.js", () => ({
+    config: {
+      telegram: {
+        token: "test-token",
+        allowedUserId: 123456789,
+        proxyUrl: "",
+      },
+      opencode: {
+        apiUrl: "http://localhost:4096",
+        username: "opencode",
+        password: "",
+        model: {
+          provider: "test-provider",
+          modelId: "test-model",
+        },
+      },
+      server: {
+        logLevel: "error",
+      },
+      bot: {
+        messageFormatMode: mode,
+        responseStreamThrottleMs: 500,
+      },
+      files: { maxFileSizeKb: 100 },
+      open: { browserRoots: "" },
+      stt: { apiUrl: "", apiKey: "", model: "", language: "" },
+      tts: { apiUrl: "", apiKey: "", model: "", voice: "" },
+    },
+  }));
+  vi.doMock("../../../src/utils/logger.js", () => ({
+    logger: {
+      debug,
+      warn,
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+  }));
+  vi.doMock("../../../src/telegram/render/pipeline.js", () => ({
+    renderTelegramBlocks,
+    renderTelegramParts,
+  }));
+  vi.doMock("../../../src/telegram/render/chunker.js", () => ({
+    chunkTelegramRenderedBlocks,
+  }));
+
+  const module = await import("../../../src/bot/utils/assistant-rendering.js");
+  return {
+    module,
+    debug,
+    warn,
+    renderTelegramBlocks,
+    renderTelegramParts,
+    chunkTelegramRenderedBlocks,
+  };
+}
+
+describe("bot/utils/assistant-rendering", () => {
+  it("uses plain parts only for assistant final delivery in raw mode", async () => {
+    const { module, debug, renderTelegramParts, chunkTelegramRenderedBlocks } =
+      await loadAssistantRendering("raw");
+
+    expect(module.renderAssistantFinalPartsSafe("hello raw", 50)).toEqual([
+      {
+        text: "hello raw",
+        fallbackText: "hello raw",
+        source: "plain",
+      },
+    ]);
+
+    expect(renderTelegramParts).not.toHaveBeenCalled();
+    expect(chunkTelegramRenderedBlocks).toHaveBeenCalledWith(
+      [
+        {
+          blockType: "plain",
+          mode: "plain",
+          text: "hello raw",
+          fallbackText: "hello raw",
+          source: "plain",
+        },
+      ],
+      { maxPartLength: 50 },
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "[AssistantRender] Built final assistant parts in raw mode",
+      expect.objectContaining({ formatMode: "raw", partCount: 1, textLength: 9 }),
+    );
+  });
+
+  it("uses plain payload only for assistant streaming in raw mode", async () => {
+    const { module, debug, renderTelegramBlocks, chunkTelegramRenderedBlocks } =
+      await loadAssistantRendering("raw");
+
+    expect(module.prepareAssistantStreamingPayload("partial **text", 40)).toEqual({
+      parts: [
+        {
+          text: "partial **text",
+          fallbackText: "partial **text",
+          source: "plain",
+        },
+      ],
+    });
+
+    expect(renderTelegramBlocks).not.toHaveBeenCalled();
+    expect(chunkTelegramRenderedBlocks).toHaveBeenCalledWith(
+      [
+        {
+          blockType: "plain",
+          mode: "plain",
+          text: "partial **text",
+          fallbackText: "partial **text",
+          source: "plain",
+        },
+      ],
+      { maxPartLength: 40 },
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "[AssistantRender] Built streaming assistant payload in raw mode",
+      expect.objectContaining({ formatMode: "raw", partCount: 1, textLength: 14 }),
+    );
+  });
+
+  it("uses rich stable prefix and plain tail for streaming in markdown mode", async () => {
+    const { module, debug, renderTelegramBlocks, chunkTelegramRenderedBlocks } =
+      await loadAssistantRendering("markdown");
+
+    expect(module.prepareAssistantStreamingPayload("done\n\nunfinished", 60)).toEqual({
+      parts: [
+        {
+          text: "rich:done\n\n",
+          fallbackText: "rich:done\n\n",
+          source: "plain",
+        },
+        {
+          text: "unfinished",
+          fallbackText: "unfinished",
+          source: "plain",
+        },
+      ],
+    });
+
+    expect(renderTelegramBlocks).toHaveBeenCalledWith("done\n\n");
+    expect(chunkTelegramRenderedBlocks).toHaveBeenCalledWith(
+      [
+        {
+          blockType: "paragraph",
+          mode: "full",
+          text: "rich:done\n\n",
+          fallbackText: "rich:done\n\n",
+          source: "plain",
+        },
+        {
+          blockType: "plain",
+          mode: "plain",
+          text: "unfinished",
+          fallbackText: "unfinished",
+          source: "plain",
+        },
+      ],
+      { maxPartLength: 60 },
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "[AssistantRender] Built streaming assistant payload in entities mode",
+      expect.objectContaining({
+        formatMode: "entities",
+        stableBoundary: 6,
+        tailLength: 10,
+        partCount: 2,
+      }),
+    );
+  });
+
+  it("falls back to plain parts when markdown final rendering fails", async () => {
+    const { module, warn, renderTelegramParts } = await loadAssistantRendering("markdown");
+    renderTelegramParts.mockImplementationOnce(() => {
+      throw new Error("render failed");
+    });
+
+    expect(module.renderAssistantFinalPartsSafe("final text", 80)).toEqual([
+      {
+        text: "final text",
+        fallbackText: "final text",
+        source: "plain",
+      },
+    ]);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[AssistantRender] Part rendering failed, falling back to plain text parts",
+      expect.any(Error),
+    );
+  });
+});

--- a/tests/bot/utils/finalize-assistant-response.logging.test.ts
+++ b/tests/bot/utils/finalize-assistant-response.logging.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("bot/utils/finalize-assistant-response logging", () => {
+  it("logs final assistant raw text exactly once per finalize call", async () => {
+    vi.resetModules();
+
+    const debug = vi.fn();
+    vi.doMock("../../../src/utils/logger.js", () => ({
+      logger: {
+        debug,
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+
+    const { finalizeAssistantResponse } =
+      await import("../../../src/bot/utils/finalize-assistant-response.js");
+
+    await finalizeAssistantResponse({
+      sessionId: "s1",
+      messageId: "m1",
+      messageText: "raw model output",
+      responseStreamer: {
+        complete: vi.fn().mockResolvedValue({ streamed: false, telegramMessageIds: [] }),
+      },
+      flushPendingServiceMessages: vi.fn().mockResolvedValue(undefined),
+      prepareStreamingPayload: vi.fn(() => null),
+      renderFinalParts: vi.fn(() => [
+        {
+          text: "raw model output",
+          fallbackText: "raw model output",
+          source: "plain" as const,
+        },
+      ]),
+      getReplyKeyboard: vi.fn(() => undefined),
+      sendRenderedPart: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(debug).toHaveBeenCalledWith(
+      "[FinalizeResponse] Final assistant raw text received: session=s1, message=m1",
+      "raw model output",
+    );
+    expect(
+      debug.mock.calls.filter(
+        (call) =>
+          call[0] ===
+          "[FinalizeResponse] Final assistant raw text received: session=s1, message=m1",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/tests/bot/utils/finalize-assistant-response.test.ts
+++ b/tests/bot/utils/finalize-assistant-response.test.ts
@@ -7,7 +7,7 @@ describe("bot/utils/finalize-assistant-response", () => {
       complete: vi.fn().mockResolvedValue({ streamed: false, telegramMessageIds: [] }),
     };
     const flushPendingServiceMessages = vi.fn().mockResolvedValue(undefined);
-    const sendText = vi.fn().mockResolvedValue(undefined);
+    const sendRenderedPart = vi.fn().mockResolvedValue(undefined);
     const keyboard = { keyboard: [[{ text: "A" }]] };
 
     await finalizeAssistantResponse({
@@ -17,11 +17,21 @@ describe("bot/utils/finalize-assistant-response", () => {
       responseStreamer,
       flushPendingServiceMessages,
       prepareStreamingPayload: vi.fn(() => ({ parts: ["final reply"], format: "raw" as const })),
-      formatSummary: vi.fn(() => ["part 1", "part 2"]),
-      formatRawSummary: vi.fn(() => ["part 1", "part 2"]),
-      resolveFormat: vi.fn(() => "markdown_v2" as const),
+      renderFinalParts: vi.fn(() => [
+        {
+          text: "part 1",
+          entities: [{ type: "bold", offset: 0, length: 6 }],
+          fallbackText: "part 1",
+          source: "entities" as const,
+        },
+        {
+          text: "part 2",
+          fallbackText: "part 2",
+          source: "plain" as const,
+        },
+      ]),
       getReplyKeyboard: vi.fn(() => keyboard),
-      sendText,
+      sendRenderedPart,
     });
 
     expect(responseStreamer.complete).toHaveBeenCalledWith("s1", "m1", {
@@ -31,20 +41,25 @@ describe("bot/utils/finalize-assistant-response", () => {
       editOptions: undefined,
     });
     expect(flushPendingServiceMessages).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledTimes(2);
-    expect(sendText).toHaveBeenNthCalledWith(
+    expect(sendRenderedPart).toHaveBeenCalledTimes(2);
+    expect(sendRenderedPart).toHaveBeenNthCalledWith(
       1,
-      "part 1",
-      "part 1",
+      {
+        text: "part 1",
+        entities: [{ type: "bold", offset: 0, length: 6 }],
+        fallbackText: "part 1",
+        source: "entities",
+      },
       { disable_notification: true, reply_markup: keyboard },
-      "markdown_v2",
     );
-    expect(sendText).toHaveBeenNthCalledWith(
+    expect(sendRenderedPart).toHaveBeenNthCalledWith(
       2,
-      "part 2",
-      "part 2",
+      {
+        text: "part 2",
+        fallbackText: "part 2",
+        source: "plain",
+      },
       { disable_notification: true, reply_markup: keyboard },
-      "markdown_v2",
     );
   });
 
@@ -53,7 +68,7 @@ describe("bot/utils/finalize-assistant-response", () => {
       complete: vi.fn().mockResolvedValue({ streamed: true, telegramMessageIds: [101] }),
     };
     const flushPendingServiceMessages = vi.fn().mockResolvedValue(undefined);
-    const sendText = vi.fn().mockResolvedValue(undefined);
+    const sendRenderedPart = vi.fn().mockResolvedValue(undefined);
     const prepareStreamingPayload = vi.fn(() => ({ parts: ["reply"], format: "raw" as const }));
     const keyboard = { keyboard: [[{ text: "ctx" }]] };
 
@@ -64,11 +79,15 @@ describe("bot/utils/finalize-assistant-response", () => {
       responseStreamer,
       flushPendingServiceMessages,
       prepareStreamingPayload,
-      formatSummary: vi.fn(() => ["reply"]),
-      formatRawSummary: vi.fn(() => ["reply"]),
-      resolveFormat: vi.fn(() => "raw" as const),
+      renderFinalParts: vi.fn(() => [
+        {
+          text: "reply",
+          fallbackText: "reply",
+          source: "plain" as const,
+        },
+      ]),
       getReplyKeyboard: vi.fn(() => keyboard),
-      sendText,
+      sendRenderedPart,
     });
 
     expect(responseStreamer.complete).toHaveBeenCalledWith("s1", "m1", {
@@ -78,15 +97,15 @@ describe("bot/utils/finalize-assistant-response", () => {
       editOptions: undefined,
     });
     expect(flushPendingServiceMessages).toHaveBeenCalledTimes(1);
-    expect(sendText).not.toHaveBeenCalled();
+    expect(sendRenderedPart).not.toHaveBeenCalled();
   });
 
-  it("still sends with keyboard when streamer reports not streamed", async () => {
+  it("still sends rendered parts with keyboard when streamer reports not streamed", async () => {
     const responseStreamer = {
       complete: vi.fn().mockResolvedValue({ streamed: false, telegramMessageIds: [] }),
     };
     const flushPendingServiceMessages = vi.fn().mockResolvedValue(undefined);
-    const sendText = vi.fn().mockResolvedValue(undefined);
+    const sendRenderedPart = vi.fn().mockResolvedValue(undefined);
     const prepareStreamingPayload = vi.fn(() => ({ parts: ["reply"], format: "raw" as const }));
 
     await finalizeAssistantResponse({
@@ -96,14 +115,25 @@ describe("bot/utils/finalize-assistant-response", () => {
       responseStreamer,
       flushPendingServiceMessages,
       prepareStreamingPayload,
-      formatSummary: vi.fn(() => ["reply"]),
-      formatRawSummary: vi.fn(() => ["reply"]),
-      resolveFormat: vi.fn(() => "raw" as const),
+      renderFinalParts: vi.fn(() => [
+        {
+          text: "reply",
+          fallbackText: "reply",
+          source: "plain" as const,
+        },
+      ]),
       getReplyKeyboard: vi.fn(() => undefined),
-      sendText,
+      sendRenderedPart,
     });
 
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText).toHaveBeenCalledWith("reply", "reply", { disable_notification: true }, "raw");
+    expect(sendRenderedPart).toHaveBeenCalledTimes(1);
+    expect(sendRenderedPart).toHaveBeenCalledWith(
+      {
+        text: "reply",
+        fallbackText: "reply",
+        source: "plain",
+      },
+      { disable_notification: true },
+    );
   });
 });

--- a/tests/bot/utils/finalize-assistant-response.test.ts
+++ b/tests/bot/utils/finalize-assistant-response.test.ts
@@ -16,7 +16,15 @@ describe("bot/utils/finalize-assistant-response", () => {
       messageText: "final reply",
       responseStreamer,
       flushPendingServiceMessages,
-      prepareStreamingPayload: vi.fn(() => ({ parts: ["final reply"], format: "raw" as const })),
+      prepareStreamingPayload: vi.fn(() => ({
+        parts: [
+          {
+            text: "final reply",
+            fallbackText: "final reply",
+            source: "plain" as const,
+          },
+        ],
+      })),
       renderFinalParts: vi.fn(() => [
         {
           text: "part 1",
@@ -35,8 +43,13 @@ describe("bot/utils/finalize-assistant-response", () => {
     });
 
     expect(responseStreamer.complete).toHaveBeenCalledWith("s1", "m1", {
-      parts: ["final reply"],
-      format: "raw",
+      parts: [
+        {
+          text: "final reply",
+          fallbackText: "final reply",
+          source: "plain",
+        },
+      ],
       sendOptions: { disable_notification: true, reply_markup: keyboard },
       editOptions: undefined,
     });
@@ -69,7 +82,15 @@ describe("bot/utils/finalize-assistant-response", () => {
     };
     const flushPendingServiceMessages = vi.fn().mockResolvedValue(undefined);
     const sendRenderedPart = vi.fn().mockResolvedValue(undefined);
-    const prepareStreamingPayload = vi.fn(() => ({ parts: ["reply"], format: "raw" as const }));
+    const prepareStreamingPayload = vi.fn(() => ({
+      parts: [
+        {
+          text: "reply",
+          fallbackText: "reply",
+          source: "plain" as const,
+        },
+      ],
+    }));
     const keyboard = { keyboard: [[{ text: "ctx" }]] };
 
     await finalizeAssistantResponse({
@@ -91,8 +112,13 @@ describe("bot/utils/finalize-assistant-response", () => {
     });
 
     expect(responseStreamer.complete).toHaveBeenCalledWith("s1", "m1", {
-      parts: ["reply"],
-      format: "raw",
+      parts: [
+        {
+          text: "reply",
+          fallbackText: "reply",
+          source: "plain",
+        },
+      ],
       sendOptions: { disable_notification: true, reply_markup: keyboard },
       editOptions: undefined,
     });
@@ -106,7 +132,15 @@ describe("bot/utils/finalize-assistant-response", () => {
     };
     const flushPendingServiceMessages = vi.fn().mockResolvedValue(undefined);
     const sendRenderedPart = vi.fn().mockResolvedValue(undefined);
-    const prepareStreamingPayload = vi.fn(() => ({ parts: ["reply"], format: "raw" as const }));
+    const prepareStreamingPayload = vi.fn(() => ({
+      parts: [
+        {
+          text: "reply",
+          fallbackText: "reply",
+          source: "plain" as const,
+        },
+      ],
+    }));
 
     await finalizeAssistantResponse({
       sessionId: "s1",

--- a/tests/bot/utils/telegram-text.test.ts
+++ b/tests/bot/utils/telegram-text.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  editRenderedBotPart,
   editBotText,
+  getTelegramRenderedPartSignature,
   sendBotText,
   sendRenderedBotPart,
 } from "../../../src/bot/utils/telegram-text.js";
@@ -74,18 +76,26 @@ describe("bot/utils/telegram-text", () => {
   });
 
   it("sends rendered parts with entities and no parse mode", async () => {
-    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 123 });
 
-    await sendRenderedBotPart({
-      api: { sendMessage },
-      chatId: 100,
-      part: {
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage },
+        chatId: 100,
+        part: {
+          text: "Hello",
+          entities: [{ type: "bold", offset: 0, length: 5 }],
+          fallbackText: "Hello",
+          source: "entities",
+        },
+        options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+      }),
+    ).resolves.toEqual({
+      messageId: 123,
+      deliveredSignature: getTelegramRenderedPartSignature({
         text: "Hello",
         entities: [{ type: "bold", offset: 0, length: 5 }],
-        fallbackText: "Hello",
-        source: "entities",
-      },
-      options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+      }),
     });
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -96,17 +106,22 @@ describe("bot/utils/telegram-text", () => {
   });
 
   it("sends plain rendered parts without entities", async () => {
-    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 321 });
 
-    await sendRenderedBotPart({
-      api: { sendMessage },
-      chatId: 100,
-      part: {
-        text: "plain text",
-        fallbackText: "plain text",
-        source: "plain",
-      },
-      options: { reply_markup: { keyboard: [] } },
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage },
+        chatId: 100,
+        part: {
+          text: "plain text",
+          fallbackText: "plain text",
+          source: "plain",
+        },
+        options: { reply_markup: { keyboard: [] } },
+      }),
+    ).resolves.toEqual({
+      messageId: 321,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: "plain text" }),
     });
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
@@ -119,18 +134,23 @@ describe("bot/utils/telegram-text", () => {
     const sendMessage = vi
       .fn()
       .mockRejectedValueOnce(new Error("Bad Request: can't parse entities: unsupported start tag"))
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce({ message_id: 222 });
 
-    await sendRenderedBotPart({
-      api: { sendMessage },
-      chatId: 100,
-      part: {
-        text: "Hello",
-        entities: [{ type: "bold", offset: 0, length: 5 }],
-        fallbackText: "Hello raw",
-        source: "entities",
-      },
-      options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage },
+        chatId: 100,
+        part: {
+          text: "Hello",
+          entities: [{ type: "bold", offset: 0, length: 5 }],
+          fallbackText: "Hello raw",
+          source: "entities",
+        },
+        options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+      }),
+    ).resolves.toEqual({
+      messageId: 222,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: "Hello raw" }),
     });
 
     expect(sendMessage).toHaveBeenCalledTimes(2);
@@ -140,6 +160,39 @@ describe("bot/utils/telegram-text", () => {
     });
     expect(sendMessage).toHaveBeenNthCalledWith(2, 100, "Hello raw", {
       reply_markup: { keyboard: [] },
+    });
+  });
+
+  it("edits rendered parts with entities and raw fallback", async () => {
+    const editMessageText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Bad Request: can't parse entities: unsupported start tag"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      editRenderedBotPart({
+        api: { editMessageText },
+        chatId: 100,
+        messageId: 500,
+        part: {
+          text: "Hello",
+          entities: [{ type: "italic", offset: 0, length: 5 }],
+          fallbackText: "Hello raw",
+          source: "entities",
+        },
+        options: { reply_markup: { inline_keyboard: [] }, parse_mode: "MarkdownV2" },
+      }),
+    ).resolves.toEqual({
+      deliveredSignature: getTelegramRenderedPartSignature({ text: "Hello raw" }),
+    });
+
+    expect(editMessageText).toHaveBeenCalledTimes(2);
+    expect(editMessageText).toHaveBeenNthCalledWith(1, 100, 500, "Hello", {
+      reply_markup: { inline_keyboard: [] },
+      entities: [{ type: "italic", offset: 0, length: 5 }],
+    });
+    expect(editMessageText).toHaveBeenNthCalledWith(2, 100, 500, "Hello raw", {
+      reply_markup: { inline_keyboard: [] },
     });
   });
 });

--- a/tests/bot/utils/telegram-text.test.ts
+++ b/tests/bot/utils/telegram-text.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { editBotText, sendBotText } from "../../../src/bot/utils/telegram-text.js";
+import {
+  editBotText,
+  sendBotText,
+  sendRenderedBotPart,
+} from "../../../src/bot/utils/telegram-text.js";
 
 describe("bot/utils/telegram-text", () => {
   it("sends raw messages by default", async () => {
@@ -67,5 +71,75 @@ describe("bot/utils/telegram-text", () => {
 
     expect(editMessageText).toHaveBeenCalledTimes(1);
     expect(editMessageText).toHaveBeenCalledWith(100, 200, "updated", undefined);
+  });
+
+  it("sends rendered parts with entities and no parse mode", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+
+    await sendRenderedBotPart({
+      api: { sendMessage },
+      chatId: 100,
+      part: {
+        text: "Hello",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+        fallbackText: "Hello",
+        source: "entities",
+      },
+      options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(100, "Hello", {
+      reply_markup: { keyboard: [] },
+      entities: [{ type: "bold", offset: 0, length: 5 }],
+    });
+  });
+
+  it("sends plain rendered parts without entities", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+
+    await sendRenderedBotPart({
+      api: { sendMessage },
+      chatId: 100,
+      part: {
+        text: "plain text",
+        fallbackText: "plain text",
+        source: "plain",
+      },
+      options: { reply_markup: { keyboard: [] } },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(100, "plain text", {
+      reply_markup: { keyboard: [] },
+    });
+  });
+
+  it("retries rendered entity parts in raw mode when Telegram rejects entities", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Bad Request: can't parse entities: unsupported start tag"))
+      .mockResolvedValueOnce(undefined);
+
+    await sendRenderedBotPart({
+      api: { sendMessage },
+      chatId: 100,
+      part: {
+        text: "Hello",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+        fallbackText: "Hello raw",
+        source: "entities",
+      },
+      options: { reply_markup: { keyboard: [] }, parse_mode: "MarkdownV2" },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, 100, "Hello", {
+      reply_markup: { keyboard: [] },
+      entities: [{ type: "bold", offset: 0, length: 5 }],
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, 100, "Hello raw", {
+      reply_markup: { keyboard: [] },
+    });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -70,6 +70,14 @@ describe("config boolean env parsing", () => {
     expect(config.bot.messageFormatMode).toBe("markdown");
   });
 
+  it("parses raw message format mode", async () => {
+    vi.stubEnv("MESSAGE_FORMAT_MODE", "raw");
+
+    const config = await loadConfig();
+
+    expect(config.bot.messageFormatMode).toBe("raw");
+  });
+
   it("falls back to markdown on invalid message format mode", async () => {
     vi.stubEnv("MESSAGE_FORMAT_MODE", "html");
 

--- a/tests/summary/formatter.test.ts
+++ b/tests/summary/formatter.test.ts
@@ -122,6 +122,15 @@ describe("summary/formatter", () => {
     expect(parts[0]).toContain("🔲 Numbered task");
   });
 
+  it("keeps malformed emphasis content when formatting markdown", () => {
+    const parts = formatSummaryWithMode("*text: *value**", "markdown");
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].length).toBeGreaterThan(0);
+    expect(parts[0]).toContain("text");
+    expect(parts[0]).toContain("value");
+  });
+
   it("formats todowrite tool metadata", () => {
     const text = formatToolInfo({
       sessionId: "s1",

--- a/tests/telegram/render/block-fallback.test.ts
+++ b/tests/telegram/render/block-fallback.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import * as blockRenderer from "../../../src/telegram/render/block-renderer.js";
+import { renderTelegramBlockWithFallback } from "../../../src/telegram/render/block-fallback.js";
+import type { TelegramBlock } from "../../../src/telegram/render/types.js";
+
+describe("telegram/render/block-fallback", () => {
+  it("keeps full mode when the preferred renderer succeeds", () => {
+    const block: TelegramBlock = {
+      type: "paragraph",
+      inlines: [{ type: "text", text: "hello" }],
+    };
+
+    expect(renderTelegramBlockWithFallback(block)).toEqual({
+      blockType: "paragraph",
+      mode: "full",
+      text: "hello",
+      fallbackText: "hello",
+      source: "plain",
+    });
+  });
+
+  it("falls back from full to simplified when style-code nesting is invalid", () => {
+    const block: TelegramBlock = {
+      type: "paragraph",
+      inlines: [{ type: "bold", children: [{ type: "code", text: "npm test" }] }],
+    };
+
+    expect(renderTelegramBlockWithFallback(block)).toEqual({
+      blockType: "paragraph",
+      mode: "simplified",
+      text: "npm test",
+      entities: [{ type: "code", offset: 0, length: 8 }],
+      fallbackText: "npm test",
+      source: "entities",
+    });
+  });
+
+  it("falls back to line-by-line when a single line has an invalid link", () => {
+    const block: TelegramBlock = {
+      type: "paragraph",
+      inlines: [
+        { type: "text", text: "good line\n" },
+        { type: "link", text: [{ type: "text", text: "bad line" }], url: "javascript:alert(1)" },
+      ],
+    };
+
+    expect(renderTelegramBlockWithFallback(block)).toEqual({
+      blockType: "paragraph",
+      mode: "line-by-line",
+      text: "good line\nbad line",
+      fallbackText: "good line\nbad line",
+      source: "plain",
+    });
+  });
+
+  it("uses plain mode when richer renderers keep failing unexpectedly", () => {
+    const block: TelegramBlock = {
+      type: "plain",
+      text: "fallback text",
+    };
+
+    const spy = vi.spyOn(blockRenderer, "renderTelegramBlock");
+    spy.mockImplementation((inputBlock, mode = "full") => {
+      if (mode !== "plain") {
+        throw new Error(`failed ${mode}`);
+      }
+
+      return {
+        blockType: inputBlock.type,
+        mode,
+        text: "fallback text",
+        fallbackText: "fallback text",
+        source: "plain",
+      };
+    });
+
+    try {
+      expect(renderTelegramBlockWithFallback(block)).toEqual({
+        blockType: "plain",
+        mode: "plain",
+        text: "fallback text",
+        fallbackText: "fallback text",
+        source: "plain",
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("keeps neighboring blocks unaffected by one local fallback", () => {
+    const blocks: TelegramBlock[] = [
+      {
+        type: "paragraph",
+        inlines: [
+          { type: "text", text: "good line\n" },
+          { type: "link", text: [{ type: "text", text: "bad line" }], url: "javascript:alert(1)" },
+        ],
+      },
+      {
+        type: "paragraph",
+        inlines: [{ type: "bold", children: [{ type: "text", text: "safe" }] }],
+      },
+    ];
+
+    expect(blocks.map(renderTelegramBlockWithFallback)).toEqual([
+      {
+        blockType: "paragraph",
+        mode: "line-by-line",
+        text: "good line\nbad line",
+        fallbackText: "good line\nbad line",
+        source: "plain",
+      },
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "safe",
+        entities: [{ type: "bold", offset: 0, length: 4 }],
+        fallbackText: "safe",
+        source: "entities",
+      },
+    ]);
+  });
+});

--- a/tests/telegram/render/block-parser.test.ts
+++ b/tests/telegram/render/block-parser.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramBlocks } from "../../../src/telegram/render/block-parser.js";
+
+describe("telegram/render/block-parser", () => {
+  it("parses paragraphs with inline formatting", () => {
+    expect(
+      parseTelegramBlocks("Hello **bold** *italic* ~~strike~~ `code` [site](https://example.com)"),
+    ).toEqual([
+      {
+        type: "paragraph",
+        inlines: [
+          { type: "text", text: "Hello " },
+          { type: "bold", children: [{ type: "text", text: "bold" }] },
+          { type: "text", text: " " },
+          { type: "italic", children: [{ type: "text", text: "italic" }] },
+          { type: "text", text: " " },
+          { type: "strike", children: [{ type: "text", text: "strike" }] },
+          { type: "text", text: " " },
+          { type: "code", text: "code" },
+          { type: "text", text: " " },
+          {
+            type: "link",
+            text: [{ type: "text", text: "site" }],
+            url: "https://example.com",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("parses headings, rules, and code blocks", () => {
+    const input = ["## Title", "", "---", "", "```ts", "const a = 1;", "```"].join("\n");
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "heading",
+        level: 2,
+        inlines: [{ type: "text", text: "Title" }],
+      },
+      { type: "rule" },
+      {
+        type: "code",
+        language: "ts",
+        text: "const a = 1;",
+      },
+    ]);
+  });
+
+  it("parses ordered, unordered, and task lists", () => {
+    const input = ["- first item", "- second **item**", "", "1. [ ] review", "2. [x] done"].join(
+      "\n",
+    );
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "list",
+        ordered: false,
+        items: [
+          [{ type: "text", text: "first item" }],
+          [
+            { type: "text", text: "second " },
+            { type: "bold", children: [{ type: "text", text: "item" }] },
+          ],
+        ],
+      },
+      {
+        type: "list",
+        ordered: true,
+        items: [[{ type: "text", text: "🔲 review" }], [{ type: "text", text: "✅ done" }]],
+      },
+    ]);
+  });
+
+  it("parses simple blockquotes with normalized lazy continuation", () => {
+    const input = ["> quoted line", "Quote continues", "", "> second paragraph"].join("\n");
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "blockquote",
+        lines: [
+          [{ type: "text", text: "quoted line\nQuote continues" }],
+          [{ type: "text", text: "second paragraph" }],
+        ],
+      },
+    ]);
+  });
+
+  it("parses tables into plain cell rows", () => {
+    const input = [
+      "| Name | Score |",
+      "| --- | ---: |",
+      "| api.js | +1.5 |",
+      "| **bold** | `code` |",
+    ].join("\n");
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "table",
+        rows: [
+          ["Name", "Score"],
+          ["api.js", "+1.5"],
+          ["bold", "code"],
+        ],
+      },
+    ]);
+  });
+
+  it("returns empty blocks for whitespace-only input", () => {
+    expect(parseTelegramBlocks(" \n\n ")).toEqual([]);
+  });
+
+  it("keeps malformed emphasis as paragraph text instead of throwing", () => {
+    const blocks = parseTelegramBlocks("*text: *value**");
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      type: "paragraph",
+      inlines: [
+        {
+          type: "italic",
+          children: [
+            { type: "text", text: "text: " },
+            { type: "italic", children: [{ type: "text", text: "value" }] },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("degrades complex quote-list mixes to plain blocks", () => {
+    const input = ["> intro", "> - item 1", "> - item 2"].join("\n");
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "plain",
+        text: "> intro\n> - item 1\n> - item 2",
+      },
+    ]);
+  });
+
+  it("degrades nested lists to plain blocks", () => {
+    const input = ["- parent", "  - child"].join("\n");
+
+    expect(parseTelegramBlocks(input)).toEqual([
+      {
+        type: "plain",
+        text: "- parent\n- child",
+      },
+    ]);
+  });
+
+  it("degrades unsupported html blocks to plain text", () => {
+    expect(parseTelegramBlocks("<div>hello</div>")).toEqual([
+      {
+        type: "plain",
+        text: "<div>hello</div>",
+      },
+    ]);
+  });
+});

--- a/tests/telegram/render/block-renderer.test.ts
+++ b/tests/telegram/render/block-renderer.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { renderTelegramBlock } from "../../../src/telegram/render/block-renderer.js";
+import type { TelegramBlock } from "../../../src/telegram/render/types.js";
+
+describe("telegram/render/block-renderer", () => {
+  it("renders paragraph blocks with inline entities", () => {
+    const block: TelegramBlock = {
+      type: "paragraph",
+      inlines: [
+        { type: "text", text: "Hello " },
+        { type: "bold", children: [{ type: "text", text: "bold" }] },
+        { type: "text", text: " " },
+        { type: "link", text: [{ type: "text", text: "site" }], url: "https://example.com" },
+      ],
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "paragraph",
+      mode: "full",
+      text: "Hello bold site",
+      entities: [
+        { type: "bold", offset: 6, length: 4 },
+        { type: "text_link", offset: 11, length: 4, url: "https://example.com" },
+      ],
+      fallbackText: "Hello bold site",
+      source: "entities",
+    });
+  });
+
+  it("renders headings as full-range bold with nested inline entities", () => {
+    const block: TelegramBlock = {
+      type: "heading",
+      level: 2,
+      inlines: [
+        { type: "text", text: "Read " },
+        { type: "italic", children: [{ type: "text", text: "this" }] },
+      ],
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "heading",
+      mode: "full",
+      text: "Read this",
+      entities: [
+        { type: "bold", offset: 0, length: 9 },
+        { type: "italic", offset: 5, length: 4 },
+      ],
+      fallbackText: "Read this",
+      source: "entities",
+    });
+  });
+
+  it("renders blockquotes with literal prefixes instead of blockquote entities", () => {
+    const block: TelegramBlock = {
+      type: "blockquote",
+      lines: [
+        [
+          { type: "text", text: "Note " },
+          { type: "bold", children: [{ type: "text", text: "this" }] },
+        ],
+        [{ type: "text", text: "Second line" }],
+      ],
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "blockquote",
+      mode: "full",
+      text: "> Note this\n> Second line",
+      entities: [{ type: "bold", offset: 7, length: 4 }],
+      fallbackText: "> Note this\n> Second line",
+      source: "entities",
+    });
+  });
+
+  it("renders ordered lists with rebased item entities", () => {
+    const block: TelegramBlock = {
+      type: "list",
+      ordered: true,
+      items: [
+        [
+          { type: "text", text: "Open " },
+          { type: "code", text: "api.js" },
+        ],
+        [
+          { type: "text", text: "Call " },
+          { type: "link", text: [{ type: "text", text: "docs" }], url: "https://example.com/docs" },
+        ],
+      ],
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "list",
+      mode: "full",
+      text: "1. Open api.js\n2. Call docs",
+      entities: [
+        { type: "code", offset: 8, length: 6 },
+        { type: "text_link", offset: 23, length: 4, url: "https://example.com/docs" },
+      ],
+      fallbackText: "1. Open api.js\n2. Call docs",
+      source: "entities",
+    });
+  });
+
+  it("renders code blocks as pre entities", () => {
+    const block: TelegramBlock = {
+      type: "code",
+      language: "ts",
+      text: "const x = 1;",
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "code",
+      mode: "full",
+      text: "const x = 1;",
+      entities: [{ type: "pre", offset: 0, length: 12, language: "ts" }],
+      fallbackText: "const x = 1;",
+      source: "entities",
+    });
+  });
+
+  it("renders tables as aligned preformatted text", () => {
+    const block: TelegramBlock = {
+      type: "table",
+      rows: [
+        ["Name", "Score"],
+        ["api.js", "+1.5"],
+        ["alert()", "-1.5"],
+      ],
+    };
+
+    expect(renderTelegramBlock(block)).toEqual({
+      blockType: "table",
+      mode: "full",
+      text: "Name    | Score\n--------|------\napi.js  | +1.5 \nalert() | -1.5 ",
+      entities: [{ type: "pre", offset: 0, length: 63 }],
+      fallbackText: "Name    | Score\n--------|------\napi.js  | +1.5 \nalert() | -1.5 ",
+      source: "entities",
+    });
+  });
+
+  it("renders rules and plain blocks without entities", () => {
+    expect(renderTelegramBlock({ type: "rule" })).toEqual({
+      blockType: "rule",
+      mode: "full",
+      text: "──────────",
+      fallbackText: "──────────",
+      source: "plain",
+    });
+
+    expect(renderTelegramBlock({ type: "plain", text: "raw text" })).toEqual({
+      blockType: "plain",
+      mode: "full",
+      text: "raw text",
+      fallbackText: "raw text",
+      source: "plain",
+    });
+  });
+
+  it("renders line-by-line mode and degrades only the broken line", () => {
+    const block: TelegramBlock = {
+      type: "paragraph",
+      inlines: [
+        { type: "text", text: "good line\n" },
+        { type: "link", text: [{ type: "text", text: "bad line" }], url: "javascript:alert(1)" },
+      ],
+    };
+
+    expect(renderTelegramBlock(block, "line-by-line")).toEqual({
+      blockType: "paragraph",
+      mode: "line-by-line",
+      text: "good line\nbad line",
+      fallbackText: "good line\nbad line",
+      source: "plain",
+    });
+  });
+});

--- a/tests/telegram/render/chunker.test.ts
+++ b/tests/telegram/render/chunker.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import { chunkTelegramRenderedBlocks } from "../../../src/telegram/render/chunker.js";
+import type { TelegramRenderedBlock } from "../../../src/telegram/render/types.js";
+
+describe("telegram/render/chunker", () => {
+  it("joins small blocks with separators and rebases entities", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "Hello",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+        fallbackText: "Hello",
+        source: "entities",
+      },
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "world",
+        entities: [{ type: "italic", offset: 0, length: 5 }],
+        fallbackText: "world",
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 20 })).toEqual([
+      {
+        text: "Hello\n\nworld",
+        entities: [
+          { type: "bold", offset: 0, length: 5 },
+          { type: "italic", offset: 7, length: 5 },
+        ],
+        fallbackText: "Hello\n\nworld",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("flushes the current part when the next block no longer fits", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "paragraph",
+        mode: "plain",
+        text: "12345678",
+        fallbackText: "12345678",
+        source: "plain",
+      },
+      {
+        blockType: "paragraph",
+        mode: "plain",
+        text: "abcdefgh",
+        fallbackText: "abcdefgh",
+        source: "plain",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 12 })).toEqual([
+      {
+        text: "12345678",
+        fallbackText: "12345678",
+        source: "plain",
+      },
+      {
+        text: "abcdefgh",
+        fallbackText: "abcdefgh",
+        source: "plain",
+      },
+    ]);
+  });
+
+  it("splits long rich paragraphs on newline boundaries and rebases entities", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "one\ntwo\nthree",
+        entities: [{ type: "bold", offset: 8, length: 5 }],
+        fallbackText: "one\ntwo\nthree",
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 8 })).toEqual([
+      {
+        text: "one\ntwo\n",
+        fallbackText: "one\ntwo\n",
+        source: "plain",
+      },
+      {
+        text: "three",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+        fallbackText: "three",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("does not split inside surrogate pairs", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "plain",
+        mode: "plain",
+        text: "A😀B",
+        fallbackText: "A😀B",
+        source: "plain",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 2 })).toEqual([
+      {
+        text: "A",
+        fallbackText: "A",
+        source: "plain",
+      },
+      {
+        text: "😀",
+        fallbackText: "😀",
+        source: "plain",
+      },
+      {
+        text: "B",
+        fallbackText: "B",
+        source: "plain",
+      },
+    ]);
+  });
+
+  it("splits oversized pre blocks and keeps pre entities", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "code",
+        mode: "full",
+        text: "first line\nsecond line\nthird line",
+        entities: [{ type: "pre", offset: 0, length: 33, language: "ts" }],
+        fallbackText: "first line\nsecond line\nthird line",
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 15 })).toEqual([
+      {
+        text: "first line\n",
+        entities: [{ type: "pre", offset: 0, length: 11, language: "ts" }],
+        fallbackText: "first line\n",
+        source: "entities",
+      },
+      {
+        text: "second line\n",
+        entities: [{ type: "pre", offset: 0, length: 12, language: "ts" }],
+        fallbackText: "second line\n",
+        source: "entities",
+      },
+      {
+        text: "third line",
+        entities: [{ type: "pre", offset: 0, length: 10, language: "ts" }],
+        fallbackText: "third line",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("splits oversized tables on line boundaries as pre blocks", () => {
+    const text = "Name    | Score\n--------|------\napi.js  | +1.5 \nalert() | -1.5 ";
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "table",
+        mode: "full",
+        text,
+        entities: [{ type: "pre", offset: 0, length: text.length }],
+        fallbackText: text,
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 25 })).toEqual([
+      {
+        text: "Name    | Score\n",
+        entities: [{ type: "pre", offset: 0, length: 16 }],
+        fallbackText: "Name    | Score\n",
+        source: "entities",
+      },
+      {
+        text: "--------|------\n",
+        entities: [{ type: "pre", offset: 0, length: 16 }],
+        fallbackText: "--------|------\n",
+        source: "entities",
+      },
+      {
+        text: "api.js  | +1.5 \n",
+        entities: [{ type: "pre", offset: 0, length: 16 }],
+        fallbackText: "api.js  | +1.5 \n",
+        source: "entities",
+      },
+      {
+        text: "alert() | -1.5 ",
+        entities: [{ type: "pre", offset: 0, length: 15 }],
+        fallbackText: "alert() | -1.5 ",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("falls back whole rich blocks to plain when one link span exceeds the limit", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "verylonglink",
+        entities: [{ type: "text_link", offset: 0, length: 12, url: "https://example.com" }],
+        fallbackText: "verylonglink",
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 5 })).toEqual([
+      {
+        text: "veryl",
+        fallbackText: "veryl",
+        source: "plain",
+      },
+      {
+        text: "ongli",
+        fallbackText: "ongli",
+        source: "plain",
+      },
+      {
+        text: "nk",
+        fallbackText: "nk",
+        source: "plain",
+      },
+    ]);
+  });
+
+  it("falls back whole rich blocks to plain when one inline code span exceeds the limit", () => {
+    const blocks: TelegramRenderedBlock[] = [
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "inlinecode",
+        entities: [{ type: "code", offset: 0, length: 10 }],
+        fallbackText: "inlinecode",
+        source: "entities",
+      },
+    ];
+
+    expect(chunkTelegramRenderedBlocks(blocks, { maxPartLength: 4 })).toEqual([
+      {
+        text: "inli",
+        fallbackText: "inli",
+        source: "plain",
+      },
+      {
+        text: "neco",
+        fallbackText: "neco",
+        source: "plain",
+      },
+      {
+        text: "de",
+        fallbackText: "de",
+        source: "plain",
+      },
+    ]);
+  });
+});

--- a/tests/telegram/render/inline-renderer.test.ts
+++ b/tests/telegram/render/inline-renderer.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramBlocks } from "../../../src/telegram/render/block-parser.js";
+import {
+  renderInlineNodes,
+  renderInlineNodesValidated,
+} from "../../../src/telegram/render/inline-renderer.js";
+import type { InlineNode } from "../../../src/telegram/render/types.js";
+
+describe("telegram/render/inline-renderer", () => {
+  it("renders supported inline nodes into text and entities", () => {
+    const nodes: InlineNode[] = [
+      { type: "text", text: "Hello " },
+      { type: "bold", children: [{ type: "text", text: "bold" }] },
+      { type: "text", text: " " },
+      { type: "italic", children: [{ type: "text", text: "italic" }] },
+      { type: "text", text: " " },
+      { type: "strike", children: [{ type: "text", text: "strike" }] },
+      { type: "text", text: " " },
+      { type: "underline", children: [{ type: "text", text: "under" }] },
+      { type: "text", text: " " },
+      { type: "spoiler", children: [{ type: "text", text: "spoiler" }] },
+      { type: "text", text: " " },
+      { type: "code", text: "code" },
+      { type: "text", text: " " },
+      {
+        type: "link",
+        text: [{ type: "text", text: "site" }],
+        url: "https://example.com",
+      },
+    ];
+
+    expect(renderInlineNodesValidated(nodes)).toEqual({
+      text: "Hello bold italic strike under spoiler code site",
+      entities: [
+        { type: "bold", offset: 6, length: 4 },
+        { type: "italic", offset: 11, length: 6 },
+        { type: "strikethrough", offset: 18, length: 6 },
+        { type: "underline", offset: 25, length: 5 },
+        { type: "spoiler", offset: 31, length: 7 },
+        { type: "code", offset: 39, length: 4 },
+        { type: "text_link", offset: 44, length: 4, url: "https://example.com" },
+      ],
+    });
+  });
+
+  it("counts UTF-16 offsets correctly for emoji and surrogate pairs", () => {
+    const nodes: InlineNode[] = [
+      { type: "text", text: "A" },
+      {
+        type: "bold",
+        children: [
+          { type: "text", text: "😀" },
+          { type: "italic", children: [{ type: "text", text: "B𠌕" }] },
+        ],
+      },
+    ];
+
+    expect(renderInlineNodesValidated(nodes)).toEqual({
+      text: "A😀B𠌕",
+      entities: [
+        { type: "bold", offset: 1, length: 5 },
+        { type: "italic", offset: 3, length: 3 },
+      ],
+    });
+  });
+
+  it("renders mixed cyrillic and emoji content", () => {
+    const nodes: InlineNode[] = [
+      {
+        type: "link",
+        text: [{ type: "text", text: "Привет 😀" }],
+        url: "https://example.com/hello",
+      },
+      { type: "text", text: " " },
+      { type: "underline", children: [{ type: "text", text: "мир" }] },
+    ];
+
+    expect(renderInlineNodesValidated(nodes)).toEqual({
+      text: "Привет 😀 мир",
+      entities: [
+        { type: "text_link", offset: 0, length: 9, url: "https://example.com/hello" },
+        { type: "underline", offset: 10, length: 3 },
+      ],
+    });
+  });
+
+  it("supports nested formatting and link-style overlap", () => {
+    const nodes: InlineNode[] = [
+      {
+        type: "bold",
+        children: [
+          { type: "text", text: "Go to " },
+          {
+            type: "link",
+            text: [
+              { type: "underline", children: [{ type: "text", text: "docs" }] },
+              { type: "text", text: " now" },
+            ],
+            url: "https://example.com/docs",
+          },
+        ],
+      },
+    ];
+
+    expect(renderInlineNodesValidated(nodes)).toEqual({
+      text: "Go to docs now",
+      entities: [
+        { type: "bold", offset: 0, length: 14 },
+        { type: "text_link", offset: 6, length: 8, url: "https://example.com/docs" },
+        { type: "underline", offset: 6, length: 4 },
+      ],
+    });
+  });
+
+  it("preserves code spans with unicode text", () => {
+    const nodes: InlineNode[] = [
+      { type: "text", text: "run " },
+      { type: "code", text: "npm тест 😀" },
+    ];
+
+    expect(renderInlineNodesValidated(nodes)).toEqual({
+      text: "run npm тест 😀",
+      entities: [{ type: "code", offset: 4, length: 11 }],
+    });
+  });
+
+  it("renders parser-produced inline nodes without validation errors", () => {
+    const blocks = parseTelegramBlocks(
+      "Hello **bold** *italic* ~~strike~~ `code` [site](https://example.com)",
+    );
+    const paragraph = blocks[0];
+
+    expect(paragraph).toMatchObject({ type: "paragraph" });
+    expect(paragraph.type).toBe("paragraph");
+
+    const rendered = renderInlineNodesValidated(paragraph.inlines);
+
+    expect(rendered.text).toBe("Hello bold italic strike code site");
+    expect(rendered.entities).toEqual([
+      { type: "bold", offset: 6, length: 4 },
+      { type: "italic", offset: 11, length: 6 },
+      { type: "strikethrough", offset: 18, length: 6 },
+      { type: "code", offset: 25, length: 4 },
+      { type: "text_link", offset: 30, length: 4, url: "https://example.com" },
+    ]);
+  });
+
+  it("keeps newline text nodes as plain text in the output", () => {
+    const nodes: InlineNode[] = [
+      { type: "text", text: "line 1" },
+      { type: "text", text: "\n" },
+      { type: "spoiler", children: [{ type: "text", text: "line 2" }] },
+    ];
+
+    expect(renderInlineNodes(nodes)).toEqual({
+      text: "line 1\nline 2",
+      entities: [{ type: "spoiler", offset: 7, length: 6 }],
+    });
+  });
+
+  it("throws when rendered entities violate validation rules", () => {
+    const nodes: InlineNode[] = [
+      {
+        type: "bold",
+        children: [{ type: "code", text: "bad" }],
+      },
+    ];
+
+    expect(() => renderInlineNodesValidated(nodes)).toThrow(/Invalid Telegram inline entities/);
+  });
+});

--- a/tests/telegram/render/markdown-normalizer.test.ts
+++ b/tests/telegram/render/markdown-normalizer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { normalizeMarkdownForTelegramRendering } from "../../../src/telegram/render/markdown-normalizer.js";
+import {
+  normalizeMarkdownForTelegramBlockParsing,
+  normalizeMarkdownForTelegramRendering,
+} from "../../../src/telegram/render/markdown-normalizer.js";
 
 describe("telegram/render/markdown-normalizer", () => {
   it("normalizes headings, quotes, horizontal rules, and checklists", () => {
@@ -65,5 +68,31 @@ describe("telegram/render/markdown-normalizer", () => {
     const input = "*text: *value**";
 
     expect(normalizeMarkdownForTelegramRendering(input)).toBe(input);
+  });
+
+  it("keeps structural markdown for parser-safe normalization", () => {
+    const input = [
+      "# Main heading",
+      "",
+      "> - [ ] Review",
+      "Follow-up line",
+      "",
+      "- [x] Done task",
+      "",
+      "---",
+    ].join("\n");
+
+    expect(normalizeMarkdownForTelegramBlockParsing(input)).toBe(
+      [
+        "# Main heading",
+        "",
+        "> - [ ] Review",
+        "> Follow-up line",
+        "",
+        "- [x] Done task",
+        "",
+        "---",
+      ].join("\n"),
+    );
   });
 });

--- a/tests/telegram/render/markdown-normalizer.test.ts
+++ b/tests/telegram/render/markdown-normalizer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMarkdownForTelegramRendering } from "../../../src/telegram/render/markdown-normalizer.js";
+
+describe("telegram/render/markdown-normalizer", () => {
+  it("normalizes headings, quotes, horizontal rules, and checklists", () => {
+    const input = [
+      "# Main heading",
+      "",
+      "> quoted line",
+      "Quote continues",
+      "",
+      "- [ ] Open task",
+      "- [x] Done task",
+      "1. [ ] Numbered task",
+      "",
+      "---",
+    ].join("\n");
+
+    expect(normalizeMarkdownForTelegramRendering(input)).toBe(
+      [
+        "**Main heading**",
+        "",
+        "> quoted line",
+        "> Quote continues",
+        "",
+        "🔲 Open task",
+        "✅ Done task",
+        "🔲 Numbered task",
+        "",
+        "──────────",
+      ].join("\n"),
+    );
+  });
+
+  it("normalizes checklists inside quotes and preserves quote mode", () => {
+    const input = ["> - [ ] Review", "Follow-up line", "- [x] Outside quote"].join("\n");
+
+    expect(normalizeMarkdownForTelegramRendering(input)).toBe(
+      ["> 🔲 Review", "> Follow-up line", "> ✅ Outside quote"].join("\n"),
+    );
+  });
+
+  it("resets quote mode after an empty line", () => {
+    const input = ["> quoted line", "", "Plain line"].join("\n");
+
+    expect(normalizeMarkdownForTelegramRendering(input)).toBe(
+      ["> quoted line", "", "Plain line"].join("\n"),
+    );
+  });
+
+  it("keeps fenced code blocks untouched", () => {
+    const input = [
+      "```ts",
+      "# Not a heading",
+      "> not a quote",
+      "- [ ] not a checklist",
+      "---",
+      "```",
+    ].join("\n");
+
+    expect(normalizeMarkdownForTelegramRendering(input)).toBe(input);
+  });
+
+  it("preserves malformed emphasis text without dropping content", () => {
+    const input = "*text: *value**";
+
+    expect(normalizeMarkdownForTelegramRendering(input)).toBe(input);
+  });
+});

--- a/tests/telegram/render/pipeline.test.ts
+++ b/tests/telegram/render/pipeline.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderTelegramBlocks,
+  renderTelegramParts,
+} from "../../../src/telegram/render/pipeline.js";
+import { validateTelegramEntities } from "../../../src/telegram/render/validator.js";
+
+describe("telegram/render/pipeline", () => {
+  it("renders markdown into block-level outputs", () => {
+    expect(renderTelegramBlocks("# Title\n\nParagraph with **bold**\n\n- item")).toEqual([
+      {
+        blockType: "heading",
+        mode: "full",
+        text: "Title",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+        fallbackText: "Title",
+        source: "entities",
+      },
+      {
+        blockType: "paragraph",
+        mode: "full",
+        text: "Paragraph with bold",
+        entities: [{ type: "bold", offset: 15, length: 4 }],
+        fallbackText: "Paragraph with bold",
+        source: "entities",
+      },
+      {
+        blockType: "list",
+        mode: "full",
+        text: "- item",
+        fallbackText: "- item",
+        source: "plain",
+      },
+    ]);
+  });
+
+  it("renders markdown into sized parts with block separators", () => {
+    const parts = renderTelegramParts("# Title\n\nParagraph with **bold**\n\n- item", {
+      maxPartLength: 100,
+    });
+
+    expect(parts).toEqual([
+      {
+        text: "Title\n\nParagraph with bold\n\n- item",
+        entities: [
+          { type: "bold", offset: 0, length: 5 },
+          { type: "bold", offset: 22, length: 4 },
+        ],
+        fallbackText: "Title\n\nParagraph with bold\n\n- item",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("splits long rich paragraphs into multiple valid parts", () => {
+    const parts = renderTelegramParts(
+      "Paragraph **bold** line\nParagraph **bold** line\nParagraph **bold** line",
+      {
+        maxPartLength: 24,
+      },
+    );
+
+    expect(parts.length).toBeGreaterThan(1);
+    expect(parts.every((part) => part.text.length <= 24)).toBe(true);
+    expect(parts.every((part) => validateTelegramEntities(part.text, part.entities ?? []).ok)).toBe(
+      true,
+    );
+  });
+
+  it("splits long code fences into multiple preformatted parts", () => {
+    const parts = renderTelegramParts(
+      "```ts\nconst first = 1;\nconst second = 2;\nconst third = 3;\n```",
+      { maxPartLength: 18 },
+    );
+
+    expect(parts).toEqual([
+      {
+        text: "const first = 1;\n",
+        entities: [{ type: "pre", offset: 0, length: 17, language: "ts" }],
+        fallbackText: "const first = 1;\n",
+        source: "entities",
+      },
+      {
+        text: "const second = 2;\n",
+        entities: [{ type: "pre", offset: 0, length: 18, language: "ts" }],
+        fallbackText: "const second = 2;\n",
+        source: "entities",
+      },
+      {
+        text: "const third = 3;",
+        entities: [{ type: "pre", offset: 0, length: 16, language: "ts" }],
+        fallbackText: "const third = 3;",
+        source: "entities",
+      },
+    ]);
+  });
+
+  it("splits long tables into multiple preformatted parts", () => {
+    const parts = renderTelegramParts(
+      "| Name | Score |\n| --- | --- |\n| api.js | +1.5 |\n| alert() | -1.5 |",
+      { maxPartLength: 25 },
+    );
+
+    expect(parts.every((part) => part.entities?.[0]?.type === "pre")).toBe(true);
+    expect(parts.every((part) => part.text.length <= 25)).toBe(true);
+  });
+
+  it("degrades oversized single links to plain parts without affecting neighboring blocks", () => {
+    const markdown = [
+      "Safe **block**.",
+      "",
+      "[averyveryverylonglink](https://example.com)",
+      "",
+      "Another **safe** block.",
+    ].join("\n");
+
+    const parts = renderTelegramParts(markdown, { maxPartLength: 12 });
+
+    expect(parts.length).toBeGreaterThan(2);
+    expect(parts.some((part) => part.entities?.some((entity) => entity.type === "bold"))).toBe(
+      true,
+    );
+    expect(parts.some((part) => part.source === "plain" && part.text.includes("avery"))).toBe(true);
+  });
+});

--- a/tests/telegram/render/validator.test.ts
+++ b/tests/telegram/render/validator.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { MessageEntity } from "grammy/types";
+import { validateTelegramEntities } from "../../../src/telegram/render/validator.js";
+
+describe("telegram/render/validator", () => {
+  it("accepts nested style entities and style-link nesting", () => {
+    const text = "hello world";
+    const entities: MessageEntity[] = [
+      { type: "bold", offset: 0, length: 11 },
+      { type: "italic", offset: 6, length: 5 },
+      { type: "text_link", offset: 0, length: 5, url: "https://example.com" },
+      { type: "underline", offset: 0, length: 5 },
+    ];
+
+    expect(validateTelegramEntities(text, entities)).toEqual({ ok: true, issues: [] });
+  });
+
+  it("rejects invalid offsets and lengths", () => {
+    const result = validateTelegramEntities("hello", [
+      { type: "bold", offset: -1, length: 2 },
+      { type: "italic", offset: 1, length: 0 },
+      { type: "underline", offset: 4, length: 2 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual([
+      "invalid_offset",
+      "invalid_length",
+      "range_out_of_bounds",
+    ]);
+  });
+
+  it("rejects partial overlaps", () => {
+    const result = validateTelegramEntities("hello world", [
+      { type: "bold", offset: 0, length: 5 },
+      { type: "italic", offset: 3, length: 5 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]?.code).toBe("partial_overlap");
+  });
+
+  it("rejects any overlap with code entities", () => {
+    const result = validateTelegramEntities("hello", [
+      { type: "code", offset: 0, length: 5 },
+      { type: "bold", offset: 0, length: 5 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]?.code).toBe("code_overlap");
+  });
+
+  it("rejects nested links and duplicate same-range entities", () => {
+    const result = validateTelegramEntities("hello world", [
+      { type: "text_link", offset: 0, length: 11, url: "https://example.com" },
+      { type: "text_link", offset: 6, length: 5, url: "https://example.org" },
+      { type: "bold", offset: 0, length: 5 },
+      { type: "bold", offset: 0, length: 5 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual([
+      "nested_link",
+      "duplicate_entity_range",
+    ]);
+  });
+
+  it("rejects invalid link urls", () => {
+    const result = validateTelegramEntities("hello", [
+      { type: "text_link", offset: 0, length: 5, url: "javascript:alert(1)" },
+    ]);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues[0]?.code).toBe("invalid_link_url");
+  });
+});


### PR DESCRIPTION
## Description of changes

 use entities-first markdown rendering in replies and streaming

## How it was tested

With tests and manually

## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
