### PR TITLE
feat(bot): TELEGRAM_API_ROOT + TELEGRAM_PROXY_SECRET for reverse-proxy setups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ TELEGRAM_ALLOWED_USER_ID=
 #   TELEGRAM_PROXY_URL=http://proxy.example.com:8080
 # TELEGRAM_PROXY_URL=
 
+# Telegram Reverse-Proxy mode (optional, alternative to TELEGRAM_PROXY_URL)
+# For corporate networks that block api.telegram.org but allow your own server.
+# Point TELEGRAM_API_ROOT at an HTTPS endpoint that reverse-proxies to
+# https://api.telegram.org (e.g. nginx). Applied to Bot API calls AND file
+# downloads. TELEGRAM_PROXY_SECRET (optional) is sent as the X-Proxy-Secret
+# header so the reverse proxy can authorize callers. See README for an example
+# nginx config.
+# TELEGRAM_API_ROOT=https://tg-proxy.yourdomain.com
+# TELEGRAM_PROXY_SECRET=some-long-random-string
+
 # OpenCode API URL (optional, default: http://localhost:4096)
 # OPENCODE_API_URL=http://localhost:4096
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `TELEGRAM_BOT_TOKEN`                       | Bot token from @BotFather                                                                                             |   Yes    | —                        |
 | `TELEGRAM_ALLOWED_USER_ID`                 | Your numeric Telegram user ID                                                                                         |   Yes    | —                        |
 | `TELEGRAM_PROXY_URL`                       | Proxy URL for Telegram API (SOCKS5/HTTP)                                                                              |    No    | —                        |
+| `TELEGRAM_API_ROOT`                        | Custom Telegram Bot API root URL (e.g. nginx reverse-proxying `api.telegram.org`); applied to API calls and file downloads | No | `https://api.telegram.org` |
+| `TELEGRAM_PROXY_SECRET`                    | Shared secret sent as `X-Proxy-Secret` header on every Bot API request and file download (used with `TELEGRAM_API_ROOT`) | No | —                        |
 | `OPENCODE_API_URL`                         | OpenCode server URL                                                                                                   |    No    | `http://localhost:4096`  |
 | `OPENCODE_AUTO_RESTART_ENABLED`            | Automatically restart a local OpenCode server when health-checks fail                                                 |    No    | `false`                  |
 | `OPENCODE_MONITOR_INTERVAL_SEC`            | Health monitor interval in seconds when OpenCode auto-restart is enabled                                              |    No    | `300`                    |
@@ -238,6 +240,44 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 > **Keep your `.env` file private.** It contains your bot token. Never commit it to version control.
 
 Logs are written to `./logs` when running from sources and to the runtime config directory `logs/` folder in `installed` mode. Log rotation depends on runtime mode: `sources` creates one file per bot launch, while `installed` appends to one file per day. Old log files are removed according to `LOG_RETENTION`.
