### PR TITLE
fix: show git worktrees as selectable projects

### DIFF
--- a/src/project/manager.ts
+++ b/src/project/manager.ts
@@ -1,5 +1,3 @@
-import { readFile, stat } from "node:fs/promises";
-import path from "node:path";
 import { opencodeClient } from "../opencode/client.js";
 import { ProjectInfo } from "../settings/manager.js";
 import { getCachedSessionProjects } from "../session/cache-manager.js";
@@ -7,33 +5,6 @@ import { logger } from "../utils/logger.js";
 
 interface InternalProject extends ProjectInfo {
   lastUpdated: number;
-}
-
-async function isLinkedGitWorktree(worktree: string): Promise<boolean> {
-  if (worktree === "/") {
-    return false;
-  }
-
-  const gitPath = path.join(worktree, ".git");
-
-  try {
-    const gitStat = await stat(gitPath);
-
-    if (!gitStat.isFile()) {
-      return false;
-    }
-
-    const gitPointer = (await readFile(gitPath, "utf-8")).trim();
-    const match = gitPointer.match(/^gitdir:\s*(.+)$/i);
-    if (!match) {
-      return false;
-    }
-
-    const gitDir = path.resolve(worktree, match[1].trim()).replace(/\\/g, "/").toLowerCase();
-    return gitDir.includes("/.git/worktrees/");
-  } catch {
-    return false;
-  }
 }
 
 function worktreeKey(worktree: string): string {
@@ -84,22 +55,36 @@ export async function getProjects(): Promise<ProjectInfo[]> {
     });
   }
 
+  // Include worktree paths from project sandboxes so git worktrees
+  // appear as selectable projects with their own session histories.
+  for (const apiProject of apiProjects) {
+    const rawSandboxes = (apiProject as unknown as { sandboxes?: string[] }).sandboxes;
+    if (Array.isArray(rawSandboxes)) {
+      for (const sandbox of rawSandboxes) {
+        if (typeof sandbox === "string" && sandbox.trim()) {
+          const key = worktreeKey(sandbox);
+          if (!mergedByWorktree.has(key)) {
+            mergedByWorktree.set(key, {
+              id: `${apiProject.id}_wt_${sandbox.split("/").pop()}`,
+              worktree: sandbox,
+              name: sandbox,
+              lastUpdated: apiProject.lastUpdated,
+            });
+          }
+        }
+      }
+    }
+  }
+
   const projectList = Array.from(mergedByWorktree.values()).sort(
     (left, right) => right.lastUpdated - left.lastUpdated,
   );
 
-  const linkedWorktreeFlags = await Promise.all(
-    projectList.map((project) => isLinkedGitWorktree(project.worktree)),
-  );
-
-  const visibleProjects = projectList.filter((_, index) => !linkedWorktreeFlags[index]);
-  const hiddenLinkedWorktrees = projectList.length - visibleProjects.length;
-
   logger.debug(
-    `[ProjectManager] Projects resolved: api=${projects.length}, cached=${cachedProjects.length}, hiddenLinkedWorktrees=${hiddenLinkedWorktrees}, total=${visibleProjects.length}`,
+    `[ProjectManager] Projects resolved: api=${projects.length}, cached=${cachedProjects.length}, total=${projectList.length}`,
   );
 
-  return visibleProjects.map(({ id, worktree, name }) => ({ id, worktree, name }));
+  return projectList.map(({ id, worktree, name }) => ({ id, worktree, name }));
 }
 
 export async function getProjectById(id: string): Promise<ProjectInfo> {


### PR DESCRIPTION
## Summary

- Git worktrees are currently filtered out of the project list by `isLinkedGitWorktree()`, making them invisible to the bot
- Users working in worktrees cannot access their sessions — `/projects` doesn't list them and `/open` fails when navigating to a worktree directory
- OpenCode stores worktree paths in the project's `sandboxes` field and supports listing sessions by worktree directory, but the bot ignores both

## Changes

- Remove the worktree exclusion filter in `getProjects()`
- Include worktree paths from the `sandboxes` field returned by the OpenCode project API
- Worktrees now appear as independent selectable projects with their own session histories
- Remove the now-unused `isLinkedGitWorktree()` function and its `fs/path` imports

## How to reproduce the bug

1. Create a git worktree: `git worktree add ../my-project-feature`
2. Open OpenCode in the worktree directory and create sessions
3. Start the Telegram bot and run `/projects` — the worktree doesn't appear
4. Try `/open` and navigate to the worktree — fails with "could not add project"

## After this fix

- `/projects` lists worktrees alongside regular projects
- `/open` successfully adds worktree directories
- `/sessions` shows sessions created in the worktree

## Test plan

- [x] Tested on ARM64 Ubuntu with git worktree of an existing repo
- [x] `/projects` shows both parent repo and worktree
- [x] `/sessions` lists worktree-specific sessions
- [x] `/open` can navigate to and select a worktree directory
- [x] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)