### PR TITLE
feat(bot): improve attached session live watch

### DIFF
--- a/src/attach/service.ts
+++ b/src/attach/service.ts
@@ -8,11 +8,190 @@ import { questionManager } from "../question/manager.js";
 import { permissionManager } from "../permission/manager.js";
 import { showCurrentQuestion } from "../bot/handlers/question.js";
 import { showPermissionRequest } from "../bot/handlers/permission.js";
+import { renderAssistantFinalPartsSafe } from "../bot/utils/assistant-rendering.js";
+import { sendRenderedBotPart } from "../bot/utils/telegram-text.js";
 import type { SessionInfo } from "../session/manager.js";
 import { getCurrentSession } from "../session/manager.js";
 import { getCurrentProject } from "../settings/manager.js";
 import { attachManager } from "./manager.js";
 import { logger } from "../utils/logger.js";
+import { t } from "../i18n/index.js";
+
+const LIVE_WATCH_MESSAGES_LIMIT = 24;
+const LIVE_WATCH_INITIAL_BACKLOG_ITEMS = 6;
+const LIVE_WATCH_POLL_INTERVAL_MS = 3000;
+
+interface ConversationItem {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  created: number;
+}
+
+interface SessionWatchState {
+  bot: Bot<Context>;
+  chatId: number;
+  session: SessionInfo;
+  sentMessageIds: Set<string>;
+  lastStatusType: string | null;
+  timer: ReturnType<typeof setInterval> | null;
+}
+
+let activeSessionWatch: SessionWatchState | null = null;
+
+function stopSessionWatch(reason: string): void {
+  if (!activeSessionWatch) {
+    return;
+  }
+
+  if (activeSessionWatch.timer) {
+    clearInterval(activeSessionWatch.timer);
+  }
+
+  logger.info(
+    `[Attach] Stopped session watch: session=${activeSessionWatch.session.id}, reason=${reason}`,
+  );
+  activeSessionWatch = null;
+}
+
+function extractTextParts(parts: Array<{ type: string; text?: string }>): string | null {
+  const textParts = parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text as string);
+
+  if (textParts.length === 0) {
+    return null;
+  }
+
+  const text = textParts.join("").trim();
+  return text.length > 0 ? text : null;
+}
+
+function buildConversationItems(
+  messages: Array<{ info: { id: string; role: string; time?: { created?: number }; summary?: boolean }; parts: Array<{ type: string; text?: string }> }>,
+): ConversationItem[] {
+  return messages
+    .map(({ info, parts }) => {
+      const role = info.role;
+      if (role !== "user" && role !== "assistant") {
+        return null;
+      }
+
+      if (role === "assistant" && info.summary) {
+        return null;
+      }
+
+      const text = extractTextParts(parts);
+      if (!text) {
+        return null;
+      }
+
+      return {
+        id: info.id,
+        role,
+        text,
+        created: info.time?.created ?? 0,
+      } as ConversationItem;
+    })
+    .filter((item): item is ConversationItem => Boolean(item))
+    .sort((a, b) => a.created - b.created);
+}
+
+async function sendConversationItem(bot: Bot<Context>, chatId: number, item: ConversationItem): Promise<void> {
+  const label = item.role === "user" ? t("sessions.preview.you") : t("sessions.preview.agent");
+  const renderedParts = renderAssistantFinalPartsSafe(`${label}\n\n${item.text}`);
+
+  for (const part of renderedParts) {
+    await sendRenderedBotPart({
+      api: bot.api,
+      chatId,
+      part,
+      options: { disable_notification: true },
+    });
+  }
+}
+
+async function pollSessionWatch(state: SessionWatchState, initial = false): Promise<void> {
+  if (!activeSessionWatch || activeSessionWatch !== state) {
+    return;
+  }
+
+  try {
+    const [{ data: messages, error: messagesError }, { data: statuses, error: statusError }] =
+      await Promise.all([
+        opencodeClient.session.messages({
+          sessionID: state.session.id,
+          directory: state.session.directory,
+          limit: LIVE_WATCH_MESSAGES_LIMIT,
+        }),
+        opencodeClient.session.status({
+          directory: state.session.directory,
+        }),
+      ]);
+
+    if (messagesError || !messages) {
+      logger.warn("[Attach] Live watch failed to fetch session messages:", messagesError);
+      return;
+    }
+
+    const items = buildConversationItems(
+      messages as Array<{
+        info: { id: string; role: string; time?: { created?: number }; summary?: boolean };
+        parts: Array<{ type: string; text?: string }>;
+      }>,
+    );
+
+    const pendingItems = initial
+      ? items
+          .slice(-LIVE_WATCH_INITIAL_BACKLOG_ITEMS)
+          .filter((item) => !state.sentMessageIds.has(item.id))
+      : items.filter((item) => !state.sentMessageIds.has(item.id));
+
+    for (const item of pendingItems) {
+      await sendConversationItem(state.bot, state.chatId, item);
+      state.sentMessageIds.add(item.id);
+    }
+
+    if (!statusError && statuses) {
+      const statusType = (statuses as Record<string, { type?: string }>)[state.session.id]?.type || "idle";
+      if (statusType !== state.lastStatusType) {
+        state.lastStatusType = statusType;
+        const statusText =
+          statusType === "busy"
+            ? t("bot.thinking")
+            : statusType === "retry"
+              ? "🔁 Retrying"
+              : "✅ Idle";
+        await state.bot.api
+          .sendMessage(state.chatId, statusText, { disable_notification: true })
+          .catch(() => {});
+      }
+    }
+  } catch (error) {
+    logger.warn("[Attach] Live watch poll failed:", error);
+  }
+}
+
+function startSessionWatch(bot: Bot<Context>, chatId: number, session: SessionInfo): void {
+  stopSessionWatch("reattach");
+
+  const state: SessionWatchState = {
+    bot,
+    chatId,
+    session,
+    sentMessageIds: new Set(),
+    lastStatusType: null,
+    timer: null,
+  };
+
+  state.timer = setInterval(() => {
+    void pollSessionWatch(state, false);
+  }, LIVE_WATCH_POLL_INTERVAL_MS);
+
+  activeSessionWatch = state;
+  logger.info(`[Attach] Started session watch: session=${session.id}`);
+  void pollSessionWatch(state, true);
+}
 
 interface EnsureAttachPinnedSessionParams {
   api: Context["api"];
@@ -166,6 +345,8 @@ export async function attachToSession(deps: AttachSessionDeps): Promise<AttachSe
     attachManager.markIdle(session.id);
   }
 