+
+### Reverse Proxy (Optional)
+
+For environments that block `api.telegram.org` but allow your own HTTPS endpoint (corporate networks, restricted regions), you can route Bot API traffic through a reverse proxy you control. This is an alternative to the SOCKS/HTTP forward proxy configured with `TELEGRAM_PROXY_URL`.
+
+Set `TELEGRAM_API_ROOT` to your reverse-proxy URL — both Bot API calls and file downloads (including voice/audio files) will use it. Optionally set `TELEGRAM_PROXY_SECRET` so the bot sends an `X-Proxy-Secret` header your proxy can use to authorize callers.
+
+`.env`:
+
+```env
+TELEGRAM_API_ROOT=https://tg-proxy.yourdomain.com
+TELEGRAM_PROXY_SECRET=some-long-random-string
+```
+
+Example nginx config:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name tg-proxy.yourdomain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/tg-proxy.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/tg-proxy.yourdomain.com/privkey.pem;
+
+    access_log off;  # the bot token appears in URL paths
+    client_max_body_size 50m;
+
+    if ($http_x_proxy_secret != "some-long-random-string") { return 403; }
+
+    location / {
+        proxy_pass https://api.telegram.org;
+        proxy_ssl_server_name on;
+        proxy_set_header Host api.telegram.org;
+    }
+}
+```
+
+`TELEGRAM_API_ROOT` and `TELEGRAM_PROXY_URL` are independent — the former picks the URL the bot connects to (a reverse proxy on your side), the latter tunnels TCP through a forward proxy. They can be combined, though that is unusual.
 
 ### Voice and Audio Transcription (Optional)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "grammy": "^1.39.2",
         "https-proxy-agent": "^7.0.6",
         "mdast-util-to-string": "^4.0.0",
+        "node-fetch": "^2.7.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "socks-proxy-agent": "^8.0.5",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "grammy": "^1.39.2",
     "https-proxy-agent": "^7.0.6",
     "mdast-util-to-string": "^4.0.0",
+    "node-fetch": "^2.7.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "socks-proxy-agent": "^8.0.5",

--- a/src/bot/handlers/voice.ts
+++ b/src/bot/handlers/voice.ts
@@ -40,9 +40,13 @@ async function downloadTelegramFileByUrl(url: string, redirectDepth: number = 0)
     const targetUrl = new URL(url);
     const requestModule = targetUrl.protocol === "http:" ? http : https;
 
+    const proxySecret = config.telegram.proxySecret;
     const request = requestModule.get(
       targetUrl,
-      { agent: getTelegramDownloadAgent() },
+      {
+        agent: getTelegramDownloadAgent(),
+        ...(proxySecret ? { headers: { "X-Proxy-Secret": proxySecret } } : {}),
+      },
       (response) => {
         const statusCode = response.statusCode ?? 0;
 
@@ -123,7 +127,8 @@ async function downloadTelegramFile(
       return null;
     }
 
-    const fileUrl = `https://api.telegram.org/file/bot${ctx.api.token}/${file.file_path}`;
+    const apiRoot = (config.telegram.apiRoot ?? "https://api.telegram.org").replace(/\/$/, "");
+    const fileUrl = `${apiRoot}/file/bot${ctx.api.token}/${file.file_path}`;
 
     logger.debug(`[Voice] Downloading file: ${file.file_path} (${file.file_size ?? "?"} bytes)`);
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error — node-fetch v2 ships no TS types and we avoid adding @types/node-fetch
+import nodeFetch from "node-fetch";
 import { Bot, Context, InputFile, NextFunction } from "grammy";
 import { promises as fs } from "fs";
 import * as path from "path";
@@ -1057,6 +1059,31 @@ export function createBot(): Bot<Context> {
   }
 
   const botOptions: ConstructorParameters<typeof Bot<Context>>[1] = {};
