### PR TITLE
feat(bot): add opt-in reasoning and tool progress streaming

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -113,6 +113,8 @@ const RESPONSE_STREAM_THROTTLE_MS = config.bot.responseStreamThrottleMs;
 const RESPONSE_STREAM_TEXT_LIMIT = 3800;
 const SESSION_RETRY_PREFIX = "🔁";
 const SUBAGENT_STREAM_PREFIX = "🧩";
+const REASONING_STREAM_PREFIX = "reasoning-live";
+const LIVE_TOOL_STREAM_PREFIX = "tool-live";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const TEMP_DIR = path.join(__dirname, "..", ".tmp");
@@ -145,6 +147,14 @@ function prepareStreamingPayload(messageText: string): StreamingMessagePayload |
 
 function prepareFinalStreamingPayload(messageText: string): StreamingMessagePayload | null {
   return prepareAssistantFinalStreamingPayload(messageText, RESPONSE_STREAM_TEXT_LIMIT);
+}
+
+function escapePlainTextForTelegramMarkdownV2(text: string): string {
+  return text.replace(/[_*[\]()~`>#+-|{}.<!]/g, "\\$&");
+}
+
+function formatReasoningChunk(text: string): string {
+  return `💭 _${escapePlainTextForTelegramMarkdownV2(text.trim())}_`;
 }
 
 function enqueueSessionCompletionTask(sessionId: string, task: () => Promise<void>): Promise<void> {
@@ -337,6 +347,71 @@ const toolCallStreamer = new ToolCallStreamer({
   },
 });
 
+const reasoningStreamer = new ToolCallStreamer({
+  throttleMs: RESPONSE_STREAM_THROTTLE_MS,
+  sendText: async (sessionId, text) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream send");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for send: ${sessionId}`);
+    }
+
+    const sentMessage = await botInstance.api.sendMessage(chatIdInstance, text, {
+      disable_notification: true,
+    });
+
+    return sentMessage.message_id;
+  },
+  editText: async (sessionId, messageId, text) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream edit");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for edit: ${sessionId}`);
+    }
+
+    try {
+      await botInstance.api.editMessageText(chatIdInstance, messageId, text);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      if (errorMessage.includes("message is not modified")) {
+        return;
+      }
+
+      throw error;
+    }
+  },
+  deleteText: async (sessionId, messageId) => {
+    if (!botInstance || !chatIdInstance || chatIdInstance <= 0) {
+      throw new Error("Bot context missing for reasoning stream delete");
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      throw new Error(`Reasoning stream session mismatch for delete: ${sessionId}`);
+    }
+
+    await botInstance.api.deleteMessage(chatIdInstance, messageId).catch((error) => {
+      const errorMessage =
+        error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      if (
+        errorMessage.includes("message to delete not found") ||
+        errorMessage.includes("message identifier is not specified")
+      ) {
+        return;
+      }
+
+      throw error;
+    });
+  },
+});
+
 function getToolStreamKey(tool: string): ToolStreamKey {
   if (tool === "todowrite") {
     return "todo";
@@ -417,6 +492,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
   summaryAggregator.setOnCleared(() => {
     toolMessageBatcher.clearAll("summary_aggregator_clear");
     toolCallStreamer.clearAll("summary_aggregator_clear");
+    reasoningStreamer.clearAll("summary_aggregator_clear");
     responseStreamer.clearAll("summary_aggregator_clear");
   });
 
@@ -450,6 +526,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         clearPromptResponseMode(sessionId);
         responseStreamer.clearMessage(sessionId, messageId, "bot_context_missing");
         toolCallStreamer.clearSession(sessionId, "bot_context_missing");
+        reasoningStreamer.clearSession(sessionId, "bot_context_missing");
         assistantRunState.clearRun(sessionId, "bot_context_missing");
         foregroundSessionState.markIdle(sessionId);
         return;
@@ -460,6 +537,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         clearPromptResponseMode(sessionId);
         responseStreamer.clearMessage(sessionId, messageId, "session_mismatch");
         toolCallStreamer.clearSession(sessionId, "session_mismatch");
+        reasoningStreamer.clearSession(sessionId, "session_mismatch");
         assistantRunState.clearRun(sessionId, "session_mismatch");
         foregroundSessionState.markIdle(sessionId);
         await scheduledTaskRuntime.flushDeferredDeliveries();
@@ -485,6 +563,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
             Promise.all([
               toolMessageBatcher.flushSession(sessionId, "assistant_message_completed"),
               toolCallStreamer.breakSession(sessionId, "assistant_message_completed"),
+              reasoningStreamer.breakSession(sessionId, "assistant_message_completed"),
             ]).then(() => undefined),
           prepareStreamingPayload: prepareFinalStreamingPayload,
           renderFinalParts: (text) => renderAssistantFinalPartsSafe(text),
@@ -574,6 +653,75 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     }
   });
 
