### PR TITLE
fix(deps): pin remark to 14.0.3 via overrides (fix ERR_REQUIRE_ESM on Node 20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "overrides": {
+    "remark": "14.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Pins `remark` to `14.0.3` (the last CJS release) via an `overrides` entry in `package.json`. Fixes `ERR_REQUIRE_ESM` for everyone running this package on Node 20 (and Node 22 without `--experimental-require-module`).

## The bug

Transitive dependency `telegram-markdown-v2@0.0.4` ships a compiled CJS build that does:
```js
const remark_1 = require("remark");
```
…but `remark@15.0.0+` is ESM-only. Node refuses `require()` of ESM modules and the whole CLI crashes at startup:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../node_modules/remark/index.js
from .../node_modules/telegram-markdown-v2/dist/convert.js not supported.
...
    at Object.<anonymous> (...\node_modules\telegram-markdown-v2\dist\convert.js:4:18) {
  code: 'ERR_REQUIRE_ESM'
}
```

Repro: fresh `npm install -g @grinev/opencode-telegram-bot` on Node 20.17.0 → run → crash.

## The fix

```json
"overrides": { "remark": "14.0.3" }
```

`remark@14.0.3` is the last CJS version (before the ESM-only migration in 15.0.0). This package doesn't call into remark directly — it's only used transitively through `telegram-markdown-v2` for the TG markdown conversion, which already targets the v14 API.

## Backward compatibility

Zero impact on existing behaviour. `overrides` only affects dependency resolution at install time; runtime code is unchanged.

## Alternatives considered

- Bumping `telegram-markdown-v2` — upstream hasn't released a CJS-compatible fix.
- Switching to dynamic `import()` in the consuming code — not applicable here since the failing require is in the transitive dep, not this repo.
- Dropping `telegram-markdown-v2` — larger refactor; this pin is minimal and reversible.