+
+  if (config.telegram.apiRoot || config.telegram.proxySecret) {
+    botOptions.client = botOptions.client ?? {};
+    if (config.telegram.apiRoot) {
+      botOptions.client.apiRoot = config.telegram.apiRoot;
+      logger.info(`[Bot] Using custom Telegram API root: ${config.telegram.apiRoot}`);
+    }
+    if (config.telegram.proxySecret) {
+      // Inject the shared-secret header via a custom fetch wrapper instead of
+      // baseFetchConfig.headers, because grammY's client spreads
+      // `{...baseFetchConfig, ...config}` and the per-request config.headers
+      // (Content-Type/Length) wipes out anything we put on baseFetchConfig.
+      // Plain-object headers merge (not the Headers class) keeps this compatible
+      // with node-fetch v2's init shape and avoids the DOM lib HeadersInit type.
+      const proxySecret = config.telegram.proxySecret;
+      botOptions.client.fetch = (((url: unknown, init: Record<string, unknown> | undefined) => {
+        const existing = (init?.headers as Record<string, string> | undefined) ?? {};
+        const merged = { ...existing, "X-Proxy-Secret": proxySecret };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (nodeFetch as any)(url, { ...(init ?? {}), headers: merged });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any);
+      logger.info(`[Bot] Sending X-Proxy-Secret header to Telegram API root`);
+    }
+  }
 
   if (config.telegram.proxyUrl) {
     const proxyUrl = config.telegram.proxyUrl;

--- a/src/bot/utils/file-download.ts
+++ b/src/bot/utils/file-download.ts
@@ -2,7 +2,13 @@ import type { Api } from "grammy";
 import { config } from "../../config.js";
 import { logger } from "../../utils/logger.js";
 
-const TELEGRAM_FILE_URL_BASE = "https://api.telegram.org/file/bot";
+const DEFAULT_TELEGRAM_FILE_URL_BASE = "https://api.telegram.org/file/bot";
+
+function fileUrlBase(): string {
+  return config.telegram.apiRoot
+    ? `${config.telegram.apiRoot.replace(/\/$/, "")}/file/bot`
+    : DEFAULT_TELEGRAM_FILE_URL_BASE;
+}
 const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB Telegram limit
 
 export interface DownloadedFile {
@@ -31,7 +37,7 @@ export async function downloadTelegramFile(api: Api, fileId: string): Promise<Do
     throw new Error(`File too large: ${sizeMb}MB (max 20MB)`);
   }
 
-  const fileUrl = `${TELEGRAM_FILE_URL_BASE}${config.telegram.token}/${file.file_path}`;
+  const fileUrl = `${fileUrlBase()}${config.telegram.token}/${file.file_path}`;
   logger.debug(`[FileDownload] Downloading from ${fileUrl.replace(config.telegram.token, "***")}`);
 
   const fetchOptions: RequestInit & { agent?: unknown } = {};
@@ -40,6 +46,14 @@ export async function downloadTelegramFile(api: Api, fileId: string): Promise<Do
   if (config.telegram.proxyUrl) {
     const { HttpsProxyAgent } = await import("https-proxy-agent");
     fetchOptions.agent = new HttpsProxyAgent(config.telegram.proxyUrl);
+  }
+
+  // Send shared secret when custom API root expects it
+  if (config.telegram.proxySecret) {
+    fetchOptions.headers = {
+      ...(fetchOptions.headers as Record<string, string> | undefined),
+      "X-Proxy-Secret": config.telegram.proxySecret,
+    };
   }
 
   const response = await fetch(fileUrl, fetchOptions);

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,12 +93,44 @@ function getOptionalTtsProviderEnvVar(key: string, defaultValue: TtsProvider): T
   return defaultValue;
 }
 
-export const config = {
-  telegram: {
+export function buildTelegramConfig(): {
+  token: string;
+  allowedUserId: number;
+  proxyUrl: string;
+  apiRoot: string;
+  proxySecret: string;
+} {
+  const proxyUrl = getEnvVar("TELEGRAM_PROXY_URL", false);
+  // grammY rejects an apiRoot ending with `/`, so normalize once at config
+  // load instead of leaking the concern into every consumer.
+  const apiRoot = getEnvVar("TELEGRAM_API_ROOT", false).replace(/\/+$/, "");
+  const proxySecret = getEnvVar("TELEGRAM_PROXY_SECRET", false);
+
+  if (proxyUrl && apiRoot) {
+    throw new Error(
+      "TELEGRAM_PROXY_URL and TELEGRAM_API_ROOT are alternative connectivity modes and cannot be used together. " +
+        "TELEGRAM_PROXY_URL tunnels TCP through a SOCKS/HTTP forward proxy; " +
+        "TELEGRAM_API_ROOT routes API calls through an HTTPS reverse proxy. Pick one.",
+    );
+  }
+  if (proxySecret && !apiRoot) {
+    throw new Error(
+      "TELEGRAM_PROXY_SECRET requires TELEGRAM_API_ROOT to be set. " +
+        "Without a custom API root, the secret header would be sent to api.telegram.org.",
+    );
+  }
+
+  return {
     token: getEnvVar("TELEGRAM_BOT_TOKEN"),
     allowedUserId: parseInt(getEnvVar("TELEGRAM_ALLOWED_USER_ID"), 10),
-    proxyUrl: getEnvVar("TELEGRAM_PROXY_URL", false),
-  },
+    proxyUrl,
+    apiRoot,
+    proxySecret,
+  };
+}
+
+export const config = {
+  telegram: buildTelegramConfig(),
   opencode: {
     apiUrl: getEnvVar("OPENCODE_API_URL", false) || "http://localhost:4096",
     username: getEnvVar("OPENCODE_SERVER_USERNAME", false) || "opencode",

--- a/tests/bot/utils/file-download.test.ts
+++ b/tests/bot/utils/file-download.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Api } from "grammy";
 import {
   toDataUri,
   formatFileSize,
@@ -106,5 +107,100 @@ describe("bot/utils/file-download", () => {
     it("returns false for empty string", () => {
       expect(isTextMimeType("")).toBe(false);
     });
+  });
+});
+
+describe("downloadTelegramFile reverse-proxy wiring", () => {
+  beforeEach(() => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "bot-token-xyz");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "123456789");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    vi.stubEnv("TELEGRAM_PROXY_URL", "");
+    vi.stubEnv("TELEGRAM_API_ROOT", "");
+    vi.stubEnv("TELEGRAM_PROXY_SECRET", "");
+  });
+
+  function makeApiStub(): Api {
+    return {
+      getFile: vi.fn().mockResolvedValue({
+        file_path: "voice/sample.ogg",
+        file_size: 100,
+      }),
+    } as unknown as Api;
+  }
+
+  function makeFetchStub(): ReturnType<typeof vi.fn> {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
+  }
+
+  async function loadDownloadModule() {
+    vi.resetModules();
+    return import("../../../src/bot/utils/file-download.js");
+  }
+
+  it("uses api.telegram.org as the file URL base when TELEGRAM_API_ROOT is unset", async () => {
+    const fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { downloadTelegramFile } = await loadDownloadModule();
+    await downloadTelegramFile(makeApiStub(), "fid");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.telegram.org/file/botbot-token-xyz/voice/sample.ogg");
+  });
+
+  it("uses TELEGRAM_API_ROOT as the file URL base when set", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    const fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { downloadTelegramFile } = await loadDownloadModule();
+    await downloadTelegramFile(makeApiStub(), "fid");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://tg-proxy.example.com/file/botbot-token-xyz/voice/sample.ogg");
+  });
+
+  it("normalizes a trailing slash so the URL has no double slash", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com/");
+    const fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { downloadTelegramFile } = await loadDownloadModule();
+    await downloadTelegramFile(makeApiStub(), "fid");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://tg-proxy.example.com/file/botbot-token-xyz/voice/sample.ogg");
+  });
+
+  it("does not send X-Proxy-Secret when TELEGRAM_PROXY_SECRET is unset", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    const fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { downloadTelegramFile } = await loadDownloadModule();
+    await downloadTelegramFile(makeApiStub(), "fid");
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = (init as { headers?: Record<string, string> } | undefined)?.headers;
+    expect(headers?.["X-Proxy-Secret"]).toBeUndefined();
+  });
+
+  it("sends X-Proxy-Secret on the file fetch when TELEGRAM_PROXY_SECRET is set", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    vi.stubEnv("TELEGRAM_PROXY_SECRET", "secret-abc");
+    const fetchMock = makeFetchStub();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { downloadTelegramFile } = await loadDownloadModule();
+    await downloadTelegramFile(makeApiStub(), "fid");
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = (init as { headers?: Record<string, string> } | undefined)?.headers;
+    expect(headers?.["X-Proxy-Secret"]).toBe("secret-abc");
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -291,3 +291,87 @@ describe("config boolean env parsing", () => {
     expect(config.tts.voice).toBe("alloy");
   });
 });