+  startSessionWatch(bot, chatId, session);
+
   await syncPinnedAttachState();
 
   let restoredQuestion = false;
@@ -231,6 +412,7 @@ export function detachAttachedSession(reason: string): void {
     return;
   }
 
+  stopSessionWatch(reason);
   stopEventListening();
   summaryAggregator.clear();
   attachManager.clear(reason);

--- a/src/bot/commands/sessions.ts
+++ b/src/bot/commands/sessions.ts
@@ -14,7 +14,6 @@ import {
 } from "../handlers/inline-menu.js";
 import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
 import { logger } from "../../utils/logger.js";
-import { safeBackgroundTask } from "../../utils/safe-background-task.js";
 import { config } from "../../config.js";
 import { getDateLocale, t } from "../../i18n/index.js";
 import { attachToSession } from "../../attach/service.js";
@@ -275,8 +274,9 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
       }
     }
 
+    let attachResult;
     try {
-      await attachToSession({
+      attachResult = await attachToSession({
         bot: deps.bot,
         chatId: ctx.chat!.id,
         session: sessionInfo,
@@ -317,26 +317,17 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
       // Send session selection confirmation with updated keyboard
       const keyboard = keyboardManager.getKeyboard();
       try {
-        await ctx.api.sendMessage(chatId, t("sessions.selected", { title: session.title }), {
+        const liveStatusText = attachResult?.busy ? t("bot.thinking") : "✅ Idle";
+        await ctx.api.sendMessage(
+          chatId,
+          `${t("sessions.selected", { title: session.title })}\n\n👀 Live watch active\n${liveStatusText}`,
+          {
           reply_markup: keyboard,
-        });
+          },
+        );
       } catch (err) {
         logger.error("[Sessions] Failed to send selection message:", err);
       }
-
-      // Send preview asynchronously
-      safeBackgroundTask({
-        taskName: "sessions.sendPreview",
-        task: () =>
-          sendSessionPreview(
-            ctx.api,
-            chatId,
-            null,
-            session.title,
-            session.id,
-            currentProject.worktree,
-          ),
-      });
     }
 
     await ctx.deleteMessage();
@@ -348,133 +339,4 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
   }
 
   return true;
-}
-
-type SessionPreviewItem = {
-  role: "user" | "assistant";
-  text: string;
-  created: number;
-};
-
-const PREVIEW_MESSAGES_LIMIT = 6;
-const PREVIEW_ITEM_MAX_LENGTH = 420;
-const TELEGRAM_MESSAGE_LIMIT = 4096;
-
-function extractTextParts(parts: Array<{ type: string; text?: string }>): string | null {
-  const textParts = parts
-    .filter((part) => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text as string);
-
-  if (textParts.length === 0) {
-    return null;
-  }
-
-  const text = textParts.join("").trim();
-  return text.length > 0 ? text : null;
-}
-
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-
-  const clipped = text.slice(0, Math.max(0, maxLength - 3)).trimEnd();
-  return `${clipped}...`;
-}
-
-async function loadSessionPreview(
-  sessionId: string,
-  directory: string,
-): Promise<SessionPreviewItem[]> {
-  try {
-    const { data: messages, error } = await opencodeClient.session.messages({
-      sessionID: sessionId,
-      directory,
-      limit: PREVIEW_MESSAGES_LIMIT,
-    });
-
-    if (error || !messages) {
-      logger.warn("[Sessions] Failed to fetch session messages:", error);
-      return [];
-    }
-
-    const items = messages
-      .map(({ info, parts }) => {
-        const role = info.role as "user" | "assistant" | undefined;
-        if (role !== "user" && role !== "assistant") {
-          return null;
-        }
-
-        if (role === "assistant" && (info as { summary?: boolean }).summary) {
-          return null;
-        }
-
-        const text = extractTextParts(parts as Array<{ type: string; text?: string }>);
-        if (!text) {
-          return null;
-        }
-
-        const created = info.time?.created ?? 0;
-        return {
-          role,
-          text: truncateText(text, PREVIEW_ITEM_MAX_LENGTH),
-          created,
-        } as SessionPreviewItem;
-      })
-      .filter((item): item is SessionPreviewItem => Boolean(item));
-
-    return items.sort((a, b) => a.created - b.created);
-  } catch (err) {
-    logger.error("[Sessions] Error loading session preview:", err);
-    return [];
-  }
-}
-
-function formatSessionPreview(_sessionTitle: string, items: SessionPreviewItem[]): string {
-  const lines: string[] = [];
-
-  if (items.length === 0) {
-    lines.push(t("sessions.preview.empty"));
-    return lines.join("\n");
-  }
-
-  lines.push(t("sessions.preview.title"));
-
-  items.forEach((item, index) => {
-    const label = item.role === "user" ? t("sessions.preview.you") : t("sessions.preview.agent");
-    lines.push(`${label} ${item.text}`);
-    if (index < items.length - 1) {
-      lines.push("");
-    }
-  });
-
-  const rawMessage = lines.join("\n");
-  return truncateText(rawMessage, TELEGRAM_MESSAGE_LIMIT);
-}
-
-async function sendSessionPreview(
-  api: Context["api"],
-  chatId: number,
-  messageId: number | null,
-  sessionTitle: string,
-  sessionId: string,
-  directory: string,
-): Promise<void> {
-  const previewItems = await loadSessionPreview(sessionId, directory);
-  const finalText = formatSessionPreview(sessionTitle, previewItems);
-
-  if (messageId) {
-    try {
-      await api.editMessageText(chatId, messageId, finalText);
-      return;
-    } catch (err) {
-      logger.warn("[Sessions] Failed to edit preview message, sending new one:", err);
-    }
-  }
-
-  try {
-    await api.sendMessage(chatId, finalText);
-  } catch (err) {
-    logger.error("[Sessions] Failed to send session preview message:", err);
-  }
 }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -56,7 +56,7 @@ import { clearAllInteractionState } from "../interaction/cleanup.js";
 import { keyboardManager } from "../keyboard/manager.js";
 import { stopEventListening, subscribeToEvents } from "../opencode/events.js";
 import { summaryAggregator } from "../summary/aggregator.js";
-import { formatToolInfo } from "../summary/formatter.js";
+import { escapePlainTextForTelegramMarkdownV2, formatToolInfo } from "../summary/formatter.js";
 import { renderSubagentCards } from "../summary/subagent-formatter.js";
 import { ToolMessageBatcher } from "../summary/tool-message-batcher.js";
 import { getCurrentSession } from "../session/manager.js";
@@ -79,6 +79,10 @@ import {
   sendBotText,
   sendRenderedBotPart,
 } from "./utils/telegram-text.js";
+import {
+  editMessageWithMarkdownFallback,
+  sendMessageWithMarkdownFallback,
+} from "./utils/send-with-markdown-fallback.js";
 import { formatAssistantRunFooter } from "./utils/assistant-run-footer.js";
 import { getModelCapabilities, supportsInput } from "../model/capabilities.js";
 import { getStoredModel } from "../model/manager.js";
@@ -113,6 +117,8 @@ const RESPONSE_STREAM_THROTTLE_MS = config.bot.responseStreamThrottleMs;
 const RESPONSE_STREAM_TEXT_LIMIT = 3800;
 const SESSION_RETRY_PREFIX = "🔁";
 const SUBAGENT_STREAM_PREFIX = "🧩";
+const LIVE_TOOL_STREAM_PREFIX = "tool-live";
+const REASONING_STREAM_PREFIX = "reasoning-live";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const TEMP_DIR = path.join(__dirname, "..", ".tmp");
@@ -145,6 +151,14 @@ function prepareStreamingPayload(messageText: string): StreamingMessagePayload |
 
 function prepareFinalStreamingPayload(messageText: string): StreamingMessagePayload | null {
   return prepareAssistantFinalStreamingPayload(messageText, RESPONSE_STREAM_TEXT_LIMIT);
+}
+
+function formatReasoningChunk(text: string): { markdown: string; fallback: string } {
+  const normalized = text.trim();
+  return {
+    markdown: `💭 _${escapePlainTextForTelegramMarkdownV2(normalized)}_`,
+    fallback: `💭 ${normalized}`,
+  };
 }
 
 function enqueueSessionCompletionTask(sessionId: string, task: () => Promise<void>): Promise<void> {
@@ -337,6 +351,87 @@ const toolCallStreamer = new ToolCallStreamer({
   },
 });
 
+const reasoningStreamer = new ToolCallStreamer({
+  throttleMs: RESPONSE_STREAM_THROTTLE_MS,
+  sendText: async (sessionId, text) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream send");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for send: ${sessionId}`);
+    }
+
+    const formatted = formatReasoningChunk(text);
+    const sentMessage = await sendMessageWithMarkdownFallback({
+      api: botInstance.api,
+      chatId: chatIdInstance,
+      text: formatted.markdown,
+      rawFallbackText: formatted.fallback,
+      options: { disable_notification: true },
+      parseMode: "MarkdownV2",
+    });
+
+    return sentMessage.message_id;
+  },
+  editText: async (sessionId, messageId, text) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream edit");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for edit: ${sessionId}`);
+    }
+
+    const formatted = formatReasoningChunk(text);
+
+    try {
+      await editMessageWithMarkdownFallback({
+        api: botInstance.api,
+        chatId: chatIdInstance,
+        messageId,
+        text: formatted.markdown,
+        rawFallbackText: formatted.fallback,
+        options: undefined,
+        parseMode: "MarkdownV2",
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      if (errorMessage.includes("message is not modified")) {
+        return;
+      }
+
+      throw error;
+    }
+  },
+  deleteText: async (sessionId, messageId) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream delete");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for delete: ${sessionId}`);
+    }
+
+    await botInstance.api.deleteMessage(chatIdInstance, messageId).catch((error) => {
+      const errorMessage =
+        error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      if (
+        errorMessage.includes("message to delete not found") ||
+        errorMessage.includes("message identifier is not specified")
+      ) {
+        return;
+      }
+
+      throw error;
+    });
+  },
+});
+
 function getToolStreamKey(tool: string): ToolStreamKey {
   if (tool === "todowrite") {
     return "todo";
@@ -417,6 +512,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
   summaryAggregator.setOnCleared(() => {
     toolMessageBatcher.clearAll("summary_aggregator_clear");
     toolCallStreamer.clearAll("summary_aggregator_clear");
+    reasoningStreamer.clearAll("summary_aggregator_clear");
     responseStreamer.clearAll("summary_aggregator_clear");
   });
 
@@ -450,6 +546,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         clearPromptResponseMode(sessionId);
         responseStreamer.clearMessage(sessionId, messageId, "bot_context_missing");
         toolCallStreamer.clearSession(sessionId, "bot_context_missing");
+        reasoningStreamer.clearSession(sessionId, "bot_context_missing");
         assistantRunState.clearRun(sessionId, "bot_context_missing");
         foregroundSessionState.markIdle(sessionId);
         return;
@@ -460,6 +557,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         clearPromptResponseMode(sessionId);
         responseStreamer.clearMessage(sessionId, messageId, "session_mismatch");
         toolCallStreamer.clearSession(sessionId, "session_mismatch");
+        reasoningStreamer.clearSession(sessionId, "session_mismatch");
         assistantRunState.clearRun(sessionId, "session_mismatch");
         foregroundSessionState.markIdle(sessionId);
         await scheduledTaskRuntime.flushDeferredDeliveries();
@@ -485,6 +583,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
             Promise.all([
               toolMessageBatcher.flushSession(sessionId, "assistant_message_completed"),
               toolCallStreamer.breakSession(sessionId, "assistant_message_completed"),
+              reasoningStreamer.breakSession(sessionId, "assistant_message_completed"),
             ]).then(() => undefined),
           prepareStreamingPayload: prepareFinalStreamingPayload,
           renderFinalParts: (text) => renderAssistantFinalPartsSafe(text),
@@ -574,6 +673,58 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     }
   });
 