+  summaryAggregator.setOnToolProgress(async (toolInfo) => {
+    if (!botInstance || !chatIdInstance) {
+      return;
+    }
+
+    if (config.bot.hideToolCallMessages || !config.bot.enableToolProgressStream) {
+      return;
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== toolInfo.sessionId) {
+      return;
+    }
+
+    if (toolInfo.tool === "task" || toolInfo.tool === "question") {
+      return;
+    }
+
+    try {
+      const message = formatToolInfo(toolInfo);
+      if (!message) {
+        return;
+      }
+
+      const status = "status" in toolInfo.state ? toolInfo.state.status : undefined;
+      const prefix =
+        status === "running"
+          ? "▶ "
+          : status === "pending"
+            ? "⏳ "
+            : status === "completed"
+              ? "✅ "
+              : status === "error"
+                ? "❌ "
+                : "";
+
+      toolCallStreamer.replaceByPrefix(
+        toolInfo.sessionId,
+        LIVE_TOOL_STREAM_PREFIX,
+        `${prefix}${message}`,
+        "activity",
+      );
+    } catch (err) {
+      logger.error("Failed to send tool progress to Telegram:", err);
+    }
+  });
+
+  summaryAggregator.setOnReasoning(async (sessionId, _messageId, reasoningText) => {
+    if (!botInstance || !chatIdInstance) {
+      return;
+    }
+
+    if (config.bot.hideThinkingMessages || !config.bot.enableReasoningStream) {
+      return;
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession || currentSession.id !== sessionId) {
+      return;
+    }
+
+    try {
+      const formatted = formatReasoningChunk(reasoningText);
+      reasoningStreamer.replaceByPrefix(sessionId, REASONING_STREAM_PREFIX, formatted, "reasoning");
+    } catch (err) {
+      logger.error("Failed to send reasoning to Telegram:", err);
+    }
+  });
+
   summaryAggregator.setOnSubagent(async (sessionId, subagents) => {
     if (!botInstance || !chatIdInstance) {
       return;
@@ -649,6 +797,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(currentSession.id, "question_asked"),
       toolCallStreamer.flushSession(currentSession.id, "question_asked"),
+      reasoningStreamer.flushSession(currentSession.id, "question_asked"),
     ]);
 
     if (questionManager.isActive()) {
@@ -697,6 +846,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(request.sessionID, "permission_asked"),
       toolCallStreamer.flushSession(request.sessionID, "permission_asked"),
+      reasoningStreamer.flushSession(request.sessionID, "permission_asked"),
     ]);
 
     logger.info(
@@ -718,6 +868,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     logger.debug("[Bot] Agent started thinking");
 
     await toolCallStreamer.breakSession(sessionId, "thinking_started");
+    await reasoningStreamer.breakSession(sessionId, "thinking_started");
 
     deliverThinkingMessage(sessionId, toolMessageBatcher, {
       hideThinkingMessages: config.bot.hideThinkingMessages,
@@ -815,6 +966,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       await Promise.all([
         toolMessageBatcher.flushSession(sessionId, "session_idle"),
         toolCallStreamer.flushSession(sessionId, "session_idle"),
+        reasoningStreamer.flushSession(sessionId, "session_idle"),
       ]);
 
       if (completedRun?.hasCompletedResponse) {
@@ -860,6 +1012,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       clearPromptResponseMode(sessionId);
       responseStreamer.clearSession(sessionId, "session_error_not_current");
       toolCallStreamer.clearSession(sessionId, "session_error_not_current");
+      reasoningStreamer.clearSession(sessionId, "session_error_not_current");
       assistantRunState.clearRun(sessionId, "session_error_not_current");
       foregroundSessionState.markIdle(sessionId);
       await scheduledTaskRuntime.flushDeferredDeliveries();
@@ -872,6 +1025,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     await Promise.all([
       toolMessageBatcher.flushSession(sessionId, "session_error"),
       toolCallStreamer.flushSession(sessionId, "session_error"),
+      reasoningStreamer.flushSession(sessionId, "session_error"),
     ]);
 
     const normalizedMessage = message.trim() || t("common.unknown_error");
@@ -1413,6 +1567,7 @@ export function cleanupBotRuntime(reason: string): void {
   summaryAggregator.clear();
   responseStreamer.clearAll(reason);
   toolCallStreamer.clearAll(reason);
+  reasoningStreamer.clearAll(reason);
   toolMessageBatcher.clearAll(reason);
   sessionCompletionTasks.clear();
   assistantRunState.clearAll(reason);

--- a/src/bot/streaming/tool-call-streamer.ts
+++ b/src/bot/streaming/tool-call-streamer.ts
@@ -3,7 +3,7 @@ import { logger } from "../../utils/logger.js";
 const TELEGRAM_MESSAGE_SAFE_LENGTH = 4000;
 const DEFAULT_STREAM_KEY = "default";
 
-export type ToolStreamKey = "default" | "subagent" | "todo";
+export type ToolStreamKey = "default" | "subagent" | "todo" | "activity" | "reasoning";
 
 interface ToolCallStreamerOptions {
   throttleMs: number;
@@ -66,18 +66,28 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+function addMultipartMarkers(chunks: string[]): string[] {
+  if (chunks.length <= 1) {
+    return chunks;
+  }
+
+  return chunks.map((chunk, index) => `[${index + 1}/${chunks.length}]\n${chunk}`);
+}
+
 function splitLongText(text: string, limit: number): string[] {
   if (text.length <= limit) {
     return [text];
   }
 
+  const markerReserve = 16;
+  const safeLimit = Math.max(1, limit - markerReserve);
   const chunks: string[] = [];
   let remaining = text;
 
-  while (remaining.length > limit) {
-    let splitIndex = remaining.lastIndexOf("\n", limit);
-    if (splitIndex <= 0 || splitIndex < Math.floor(limit * 0.5)) {
-      splitIndex = limit;
+  while (remaining.length > safeLimit) {
+    let splitIndex = remaining.lastIndexOf("\n", safeLimit);
+    if (splitIndex <= 0 || splitIndex < Math.floor(safeLimit * 0.5)) {
+      splitIndex = safeLimit;
     }
 
     chunks.push(remaining.slice(0, splitIndex));
@@ -88,7 +98,7 @@ function splitLongText(text: string, limit: number): string[] {
     chunks.push(remaining);
   }
 
-  return chunks;
+  return addMultipartMarkers(chunks);
 }
 
 function buildParts(entries: StreamEntry[]): string[] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,8 @@ export const config = {
     hideToolCallMessages: getOptionalBooleanEnvVar("HIDE_TOOL_CALL_MESSAGES", false),
     hideToolFileMessages: getOptionalBooleanEnvVar("HIDE_TOOL_FILE_MESSAGES", false),
     messageFormatMode: getOptionalMessageFormatModeEnvVar("MESSAGE_FORMAT_MODE", "markdown"),
+    enableReasoningStream: getOptionalBooleanEnvVar("ENABLE_REASONING_STREAM", false),
+    enableToolProgressStream: getOptionalBooleanEnvVar("ENABLE_TOOL_PROGRESS_STREAM", false),
   },
   files: {
     maxFileSizeKb: parseInt(getEnvVar("CODE_FILE_MAX_SIZE_KB", false) || "100", 10),

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -32,6 +32,8 @@ type MessageCompleteCallback = (
 
 type MessagePartialCallback = (sessionId: string, messageId: string, messageText: string) => void;
 
+type ReasoningCallback = (sessionId: string, messageId: string, reasoningText: string) => void;
+
 type ExternalUserInputCallback = (
   sessionId: string,
   messageId: string,
@@ -74,6 +76,8 @@ export interface ToolFileInfo extends ToolInfo {
 }
 
 type ToolCallback = (toolInfo: ToolInfo) => void;
+
+type ToolProgressCallback = (toolInfo: ToolInfo) => void;
 
 type ToolFileCallback = (fileInfo: ToolFileInfo) => void;
 
@@ -153,6 +157,11 @@ interface TextMessageState {
   optimisticUpdateCount: number;
 }
 
+interface ReasoningMessageState {
+  orderedPartIds: string[];
+  partTexts: Map<string, string>;
+}
+
 interface SubagentState extends SubagentInfo {
   hasSubtaskMetadata: boolean;
   hasTaskToolMetadata: boolean;
@@ -191,13 +200,16 @@ function countDiffChangesFromText(text: string): { additions: number; deletions:
 class SummaryAggregator {
   private currentSessionId: string | null = null;
   private textMessageStates: Map<string, TextMessageState> = new Map();
+  private reasoningMessageStates: Map<string, ReasoningMessageState> = new Map();
   private messages: Map<string, { role: string }> = new Map();
   private messageCount = 0;
   private lastUpdated = 0;
   private onCompleteCallback: MessageCompleteCallback | null = null;
   private onPartialCallback: MessagePartialCallback | null = null;
+  private onReasoningCallback: ReasoningCallback | null = null;
   private onExternalUserInputCallback: ExternalUserInputCallback | null = null;
   private onToolCallback: ToolCallback | null = null;
+  private onToolProgressCallback: ToolProgressCallback | null = null;
   private onToolFileCallback: ToolFileCallback | null = null;
   private onQuestionCallback: QuestionCallback | null = null;
   private onQuestionErrorCallback: QuestionErrorCallback | null = null;
@@ -243,12 +255,20 @@ class SummaryAggregator {
     this.onPartialCallback = callback;
   }
 
+  setOnReasoning(callback: ReasoningCallback): void {
+    this.onReasoningCallback = callback;
+  }
+
   setOnExternalUserInput(callback: ExternalUserInputCallback): void {
     this.onExternalUserInputCallback = callback;
   }
 
   setOnTool(callback: ToolCallback): void {
     this.onToolCallback = callback;
+  }
+
+  setOnToolProgress(callback: ToolProgressCallback): void {
+    this.onToolProgressCallback = callback;
   }
 
   setOnToolFile(callback: ToolFileCallback): void {
@@ -430,6 +450,7 @@ class SummaryAggregator {
     this.stopTypingIndicator();
     this.currentSessionId = null;
     this.textMessageStates.clear();
+    this.reasoningMessageStates.clear();
     this.messages.clear();
     this.partHashes.clear();
     this.knownTextPartIds.clear();
@@ -1128,6 +1149,22 @@ class SummaryAggregator {
     if (part.type === "text") {
       this.registerKnownTextPart(messageID, part.id);
       this.registerTextPart(messageID, part.id);
+    } else if (part.type === "reasoning") {
+      this.registerReasoningPart(messageID, part.id);
+      this.applyReasoningDelta((part as { sessionID: string }).sessionID, messageID, part.id, part.text || "");
+
+      if (!this.thinkingFiredForMessages.has(messageID) && this.onThinkingCallback) {
+        this.thinkingFiredForMessages.add(messageID);
+        const callback = this.onThinkingCallback;
+        const reasoningSessionId = part.sessionID;
+        setImmediate(() => {
+          if (typeof callback === "function") {
+            callback(reasoningSessionId);
+          }
+        });
+      }
+
+      return;
     }
 
     const deltaFromUpdated = (event.properties as { delta?: unknown }).delta;
@@ -1141,20 +1178,7 @@ class SummaryAggregator {
       return;
     }
 
-    if (part.type === "reasoning") {
-      // Fire the thinking callback once per message on the first reasoning part.
-      // This is the signal that the model is actually doing extended thinking.
-      if (!this.thinkingFiredForMessages.has(messageID) && this.onThinkingCallback) {
-        this.thinkingFiredForMessages.add(messageID);
-        const callback = this.onThinkingCallback;
-        const sessionID = part.sessionID;
-        setImmediate(() => {
-          if (typeof callback === "function") {
-            callback(sessionID);
-          }
-        });
-      }
-    } else if (part.type === "text" && "text" in part && part.text) {
+    if (part.type === "text" && "text" in part && part.text) {
       const wasUpdated =
         messageInfo && messageInfo.role === "assistant"
           ? this.setTextPartSnapshot(messageID, part.id, part.text)
@@ -1212,6 +1236,25 @@ class SummaryAggregator {
         // This ensures we have access to the requestID needed for question.reply().
       }
 
+      const toolData: ToolInfo = {
+        sessionId: part.sessionID,
+        messageId: messageID,
+        callId: part.callID,
+        tool: part.tool,
+        state: part.state,
+        input,
+        title,
+        metadata:
+          "metadata" in state
+            ? (state.metadata as { [key: string]: unknown } | undefined)
+            : undefined,
+        hasFileAttachment: false,
+      };
+
+      if (this.onToolProgressCallback) {
+        this.onToolProgressCallback(toolData);
+      }
+
       if ("status" in state && state.status === "completed") {
         logger.debug(
           `[Aggregator] Tool completed: callID=${part.callID}, tool=${part.tool}`,
@@ -1230,15 +1273,8 @@ class SummaryAggregator {
             state.metadata as { [key: string]: unknown } | undefined,
           );
 
-          const toolData: ToolInfo = {
-            sessionId: part.sessionID,
-            messageId: messageID,
-            callId: part.callID,
-            tool: part.tool,
-            state: part.state,
-            input,
-            title,
-            metadata: state.metadata as { [key: string]: unknown },
+          const completedToolData: ToolInfo = {
+            ...toolData,
             hasFileAttachment: !!preparedFileContext.fileData,
           };
 
@@ -1247,7 +1283,7 @@ class SummaryAggregator {
           );
 
           if (this.onToolCallback) {
-            this.onToolCallback(toolData);
+            this.onToolCallback(completedToolData);
           }
 
           if (preparedFileContext.fileData && this.onToolFileCallback) {
@@ -1255,7 +1291,7 @@ class SummaryAggregator {
               `[Aggregator] Sending ${part.tool} file: ${preparedFileContext.fileData.filename} (${preparedFileContext.fileData.buffer.length} bytes)`,
             );
             this.onToolFileCallback({
-              ...toolData,
+              ...completedToolData,
               hasFileAttachment: true,
               fileData: preparedFileContext.fileData,
             });
@@ -1283,13 +1319,17 @@ class SummaryAggregator {
       return;
     }
 
-    if (partType && partType !== "text") {
+    if (partType && partType !== "text" && partType !== "reasoning") {
       return;
     }
 
     if (partType === "text") {
       this.registerKnownTextPart(messageID, partID);
       this.registerTextPart(messageID, partID);
+    } else if (partType === "reasoning") {
+      this.registerReasoningPart(messageID, partID);
+      this.applyReasoningDelta(sessionID, messageID, partID, delta, part?.text);
+      return;
     } else {
       const knownTextIds = this.knownTextPartIds.get(messageID);
       const isKnownTextPart = knownTextIds?.has(partID) ?? false;
@@ -1378,6 +1418,7 @@ class SummaryAggregator {
 
   private cleanupCompletedMessage(messageId: string): void {
     this.textMessageStates.delete(messageId);
+    this.reasoningMessageStates.delete(messageId);
     this.messages.delete(messageId);
     this.partHashes.delete(messageId);
     this.knownTextPartIds.delete(messageId);
@@ -1470,6 +1511,97 @@ class SummaryAggregator {
     }
 
     return state.orderedPartIds.map((partID) => state.partTexts.get(partID) || "").join("");
+  }
+
+  private emitReasoningText(sessionId: string, messageId: string, reasoningText: string): void {
+    if (!this.onReasoningCallback || !reasoningText.trim()) {
+      return;
+    }
+
+    try {
+      this.onReasoningCallback(sessionId, messageId, reasoningText);
+    } catch (err) {
+      logger.error("[Aggregator] Error in reasoning callback:", err);
+    }
+  }
+
+  private getOrCreateReasoningMessageState(messageID: string): ReasoningMessageState {
+    const existing = this.reasoningMessageStates.get(messageID);
+    if (existing) {
+      return existing;
+    }
+
+    const state: ReasoningMessageState = {
+      orderedPartIds: [],
+      partTexts: new Map(),
+    };
+    this.reasoningMessageStates.set(messageID, state);
+    return state;
+  }
+
+  private registerReasoningPart(messageID: string, partID: string): void {
+    const state = this.getOrCreateReasoningMessageState(messageID);
+    if (!state.orderedPartIds.includes(partID)) {
+      state.orderedPartIds.push(partID);
+    }
+  }
+
+  private setReasoningPartSnapshot(messageID: string, partID: string, text: string): boolean {
+    const normalized = text;
+    const partHash = this.hashString(`reasoning\n${partID}\n${normalized}`);
+
+    if (!this.partHashes.has(messageID)) {
+      this.partHashes.set(messageID, new Set());
+    }
+
+    const hashes = this.partHashes.get(messageID)!;
+    if (hashes.has(partHash)) {
+      return false;
+    }
+
+    hashes.add(partHash);
+    this.registerReasoningPart(messageID, partID);
+    const state = this.getOrCreateReasoningMessageState(messageID);
+    state.partTexts.set(partID, normalized);
+    return true;
+  }
+
+  private getCombinedReasoningText(messageID: string): string {
+    const state = this.reasoningMessageStates.get(messageID);
+    if (!state) {
+      return "";
+    }
+
+    return state.orderedPartIds.map((partID) => state.partTexts.get(partID) || "").join("");
+  }
+
+  private applyReasoningDelta(
+    sessionID: string,
+    messageID: string,
+    partID: string,
+    delta: string,
+    fullTextHint?: string,
+  ): void {
+    if (sessionID !== this.currentSessionId) {
+      return;
+    }
+
+    this.registerReasoningPart(messageID, partID);
+    const state = this.getOrCreateReasoningMessageState(messageID);
+    const previous = state.partTexts.get(partID) || "";
+    let accumulated = `${previous}${delta}`;
+
+    if (typeof fullTextHint === "string" && fullTextHint.length > accumulated.length) {
+      accumulated = fullTextHint;
+    }
+
+    state.partTexts.set(partID, accumulated);
+    const combined = this.getCombinedReasoningText(messageID);
+    if (!combined.trim()) {
+      return;
+    }
+
+    this.emitReasoningText(sessionID, messageID, combined);
   }
 
   private prepareToolFileContext(

--- a/src/summary/formatter.ts
+++ b/src/summary/formatter.ts
@@ -386,7 +386,12 @@ export function formatToolInfo(toolInfo: ToolInfo): string | null {
   }
 
   if (tool === "bash" && input && typeof input.command === "string") {
-    details = truncateWithEllipsis(input.command, config.bot.bashToolDisplayMaxLength);
+    const status = "status" in toolInfo.state ? toolInfo.state.status : undefined;
+    const bashMaxLength =
+      status === "running" || status === "pending"
+        ? Math.max(config.bot.bashToolDisplayMaxLength, 4000)
+        : config.bot.bashToolDisplayMaxLength;
+    details = truncateWithEllipsis(input.command, bashMaxLength);
   }
 
   if (tool === "apply_patch") {


### PR DESCRIPTION
## Summary
- Add reasoningStreamer for streaming model reasoning text to Telegram in real time
- Add setOnToolProgress callback for live tool activity updates with status badges
- Add multipart markers for long streamed messages
- Add config opt-in flags: ENABLE_REASONING_STREAM and ENABLE_TOOL_PROGRESS_STREAM (default: off)
- Uses SSE (no polling) for efficiency

## Related
- Follows up on feedback from PR #94 (closed)
- Fixes live watch feature as requested by grinev

## Verification
- npm run build
- npm run lint
- npx vitest run