+
+describe("config telegram reverse-proxy", () => {
+  beforeEach(() => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "123456789");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    delete process.env.TELEGRAM_PROXY_URL;
+    delete process.env.TELEGRAM_API_ROOT;
+    delete process.env.TELEGRAM_PROXY_SECRET;
+  });
+
+  // Drive buildTelegramConfig directly: re-importing the whole config module to
+  // observe a top-level throw turned out to be flaky under vitest (the module
+  // evaluation error propagates through the module loader rather than as a
+  // simple promise rejection). The exported builder is the unit under test.
+  async function loadBuilder() {
+    const module = await import("../src/config.js");
+    return module.buildTelegramConfig;
+  }
+
+  it("leaves apiRoot and proxySecret empty when neither env var is set", async () => {
+    const buildTelegramConfig = await loadBuilder();
+    const telegram = buildTelegramConfig();
+
+    expect(telegram.apiRoot).toBe("");
+    expect(telegram.proxySecret).toBe("");
+  });
+
+  it("strips a trailing slash from TELEGRAM_API_ROOT", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com/");
+    const buildTelegramConfig = await loadBuilder();
+
+    expect(buildTelegramConfig().apiRoot).toBe("https://tg-proxy.example.com");
+  });
+
+  it("strips multiple trailing slashes from TELEGRAM_API_ROOT", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com///");
+    const buildTelegramConfig = await loadBuilder();
+
+    expect(buildTelegramConfig().apiRoot).toBe("https://tg-proxy.example.com");
+  });
+
+  it("preserves TELEGRAM_API_ROOT that has no trailing slash", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    const buildTelegramConfig = await loadBuilder();
+
+    expect(buildTelegramConfig().apiRoot).toBe("https://tg-proxy.example.com");
+  });
+
+  it("accepts TELEGRAM_API_ROOT together with TELEGRAM_PROXY_SECRET", async () => {
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    vi.stubEnv("TELEGRAM_PROXY_SECRET", "shared-secret");
+    const buildTelegramConfig = await loadBuilder();
+
+    const telegram = buildTelegramConfig();
+    expect(telegram.apiRoot).toBe("https://tg-proxy.example.com");
+    expect(telegram.proxySecret).toBe("shared-secret");
+  });
+
+  it("allows TELEGRAM_PROXY_URL alone without TELEGRAM_API_ROOT", async () => {
+    vi.stubEnv("TELEGRAM_PROXY_URL", "socks5://forward.example.com:1080");
+    const buildTelegramConfig = await loadBuilder();
+
+    const telegram = buildTelegramConfig();
+    expect(telegram.proxyUrl).toBe("socks5://forward.example.com:1080");
+    expect(telegram.apiRoot).toBe("");
+  });
+
+  it("rejects TELEGRAM_PROXY_URL combined with TELEGRAM_API_ROOT", async () => {
+    vi.stubEnv("TELEGRAM_PROXY_URL", "socks5://forward.example.com:1080");
+    vi.stubEnv("TELEGRAM_API_ROOT", "https://tg-proxy.example.com");
+    const buildTelegramConfig = await loadBuilder();
+
+    expect(() => buildTelegramConfig()).toThrow(/cannot be used together/i);
+  });
+
+  it("rejects TELEGRAM_PROXY_SECRET without TELEGRAM_API_ROOT", async () => {
+    vi.stubEnv("TELEGRAM_PROXY_SECRET", "shared-secret");
+    const buildTelegramConfig = await loadBuilder();
+
+    expect(() => buildTelegramConfig()).toThrow(/TELEGRAM_PROXY_SECRET requires TELEGRAM_API_ROOT/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two new environment variables for routing Telegram Bot API calls and file downloads through a custom HTTPS reverse-proxy (e.g. nginx proxying `api.telegram.org`) with an optional shared-secret header.

- `TELEGRAM_API_ROOT` — replaces `https://api.telegram.org` for both Bot API calls (via grammY's `client.apiRoot`) and file downloads. Defaults to empty → existing behaviour preserved.
- `TELEGRAM_PROXY_SECRET` — if set, `X-Proxy-Secret` header is sent on every request so the reverse proxy can authorise callers. Defaults to empty.

## Motivation

Corporate networks frequently block `api.telegram.org` at the DNS/IP level but allow the operator's own HTTPS endpoint. The existing `TELEGRAM_PROXY_URL` covers the SOCKS/HTTP-CONNECT forward-proxy case (tunnel TCP to `api.telegram.org` via a proxy). This PR covers the orthogonal **reverse-proxy / URL-rewrite** case: the bot connects directly to a reverse proxy that forwards to `api.telegram.org` server-side, with a shared secret gating access.

Typical nginx config on the operator's VPS:

```nginx
server {
    listen 443 ssl http2;
    server_name tg-proxy.yourdomain.com;

    ssl_certificate     /etc/letsencrypt/live/tg-proxy.yourdomain.com/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/tg-proxy.yourdomain.com/privkey.pem;

    access_log off;  # token is in URL path — don't log
    client_max_body_size 50m;

    if ($http_x_proxy_secret != "your-shared-secret") { return 403; }

    location / {
        proxy_pass https://api.telegram.org;
        proxy_ssl_server_name on;
        proxy_set_header Host api.telegram.org;
    }
}
```

Bot-side `.env`:

```
TELEGRAM_API_ROOT=https://tg-proxy.yourdomain.com
TELEGRAM_PROXY_SECRET=your-shared-secret
```

## Changes

- `src/config.ts` — new `telegram.apiRoot` + `telegram.proxySecret` fields.
- `src/bot/index.ts` — pass `apiRoot` into grammY's `client` options; inject `X-Proxy-Secret` via `baseFetchConfig.headers`. Composes with the existing `TELEGRAM_PROXY_URL` path.
- `src/bot/utils/file-download.ts` — derive the file URL base from `apiRoot`; add the secret header to the `fetch()` call.
- `src/bot/handlers/voice.ts` — same for the raw `http.get()` code path that downloads voice files (URL base + header).
- `.env.example` — documents the two new variables with a short motivation.

## Note on branch contents

This branch also carries a second commit that pins `remark` to `14.0.3` to fix an unrelated `ERR_REQUIRE_ESM` crash on Node 20 — I've opened that as a separate single-commit PR #93 so it can be reviewed and merged independently on its own merits. If #93 lands first, GitHub will auto-close that commit here and this PR will rebase cleanly. If you prefer I drop the remark commit from this branch while #93 is under review, let me know and I'll force-push.

## Backward compatibility

Both new env vars default to empty. When unset, the bot behaves exactly as before: base URL stays `https://api.telegram.org`, no extra headers, no logs. Existing installs are unaffected.

## Test plan

- [x] With neither var set — behavior unchanged, bot operates against `api.telegram.org` directly.
- [x] With `TELEGRAM_API_ROOT` set — Bot API calls go to the new root; file downloads use the new root.
- [x] With `TELEGRAM_PROXY_SECRET` set — header is attached to API calls AND to both file-download code paths.
- [x] End-to-end test against an nginx reverse-proxy + `if ($http_x_proxy_secret != "suckit") { return 403; }` — getMe/sendMessage/getFile all round-trip correctly.

## Notes

Composition with `TELEGRAM_PROXY_URL`: the reverse-proxy and forward-proxy features are orthogonal and can be used together (forward proxy to *reach* the reverse proxy, though that's an unusual combination). No code path conflict.