+  summaryAggregator.setOnToolProgress((toolInfo) => {
+    if (!botInstance || !chatIdInstance) {
+      return;
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== toolInfo.sessionId) {
+      return;
+    }
+
+    if (toolInfo.tool === "task" || toolInfo.tool === "question") {
+      return;
+    }
+
+    const message = formatToolInfo(toolInfo);
+    if (!message) {
+      return;
+    }
+
+    const status = "status" in toolInfo.state ? toolInfo.state.status : undefined;
+    const prefix =
+      status === "running"
+        ? "▶ "
+        : status === "pending"
+          ? "⏳ "
+          : status === "completed"
+            ? "✅ "
+            : status === "error"
+              ? "❌ "
+              : "";
+
+    toolCallStreamer.replaceByPrefix(
+      toolInfo.sessionId,
+      LIVE_TOOL_STREAM_PREFIX,
+      `${prefix}${message}`,
+      "activity",
+    );
+  });
+
+  summaryAggregator.setOnReasoning((sessionId, _messageId, reasoningText) => {
+    if (!botInstance || !chatIdInstance) {
+      return;
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      return;
+    }
+
+    reasoningStreamer.replaceByPrefix(sessionId, REASONING_STREAM_PREFIX, reasoningText, "reasoning");
+  });
+
   summaryAggregator.setOnSubagent(async (sessionId, subagents) => {
     if (!botInstance || !chatIdInstance) {
       return;
@@ -649,6 +800,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(currentSession.id, "question_asked"),
       toolCallStreamer.flushSession(currentSession.id, "question_asked"),
+      reasoningStreamer.flushSession(currentSession.id, "question_asked"),
     ]);
 
     if (questionManager.isActive()) {
@@ -697,6 +849,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(request.sessionID, "permission_asked"),
       toolCallStreamer.flushSession(request.sessionID, "permission_asked"),
+      reasoningStreamer.flushSession(request.sessionID, "permission_asked"),
     ]);
 
     logger.info(
@@ -718,6 +871,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     logger.debug("[Bot] Agent started thinking");
 
     await toolCallStreamer.breakSession(sessionId, "thinking_started");
+    await reasoningStreamer.breakSession(sessionId, "thinking_started");
 
     deliverThinkingMessage(sessionId, toolMessageBatcher, {
       hideThinkingMessages: config.bot.hideThinkingMessages,
@@ -815,6 +969,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       await Promise.all([
         toolMessageBatcher.flushSession(sessionId, "session_idle"),
         toolCallStreamer.flushSession(sessionId, "session_idle"),
+        reasoningStreamer.breakSession(sessionId, "session_idle"),
       ]);
 
       if (completedRun?.hasCompletedResponse) {
@@ -860,6 +1015,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       clearPromptResponseMode(sessionId);
       responseStreamer.clearSession(sessionId, "session_error_not_current");
       toolCallStreamer.clearSession(sessionId, "session_error_not_current");
+      reasoningStreamer.clearSession(sessionId, "session_error_not_current");
       assistantRunState.clearRun(sessionId, "session_error_not_current");
       foregroundSessionState.markIdle(sessionId);
       await scheduledTaskRuntime.flushDeferredDeliveries();
@@ -872,6 +1028,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(sessionId, "session_error"),
       toolCallStreamer.flushSession(sessionId, "session_error"),
+      reasoningStreamer.breakSession(sessionId, "session_error"),
     ]);
 
     const normalizedMessage = message.trim() || t("common.unknown_error");
@@ -1413,6 +1570,7 @@ export function cleanupBotRuntime(reason: string): void {
   summaryAggregator.clear();
   responseStreamer.clearAll(reason);
   toolCallStreamer.clearAll(reason);
+  reasoningStreamer.clearAll(reason);
   toolMessageBatcher.clearAll(reason);
   sessionCompletionTasks.clear();
   assistantRunState.clearAll(reason);

--- a/src/bot/streaming/tool-call-streamer.ts
+++ b/src/bot/streaming/tool-call-streamer.ts
@@ -3,7 +3,7 @@ import { logger } from "../../utils/logger.js";
 const TELEGRAM_MESSAGE_SAFE_LENGTH = 4000;
 const DEFAULT_STREAM_KEY = "default";
 
-export type ToolStreamKey = "default" | "subagent" | "todo";
+export type ToolStreamKey = "default" | "subagent" | "todo" | "activity" | "status" | "reasoning";
 
 interface ToolCallStreamerOptions {
   throttleMs: number;
@@ -66,18 +66,28 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+function addMultipartMarkers(chunks: string[]): string[] {
+  if (chunks.length <= 1) {
+    return chunks;
+  }
+
+  return chunks.map((chunk, index) => `[${index + 1}/${chunks.length}]\n${chunk}`);
+}
+
 function splitLongText(text: string, limit: number): string[] {
   if (text.length <= limit) {
     return [text];
   }
 
+  const markerReserve = 16;
+  const safeLimit = Math.max(1, limit - markerReserve);
   const chunks: string[] = [];
   let remaining = text;
 
-  while (remaining.length > limit) {
-    let splitIndex = remaining.lastIndexOf("\n", limit);
-    if (splitIndex <= 0 || splitIndex < Math.floor(limit * 0.5)) {
-      splitIndex = limit;
+  while (remaining.length > safeLimit) {
+    let splitIndex = remaining.lastIndexOf("\n", safeLimit);
+    if (splitIndex <= 0 || splitIndex < Math.floor(safeLimit * 0.5)) {
+      splitIndex = safeLimit;
     }
 
     chunks.push(remaining.slice(0, splitIndex));
@@ -88,7 +98,7 @@ function splitLongText(text: string, limit: number): string[] {
     chunks.push(remaining);
   }
 
-  return chunks;
+  return addMultipartMarkers(chunks);
 }
 
 function buildParts(entries: StreamEntry[]): string[] {

--- a/src/bot/utils/assistant-rendering.ts
+++ b/src/bot/utils/assistant-rendering.ts
@@ -15,11 +15,31 @@ export function createPlainRenderedBlock(text: string): TelegramRenderedBlock {
   };
 }
 
+function addMultipartMarkers(parts: TelegramRenderedPart[]): TelegramRenderedPart[] {
+  if (parts.length <= 1) {
+    return parts;
+  }
+
+  return parts.map((part, index) => {
+    const marker = `[${index + 1}/${parts.length}]\n`;
+    return {
+      ...part,
+      text: `${marker}${part.text}`,
+      fallbackText: `${marker}${part.fallbackText}`,
+    };
+  });
+}
+
 export function createPlainRenderedParts(
   text: string,
   maxPartLength: number,
 ): TelegramRenderedPart[] {
-  return chunkTelegramRenderedBlocks([createPlainRenderedBlock(text)], { maxPartLength });
+  const markerReserve = 16;
+  const chunkLimit = Math.max(1, maxPartLength - markerReserve);
+  const parts = chunkTelegramRenderedBlocks([createPlainRenderedBlock(text)], {
+    maxPartLength: chunkLimit,
+  });
+  return addMultipartMarkers(parts);
 }
 
 function useAssistantEntitiesFormat(): boolean {

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -32,6 +32,8 @@ type MessageCompleteCallback = (
 
 type MessagePartialCallback = (sessionId: string, messageId: string, messageText: string) => void;
 
+type ReasoningCallback = (sessionId: string, messageId: string, reasoningText: string) => void;
+
 type ExternalUserInputCallback = (
   sessionId: string,
   messageId: string,
@@ -74,6 +76,8 @@ export interface ToolFileInfo extends ToolInfo {
 }
 
 type ToolCallback = (toolInfo: ToolInfo) => void;
+
+type ToolProgressCallback = (toolInfo: ToolInfo) => void;
 
 type ToolFileCallback = (fileInfo: ToolFileInfo) => void;
 
@@ -153,6 +157,11 @@ interface TextMessageState {
   optimisticUpdateCount: number;
 }
 
+interface ReasoningMessageState {
+  orderedPartIds: string[];
+  partTexts: Map<string, string>;
+}
+
 interface SubagentState extends SubagentInfo {
   hasSubtaskMetadata: boolean;
   hasTaskToolMetadata: boolean;
@@ -191,13 +200,16 @@ function countDiffChangesFromText(text: string): { additions: number; deletions:
 class SummaryAggregator {
   private currentSessionId: string | null = null;
   private textMessageStates: Map<string, TextMessageState> = new Map();
+  private reasoningMessageStates: Map<string, ReasoningMessageState> = new Map();
   private messages: Map<string, { role: string }> = new Map();
   private messageCount = 0;
   private lastUpdated = 0;
   private onCompleteCallback: MessageCompleteCallback | null = null;
   private onPartialCallback: MessagePartialCallback | null = null;
+  private onReasoningCallback: ReasoningCallback | null = null;
   private onExternalUserInputCallback: ExternalUserInputCallback | null = null;
   private onToolCallback: ToolCallback | null = null;
+  private onToolProgressCallback: ToolProgressCallback | null = null;
   private onToolFileCallback: ToolFileCallback | null = null;
   private onQuestionCallback: QuestionCallback | null = null;
   private onQuestionErrorCallback: QuestionErrorCallback | null = null;
@@ -243,12 +255,20 @@ class SummaryAggregator {
     this.onPartialCallback = callback;
   }
 
+  setOnReasoning(callback: ReasoningCallback): void {
+    this.onReasoningCallback = callback;
+  }
+
   setOnExternalUserInput(callback: ExternalUserInputCallback): void {
     this.onExternalUserInputCallback = callback;
   }
 
   setOnTool(callback: ToolCallback): void {
     this.onToolCallback = callback;
+  }
+
+  setOnToolProgress(callback: ToolProgressCallback): void {
+    this.onToolProgressCallback = callback;
   }
 
   setOnToolFile(callback: ToolFileCallback): void {
@@ -430,6 +450,7 @@ class SummaryAggregator {
     this.stopTypingIndicator();
     this.currentSessionId = null;
     this.textMessageStates.clear();
+    this.reasoningMessageStates.clear();
     this.messages.clear();
     this.partHashes.clear();
     this.knownTextPartIds.clear();
@@ -1154,6 +1175,16 @@ class SummaryAggregator {
           }
         });
       }
+
+      if (part.text) {
+        const wasUpdated = this.setReasoningPartSnapshot(messageID, part.id, part.text);
+        if (!wasUpdated) {
+          return;
+        }
+
+        const fullReasoning = this.getCombinedReasoningText(messageID);
+        this.emitReasoningText(part.sessionID, messageID, fullReasoning);
+      }
     } else if (part.type === "text" && "text" in part && part.text) {
       const wasUpdated =
         messageInfo && messageInfo.role === "assistant"
@@ -1182,6 +1213,20 @@ class SummaryAggregator {
       const state = part.state;
       const input = "input" in state ? (state.input as { [key: string]: unknown }) : undefined;
       const title = "title" in state ? state.title : undefined;
+      const toolData: ToolInfo = {
+        sessionId: part.sessionID,
+        messageId: messageID,
+        callId: part.callID,
+        tool: part.tool,
+        state: part.state,
+        input,
+        title,
+        metadata:
+          "metadata" in state
+            ? (state.metadata as { [key: string]: unknown } | undefined)
+            : undefined,
+        hasFileAttachment: false,
+      };
 
       if (part.tool === "task") {
         this.updateSubagentFromTaskTool(part.sessionID, input);
@@ -1212,6 +1257,10 @@ class SummaryAggregator {
         // This ensures we have access to the requestID needed for question.reply().
       }
 
+      if (this.onToolProgressCallback) {
+        this.onToolProgressCallback(toolData);
+      }
+
       if ("status" in state && state.status === "completed") {
         logger.debug(
           `[Aggregator] Tool completed: callID=${part.callID}, tool=${part.tool}`,
@@ -1230,15 +1279,8 @@ class SummaryAggregator {
             state.metadata as { [key: string]: unknown } | undefined,
           );
 
-          const toolData: ToolInfo = {
-            sessionId: part.sessionID,
-            messageId: messageID,
-            callId: part.callID,
-            tool: part.tool,
-            state: part.state,
-            input,
-            title,
-            metadata: state.metadata as { [key: string]: unknown },
+          const completedToolData: ToolInfo = {
+            ...toolData,
             hasFileAttachment: !!preparedFileContext.fileData,
           };
 
@@ -1247,7 +1289,7 @@ class SummaryAggregator {
           );
 
           if (this.onToolCallback) {
-            this.onToolCallback(toolData);
+            this.onToolCallback(completedToolData);
           }
 
           if (preparedFileContext.fileData && this.onToolFileCallback) {
@@ -1255,7 +1297,7 @@ class SummaryAggregator {
               `[Aggregator] Sending ${part.tool} file: ${preparedFileContext.fileData.filename} (${preparedFileContext.fileData.buffer.length} bytes)`,
             );
             this.onToolFileCallback({
-              ...toolData,
+              ...completedToolData,
               hasFileAttachment: true,
               fileData: preparedFileContext.fileData,
             });
@@ -1283,13 +1325,17 @@ class SummaryAggregator {
       return;
     }
 
-    if (partType && partType !== "text") {
+    if (partType && partType !== "text" && partType !== "reasoning") {
       return;
     }
 
     if (partType === "text") {
       this.registerKnownTextPart(messageID, partID);
       this.registerTextPart(messageID, partID);
+    } else if (partType === "reasoning") {
+      this.registerReasoningPart(messageID, partID);
+      this.applyReasoningDelta(sessionID, messageID, partID, delta, part?.text);
+      return;
     } else {
       const knownTextIds = this.knownTextPartIds.get(messageID);
       const isKnownTextPart = knownTextIds?.has(partID) ?? false;
@@ -1378,6 +1424,7 @@ class SummaryAggregator {
 
   private cleanupCompletedMessage(messageId: string): void {
     this.textMessageStates.delete(messageId);
+    this.reasoningMessageStates.delete(messageId);
     this.messages.delete(messageId);
     this.partHashes.delete(messageId);
     this.knownTextPartIds.delete(messageId);
@@ -1400,6 +1447,18 @@ class SummaryAggregator {
     }
   }
 
+  private emitReasoningText(sessionId: string, messageId: string, reasoningText: string): void {
+    if (!this.onReasoningCallback || !reasoningText.trim()) {
+      return;
+    }
+
+    try {
+      this.onReasoningCallback(sessionId, messageId, reasoningText);
+    } catch (err) {
+      logger.error("[Aggregator] Error in reasoning callback:", err);
+    }
+  }
+
   private getOrCreateTextMessageState(messageID: string): TextMessageState {
     const existing = this.textMessageStates.get(messageID);
     if (existing) {
@@ -1415,6 +1474,20 @@ class SummaryAggregator {
     return state;
   }
 
+  private getOrCreateReasoningMessageState(messageID: string): ReasoningMessageState {
+    const existing = this.reasoningMessageStates.get(messageID);
+    if (existing) {
+      return existing;
+    }
+
+    const state: ReasoningMessageState = {
+      orderedPartIds: [],
+      partTexts: new Map(),
+    };
+    this.reasoningMessageStates.set(messageID, state);
+    return state;
+  }
+
   private registerKnownTextPart(messageID: string, partID: string): void {
     if (!this.knownTextPartIds.has(messageID)) {
       this.knownTextPartIds.set(messageID, new Set());
@@ -1425,6 +1498,13 @@ class SummaryAggregator {
 
   private registerTextPart(messageID: string, partID: string): void {
     const state = this.getOrCreateTextMessageState(messageID);
+    if (!state.orderedPartIds.includes(partID)) {
+      state.orderedPartIds.push(partID);
+    }
+  }
+
+  private registerReasoningPart(messageID: string, partID: string): void {
+    const state = this.getOrCreateReasoningMessageState(messageID);
     if (!state.orderedPartIds.includes(partID)) {
       state.orderedPartIds.push(partID);
     }
@@ -1463,6 +1543,26 @@ class SummaryAggregator {
     return true;
   }
 
+  private setReasoningPartSnapshot(messageID: string, partID: string, text: string): boolean {
+    const normalized = text;
+    const partHash = this.hashString(`reasoning\n${partID}\n${normalized}`);
+
+    if (!this.partHashes.has(messageID)) {
+      this.partHashes.set(messageID, new Set());
+    }
+
+    const hashes = this.partHashes.get(messageID)!;
+    if (hashes.has(partHash)) {
+      return false;
+    }
+
+    hashes.add(partHash);
+    this.registerReasoningPart(messageID, partID);
+    const state = this.getOrCreateReasoningMessageState(messageID);
+    state.partTexts.set(partID, normalized);
+    return true;
+  }
+
   private getCombinedMessageText(messageID: string): string {
     const state = this.textMessageStates.get(messageID);
     if (!state) {
@@ -1470,6 +1570,44 @@ class SummaryAggregator {
     }
 
     return state.orderedPartIds.map((partID) => state.partTexts.get(partID) || "").join("");
+  }
+
+  private getCombinedReasoningText(messageID: string): string {
+    const state = this.reasoningMessageStates.get(messageID);
+    if (!state) {
+      return "";
+    }
+
+    return state.orderedPartIds.map((partID) => state.partTexts.get(partID) || "").join("");
+  }
+
+  private applyReasoningDelta(
+    sessionID: string,
+    messageID: string,
+    partID: string,
+    delta: string,
+    fullTextHint?: string,
+  ): void {
+    if (sessionID !== this.currentSessionId) {
+      return;
+    }
+
+    this.registerReasoningPart(messageID, partID);
+    const state = this.getOrCreateReasoningMessageState(messageID);
+    const previous = state.partTexts.get(partID) || "";
+    let accumulated = `${previous}${delta}`;
+
+    if (typeof fullTextHint === "string" && fullTextHint.length > accumulated.length) {
+      accumulated = fullTextHint;
+    }
+
+    state.partTexts.set(partID, accumulated);
+    const combined = this.getCombinedReasoningText(messageID);
+    if (!combined.trim()) {
+      return;
+    }
+
+    this.emitReasoningText(sessionID, messageID, combined);
   }
 
   private prepareToolFileContext(

--- a/src/summary/formatter.ts
+++ b/src/summary/formatter.ts
@@ -361,6 +361,7 @@ function extractFirstUpdatedFileFromTitle(title: string): string {
 
 export function formatToolInfo(toolInfo: ToolInfo): string | null {
   const { tool, input, title } = toolInfo;
+  const status = "status" in toolInfo.state ? toolInfo.state.status : undefined;
   logger.debug(
     `[Formatter] formatToolInfo: tool=${tool}, hasMetadata=${!!toolInfo.metadata}, hasFilediff=${!!toolInfo.metadata?.filediff}`,
   );
@@ -386,7 +387,11 @@ export function formatToolInfo(toolInfo: ToolInfo): string | null {
   }
 
   if (tool === "bash" && input && typeof input.command === "string") {
-    details = truncateWithEllipsis(input.command, config.bot.bashToolDisplayMaxLength);
+    const bashMaxLength =
+      status === "running" || status === "pending"
+        ? Math.max(config.bot.bashToolDisplayMaxLength, 4000)
+        : config.bot.bashToolDisplayMaxLength;
+    details = truncateWithEllipsis(input.command, bashMaxLength);
   }
 
   if (tool === "apply_patch") {

--- a/tests/bot/commands/sessions.test.ts
+++ b/tests/bot/commands/sessions.test.ts
@@ -375,7 +375,7 @@ describe("bot/commands/sessions", () => {
     });
     expect((ctx.api.sendMessage as ReturnType<typeof vi.fn>).mock.calls[1]).toEqual([
       111,
-      t("sessions.selected", { title: "Session 1" }),
+      `${t("sessions.selected", { title: "Session 1" })}\n\n👀 Live watch active\n✅ Idle`,
       expect.objectContaining({
         reply_markup: { inline_keyboard: [] },
       }),

--- a/tests/bot/utils/assistant-rendering.test.ts
+++ b/tests/bot/utils/assistant-rendering.test.ts
@@ -117,7 +117,7 @@ describe("bot/utils/assistant-rendering", () => {
           source: "plain",
         },
       ],
-      { maxPartLength: 50 },
+      { maxPartLength: 34 },
     );
     expect(debug).toHaveBeenCalledWith(
       "[AssistantRender] Built final assistant parts in raw mode",
@@ -150,7 +150,7 @@ describe("bot/utils/assistant-rendering", () => {
           source: "plain",
         },
       ],
-      { maxPartLength: 40 },
+      { maxPartLength: 24 },
     );
     expect(debug).toHaveBeenCalledWith(
       "[AssistantRender] Built streaming assistant payload in raw mode",


### PR DESCRIPTION
## Summary
- improve attached-session follow mode by replacing the truncated preview with a live watch that sends recent backlog and polls for new session messages
- stream live tool activity and OpenCode reasoning text to Telegram, and keep long multipart updates readable with numbered chunks
- keep the patchset source-only: no dependency, lockfile, or Vercel-related changes

## Related
- separate context compaction fix: #95
- separate dependency / supply-chain audit tracking: #96

## Verification
- npm run build
- npm run lint
- npx vitest run tests/summary/formatter.test.ts tests/bot/commands/sessions.test.ts tests/bot/utils/assistant-rendering.test.ts