### PR TITLE
feat: add HIDE_TOOL_FILE_MESSAGES env var to suppress file edit documents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,9 @@ OPENCODE_MODEL_ID=big-pickle
 # Hide tool call service messages (default: false)
 # HIDE_TOOL_CALL_MESSAGES=false
 
+# Hide tool file edit documents sent as .txt attachments (default: false)
+# HIDE_TOOL_FILE_MESSAGES=false
+
 # Assistant message formatting mode (default: markdown)
 # markdown = convert assistant replies to Telegram MarkdownV2
 # raw = show assistant replies as plain text

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `SERVICE_MESSAGES_INTERVAL_SEC` | Service messages interval (thinking + tool calls); keep `>=2` to avoid Telegram rate limits, `0` = immediate |    No    | `5`                      |
 | `HIDE_THINKING_MESSAGES`        | Hide `💭 Thinking...` service messages                                                                       |    No    | `false`                  |
 | `HIDE_TOOL_CALL_MESSAGES`       | Hide tool-call service messages (`💻 bash ...`, `📖 read ...`, etc.)                                         |    No    | `false`                  |
+| `HIDE_TOOL_FILE_MESSAGES`       | Hide file edit documents sent as `.txt` attachments (`edit_*.txt`, `write_*.txt`)                            |    No    | `false`                  |
 | `RESPONSE_STREAMING`            | Stream assistant replies while they are generated across one or more Telegram messages                       |    No    | `true`                   |
 | `MESSAGE_FORMAT_MODE`           | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw`                                   |    No    | `markdown`               |
 | `CODE_FILE_MAX_SIZE_KB`         | Max file size (KB) to send as document                                                                       |    No    | `100`                    |

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -546,6 +546,10 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       return;
     }
 
+    if (config.bot.hideToolFileMessages) {
+      return;
+    }
+
     try {
       await toolCallStreamer.breakSession(fileInfo.sessionId, "tool_file_boundary");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,7 @@ export const config = {
     locale: getOptionalLocaleEnvVar("BOT_LOCALE", "en"),
     hideThinkingMessages: getOptionalBooleanEnvVar("HIDE_THINKING_MESSAGES", false),
     hideToolCallMessages: getOptionalBooleanEnvVar("HIDE_TOOL_CALL_MESSAGES", false),
+    hideToolFileMessages: getOptionalBooleanEnvVar("HIDE_TOOL_FILE_MESSAGES", false),
     messageFormatMode: getOptionalMessageFormatModeEnvVar("MESSAGE_FORMAT_MODE", "markdown"),
   },
   files: {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,41 +17,49 @@ describe("config boolean env parsing", () => {
   it("uses false defaults for hide service message flags", async () => {
     vi.stubEnv("HIDE_THINKING_MESSAGES", "");
     vi.stubEnv("HIDE_TOOL_CALL_MESSAGES", "");
+    vi.stubEnv("HIDE_TOOL_FILE_MESSAGES", "");
 
     const config = await loadConfig();
 
     expect(config.bot.hideThinkingMessages).toBe(false);
     expect(config.bot.hideToolCallMessages).toBe(false);
+    expect(config.bot.hideToolFileMessages).toBe(false);
   });
 
   it("parses truthy values for hide service message flags", async () => {
     vi.stubEnv("HIDE_THINKING_MESSAGES", "YES");
     vi.stubEnv("HIDE_TOOL_CALL_MESSAGES", "1");
+    vi.stubEnv("HIDE_TOOL_FILE_MESSAGES", "true");
 
     const config = await loadConfig();
 
     expect(config.bot.hideThinkingMessages).toBe(true);
     expect(config.bot.hideToolCallMessages).toBe(true);
+    expect(config.bot.hideToolFileMessages).toBe(true);
   });
 
   it("parses falsy values for hide service message flags", async () => {
     vi.stubEnv("HIDE_THINKING_MESSAGES", "off");
     vi.stubEnv("HIDE_TOOL_CALL_MESSAGES", "0");
+    vi.stubEnv("HIDE_TOOL_FILE_MESSAGES", "false");
 
     const config = await loadConfig();
 
     expect(config.bot.hideThinkingMessages).toBe(false);
     expect(config.bot.hideToolCallMessages).toBe(false);
+    expect(config.bot.hideToolFileMessages).toBe(false);
   });
 
   it("falls back to defaults on invalid values", async () => {
     vi.stubEnv("HIDE_THINKING_MESSAGES", "banana");
     vi.stubEnv("HIDE_TOOL_CALL_MESSAGES", "nope");
+    vi.stubEnv("HIDE_TOOL_FILE_MESSAGES", "invalid");
 
     const config = await loadConfig();
 
     expect(config.bot.hideThinkingMessages).toBe(false);
     expect(config.bot.hideToolCallMessages).toBe(false);
+    expect(config.bot.hideToolFileMessages).toBe(false);
   });
 
   it("uses markdown as default message format mode", async () => {


### PR DESCRIPTION
## Summary

Adds a new `HIDE_TOOL_FILE_MESSAGES` configuration flag that prevents the bot from sending `edit_*.txt` and `write_*.txt` code file attachments to Telegram.

## Motivation

When the bot edits or writes files, it currently sends every change as a `.txt` document to Telegram. For users working on larger tasks, this creates a lot of noise in the chat. This PR gives users an opt-in way to suppress those file-edit documents while still receiving all streaming text responses and pinned diff summaries.

## Changes

- `src/config.ts`: Parse `HIDE_TOOL_FILE_MESSAGES` env var
- `src/bot/index.ts`: Skip `enqueueFile` in `setOnToolFile` when the flag is `true`
- `.env.example`: Document the new option
- `README.md`: Add the new env var to the configuration table
- `tests/config.test.ts`: Update tests to cover the new flag

## Usage

```env
HIDE_TOOL_FILE_MESSAGES=true
```