### PR TITLE
fix(bot): compact sessions before prompting

### DIFF
--- a/src/bot/handlers/prompt.ts
+++ b/src/bot/handlers/prompt.ts
@@ -32,6 +32,7 @@ import { externalUserInputSuppressionManager } from "../../external-input/suppre
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
 const promptResponseModes = new Map<string, PromptResponseMode>();
+const AUTO_COMPACT_CONTEXT_USAGE_RATIO = 0.95;
 
 export type PromptResponseMode = "text_only" | "text_and_tts";
 
@@ -59,6 +60,81 @@ export function consumePromptResponseMode(sessionId: string): PromptResponseMode
   const responseMode = promptResponseModes.get(sessionId) ?? null;
   promptResponseModes.delete(sessionId);
   return responseMode;
+}
+
+async function ensureContextInfoLoaded(session: {
+  id: string;
+  directory: string;
+}): Promise<{ tokensUsed: number; tokensLimit: number } | null> {
+  const currentContextInfo = pinnedMessageManager.getContextInfo();
+  if (currentContextInfo && currentContextInfo.tokensLimit > 0 && currentContextInfo.tokensUsed > 0) {
+    return currentContextInfo;
+  }
+
+  try {
+    if (pinnedMessageManager.getContextLimit() === 0) {
+      await pinnedMessageManager.refreshContextLimit();
+    }
+    await pinnedMessageManager.loadContextFromHistory(session.id, session.directory);
+  } catch (err) {
+    logger.warn("[Bot] Failed to preload session context before prompt:", err);
+  }
+
+  return pinnedMessageManager.getContextInfo();
+}
+
+async function compactSessionIfNeeded(
+  ctx: Context,
+  session: { id: string; directory: string },
+  storedModel: { providerID: string; modelID: string },
+): Promise<boolean> {
+  const contextInfo = await ensureContextInfoLoaded(session);
+  if (!contextInfo) {
+    return true;
+  }
+
+  const { tokensUsed, tokensLimit } = contextInfo;
+  if (!Number.isFinite(tokensUsed) || !Number.isFinite(tokensLimit) || tokensLimit <= 0) {
+    return true;
+  }
+
+  if (tokensUsed < tokensLimit * AUTO_COMPACT_CONTEXT_USAGE_RATIO) {
+    return true;
+  }
+
+  logger.warn(
+    `[Bot] Session ${session.id} is using ${tokensUsed}/${tokensLimit} context tokens. Compacting before prompt.`,
+  );
+
+  const progressMessage = await ctx.reply(t("context.progress")).catch(() => null);
+  const { error } = await opencodeClient.session.summarize({
+    sessionID: session.id,
+    directory: session.directory,
+    providerID: storedModel.providerID,
+    modelID: storedModel.modelID,
+  });
+
+  if (error) {
+    logger.error("[Bot] Automatic context compaction failed before prompt:", error);
+    if (progressMessage) {
+      await ctx.api.editMessageText(ctx.chat!.id, progressMessage.message_id, t("context.error")).catch(() => {});
+    } else {
+      await ctx.reply(t("context.error")).catch(() => {});
+    }
+    return false;
+  }
+
+  try {
+    await pinnedMessageManager.onSessionCompacted(session.id, session.directory);
+  } catch (err) {
+    logger.warn("[Bot] Failed to refresh pinned context after automatic compaction:", err);
+  }
+
+  if (progressMessage) {
+    await ctx.api.editMessageText(ctx.chat!.id, progressMessage.message_id, t("context.success")).catch(() => {});
+  }
+
+  return true;
 }
 
 async function isSessionBusy(sessionId: string, directory: string): Promise<boolean> {
@@ -216,6 +292,11 @@ export async function processUserPrompt(
   try {
     const currentAgent = await resolveProjectAgent(getStoredAgent());
     const storedModel = getStoredModel();
+
+    const compacted = await compactSessionIfNeeded(ctx, currentSession, storedModel);
+    if (!compacted) {
+      return false;
+    }
 
     // Build parts array with text and files
     const parts: Array<TextPartInput | FilePartInput> = [];

--- a/tests/bot/handlers/prompt.test.ts
+++ b/tests/bot/handlers/prompt.test.ts
@@ -12,6 +12,7 @@ const mocked = vi.hoisted(() => ({
   sessionStatusMock: vi.fn(),
   sessionPromptMock: vi.fn(),
   sessionCreateMock: vi.fn(),
+  sessionSummarizeMock: vi.fn(),
   suppressionRegisterMock: vi.fn(),
   safeBackgroundTaskMock: vi.fn(),
   setSessionSummaryMock: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock("../../../src/opencode/client.js", () => ({
       status: mocked.sessionStatusMock,
       prompt: mocked.sessionPromptMock,
       create: mocked.sessionCreateMock,
+      summarize: mocked.sessionSummarizeMock,
     },
   },
 }));
@@ -66,6 +68,10 @@ vi.mock("../../../src/pinned/manager.js", () => ({
     onSessionChange: vi.fn(),
     clear: vi.fn(),
     getContextInfo: vi.fn(() => null),
+    getContextLimit: vi.fn(() => 0),
+    refreshContextLimit: vi.fn(),
+    loadContextFromHistory: vi.fn(),
+    onSessionCompacted: vi.fn(),
   },
 }));
 
@@ -138,6 +144,9 @@ vi.mock("../../../src/external-input/suppression.js", () => ({
 function createContext(): Context {
   return {
     chat: { id: 777 },
+    api: {
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    },
     reply: vi.fn().mockResolvedValue({ message_id: 100 }),
   } as unknown as Context;
 }
@@ -160,6 +169,7 @@ describe("bot/handlers/prompt", () => {
     mocked.sessionStatusMock.mockReset();
     mocked.sessionPromptMock.mockReset();
     mocked.sessionCreateMock.mockReset();
+    mocked.sessionSummarizeMock.mockReset();
     mocked.suppressionRegisterMock.mockReset();
     mocked.safeBackgroundTaskMock.mockReset();
     mocked.setSessionSummaryMock.mockReset();
@@ -179,6 +189,7 @@ describe("bot/handlers/prompt", () => {
       error: null,
     });
     mocked.sessionPromptMock.mockResolvedValue({ data: {}, error: null });
+    mocked.sessionSummarizeMock.mockResolvedValue({ data: true, error: null });
   });
 
   it("registers suppression entry for text prompts", async () => {
@@ -209,5 +220,25 @@ describe("bot/handlers/prompt", () => {
 
     expect(handled).toBe(true);
     expect(mocked.suppressionRegisterMock).not.toHaveBeenCalled();
+  });
+
+  it("compacts the session before prompting when context usage exceeds the model limit", async () => {
+    const { pinnedMessageManager } = await import("../../../src/pinned/manager.js");
+    vi.mocked(pinnedMessageManager.getContextInfo).mockReturnValue({
+      tokensUsed: 195_000,
+      tokensLimit: 200_000,
+    });
+
+    const ctx = createContext();
+    const handled = await processUserPrompt(ctx, "Review README", createDeps());
+
+    expect(handled).toBe(true);
+    expect(mocked.sessionSummarizeMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      directory: "D:\\Projects\\Repo",
+      providerID: "openai",
+      modelID: "gpt-5",
+    });
+    expect(ctx.reply).toHaveBeenCalledWith("⏳ Compacting context...");
   });
 });


### PR DESCRIPTION
## Summary
- auto-compact attached sessions before `session.prompt` when history usage is already near the model context limit
- preload pinned context usage before prompting so the bot can detect oversized sessions reliably
- add a prompt-handler test that covers the pre-prompt summarize path

## Related
- live watch / reasoning forwarding work: #94
- separate dependency / supply-chain audit tracking: #96

## Verification
- npm run build
- npm run lint
- npx vitest run tests/bot/handlers/prompt.test.ts