### PR TITLE
feat(tts): add Google Cloud TTS provider and markdown stripping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,12 @@ OPENCODE_MODEL_ID=big-pickle
 
 # Text-to-Speech credentials (optional)
 # TTS reply behavior is controlled globally with /tts and persisted in settings.json.
-# Set both TTS_API_URL and TTS_API_KEY to enable audio replies.
+# Provider: "openai" (default) or "google".
+# For OpenAI-compatible APIs, set TTS_API_URL and TTS_API_KEY.
+# For Google Cloud, set TTS_PROVIDER=google and GOOGLE_APPLICATION_CREDENTIALS.
+# TTS_PROVIDER=openai
 # TTS_API_URL=
 # TTS_API_KEY=
 # TTS_MODEL=gpt-4o-mini-tts
 # TTS_VOICE=alloy
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json

--- a/.env.example
+++ b/.env.example
@@ -106,11 +106,21 @@ OPENCODE_MODEL_ID=big-pickle
 # Text-to-Speech credentials (optional)
 # TTS reply behavior is controlled globally with /tts and persisted in settings.json.
 # Provider: "openai" (default) or "google".
-# For OpenAI-compatible APIs, set TTS_API_URL and TTS_API_KEY.
-# For Google Cloud, set TTS_PROVIDER=google and GOOGLE_APPLICATION_CREDENTIALS.
-# TTS_PROVIDER=openai
+#
+# --- OpenAI-compatible (default) ---
+# Set TTS_API_URL and TTS_API_KEY to any OpenAI-compatible TTS endpoint.
 # TTS_API_URL=
 # TTS_API_KEY=
 # TTS_MODEL=gpt-4o-mini-tts
 # TTS_VOICE=alloy
+#
+# --- Google Cloud TTS ---
+# 1. Create a project at https://console.cloud.google.com
+# 2. Enable "Cloud Text-to-Speech API"
+# 3. Create a Service Account (IAM & Admin > Service Accounts)
+#    with role "Cloud Text-to-Speech API User"
+# 4. Download the JSON key file
+# Free tier: 1M characters/month (WaveNet/Neural2), 4M/month (Standard voices)
+# TTS_PROVIDER=google
+# TTS_VOICE=en-US-Studio-O
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
+        "@google-cloud/text-to-speech": "^6.4.0",
         "@grammyjs/menu": "^1.3.1",
         "@opencode-ai/sdk": "^1.1.21",
         "better-sqlite3": "^12.6.2",
@@ -621,6 +622,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@google-cloud/text-to-speech": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/text-to-speech/-/text-to-speech-6.4.0.tgz",
+      "integrity": "sha512-KUnK+mBYz9aegxHrBbwEignOkGRqXvqOXs/EGY7CAJhMFKuNSieW02/PV/ipVRsJM11MP69qgTgEetoyAN0HAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@grammyjs/menu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@grammyjs/menu/-/menu-1.3.1.tgz",
@@ -638,6 +651,37 @@
       "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.23.0.tgz",
       "integrity": "sha512-D3jQ4UWERPsyR3op/YFudMMIPNTU47vy7L51uO9/73tMELmjO/+LX5N36/Y0CG5IQfIsz43MxiHI5rgsK0/k+g==",
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -681,7 +725,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -699,7 +742,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -712,7 +754,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -773,6 +814,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -821,12 +872,75 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1241,7 +1355,6 @@
       "version": "25.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.8.tgz",
       "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1743,7 +1856,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1753,7 +1865,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1808,7 +1919,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -1843,6 +1953,15 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bindings": {
@@ -1899,6 +2018,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1990,11 +2115,61 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2007,7 +2182,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2021,7 +2195,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2030,6 +2203,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -2159,18 +2341,37 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -2229,6 +2430,15 @@
         "@esbuild/win32-arm64": "0.27.2",
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2504,6 +2714,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2566,7 +2799,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -2577,6 +2809,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-constants": {
@@ -2605,6 +2849,61 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2677,6 +2976,132 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-gax/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-gax/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/grammy": {
       "version": "1.39.2",
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.39.2.tgz",
@@ -2721,6 +3146,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -2839,7 +3277,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2884,7 +3321,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -2945,7 +3381,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -2977,6 +3412,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2997,6 +3441,27 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3038,12 +3503,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3066,7 +3543,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/magic-string": {
@@ -3919,7 +4395,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3981,6 +4456,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -3999,6 +4494,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/once": {
@@ -4064,7 +4568,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -4104,7 +4607,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4114,7 +4616,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -4243,6 +4744,42 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -4400,6 +4937,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4418,6 +4964,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/reusify": {
@@ -4553,7 +5112,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4566,7 +5124,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4583,7 +5140,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -4699,6 +5255,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4712,7 +5283,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -4731,7 +5301,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4746,14 +5315,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4766,7 +5333,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -4782,7 +5348,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4796,7 +5361,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4838,6 +5402,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4877,6 +5447,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/telegram-markdown-v2": {
@@ -5140,7 +5743,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -5447,6 +6049,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -5467,7 +6078,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5510,7 +6120,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -5529,7 +6138,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5547,14 +6155,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5569,7 +6175,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5582,7 +6187,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5595,7 +6199,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5612,6 +6215,62 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "homepage": "https://github.com/grinev/opencode-telegram-bot#readme",
   "dependencies": {
+    "@google-cloud/text-to-speech": "^6.4.0",
     "@grammyjs/menu": "^1.3.1",
     "@opencode-ai/sdk": "^1.1.21",
     "better-sqlite3": "^12.6.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,7 @@ export const config = {
   tts: {
     apiUrl: getEnvVar("TTS_API_URL", false),
     apiKey: getEnvVar("TTS_API_KEY", false),
+    provider: getEnvVar("TTS_PROVIDER", false) || "openai",
     model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
     voice: getEnvVar("TTS_VOICE", false) || "alloy",
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ const runtimePaths = getRuntimePaths();
 dotenv.config({ path: runtimePaths.envFilePath, quiet: true });
 
 export type MessageFormatMode = "raw" | "markdown";
+export type TtsProvider = "openai" | "google";
 
 function getEnvVar(key: string, required: boolean = true): string {
   const value = process.env[key];
@@ -75,6 +76,23 @@ function getOptionalMessageFormatModeEnvVar(
   return defaultValue;
 }
 
+const VALID_TTS_PROVIDERS: TtsProvider[] = ["openai", "google"];
+
+function getOptionalTtsProviderEnvVar(key: string, defaultValue: TtsProvider): TtsProvider {
+  const value = getEnvVar(key, false);
+
+  if (!value) {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (VALID_TTS_PROVIDERS.includes(normalized as TtsProvider)) {
+    return normalized as TtsProvider;
+  }
+
+  return defaultValue;
+}
+
 export const config = {
   telegram: {
     token: getEnvVar("TELEGRAM_BOT_TOKEN"),
@@ -126,7 +144,7 @@ export const config = {
   tts: {
     apiUrl: getEnvVar("TTS_API_URL", false),
     apiKey: getEnvVar("TTS_API_KEY", false),
-    provider: getEnvVar("TTS_PROVIDER", false) || "openai",
+    provider: getOptionalTtsProviderEnvVar("TTS_PROVIDER", "openai"),
     model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
     voice: getEnvVar("TTS_VOICE", false) || "alloy",
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,11 +141,15 @@ export const config = {
     language: getEnvVar("STT_LANGUAGE", false),
     notePrompt: getEnvVar("STT_NOTE_PROMPT", false),
   },
-  tts: {
-    apiUrl: getEnvVar("TTS_API_URL", false),
-    apiKey: getEnvVar("TTS_API_KEY", false),
-    provider: getOptionalTtsProviderEnvVar("TTS_PROVIDER", "openai"),
-    model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
-    voice: getEnvVar("TTS_VOICE", false) || "alloy",
-  },
+  tts: (() => {
+    const provider = getOptionalTtsProviderEnvVar("TTS_PROVIDER", "openai");
+    const defaultVoice = provider === "google" ? "en-US-Studio-O" : "alloy";
+    return {
+      apiUrl: getEnvVar("TTS_API_URL", false),
+      apiKey: getEnvVar("TTS_API_KEY", false),
+      provider,
+      model: getEnvVar("TTS_MODEL", false) || "gpt-4o-mini-tts",
+      voice: getEnvVar("TTS_VOICE", false) || defaultVoice,
+    };
+  })(),
 };

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -12,7 +12,7 @@ export interface TtsResult {
 
 export function isTtsConfigured(): boolean {
   if (config.tts.provider === "google") {
-    return Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+    return true;
   }
   return Boolean(config.tts.apiUrl && config.tts.apiKey);
 }
@@ -41,7 +41,7 @@ export function stripMarkdownForSpeech(text: string): string {
   clean = clean.replace(/^[-*]\s+/gm, "");
   clean = clean.replace(/^\d+\.\s+/gm, "");
   clean = clean.replace(/^[-*_]{3,}\s*$/gm, "");
-  clean = clean.replace(/<[^>]+>/g, "");
+  clean = clean.replace(/<\/?[A-Za-z][^>]*>/g, "");
   clean = clean.replace(/[ \t]+/g, " ");
   clean = clean.replace(/\n{3,}/g, "\n\n");
 
@@ -65,6 +65,11 @@ function getGoogleClient(): textToSpeech.TextToSpeechClient {
   return googleClient;
 }
 
+/** @internal Reset Google client singleton (for tests only). */
+export function _resetGoogleClient(): void {
+  googleClient = null;
+}
+
 async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
   const client = getGoogleClient();
   const voiceName = config.tts.voice || "en-US-Studio-O";
@@ -74,14 +79,18 @@ async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
     `[TTS] Google Cloud TTS: voice=${voiceName}, languageCode=${languageCode}, chars=${text.length}`,
   );
 
-  const [response] = await client.synthesizeSpeech({
-    input: { text },
-    voice: { languageCode, name: voiceName },
-    audioConfig: { audioEncoding: "MP3" },
-  });
+  const [response] = await client.synthesizeSpeech(
+    {
+      input: { text },
+      voice: { languageCode, name: voiceName },
+      audioConfig: { audioEncoding: "MP3" },
+    },
+    { timeout: TTS_REQUEST_TIMEOUT_MS },
+  );
 
-  const buffer = response.audioContent as Buffer;
-  if (!buffer || buffer.length === 0) {
+  const raw = response.audioContent;
+  const buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw as Uint8Array);
+  if (buffer.length === 0) {
     throw new Error("Google TTS API returned an empty audio response");
   }
 
@@ -135,9 +144,15 @@ async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
 
 // --- Public API ---
 
+function getNotConfiguredMessage(): string {
+  return config.tts.provider === "google"
+    ? "TTS is not configured: set GOOGLE_APPLICATION_CREDENTIALS for Google Cloud TTS"
+    : "TTS is not configured: set TTS_API_URL and TTS_API_KEY";
+}
+
 export async function synthesizeSpeech(text: string): Promise<TtsResult> {
   if (!isTtsConfigured()) {
-    throw new Error("TTS is not configured: set TTS API credentials");
+    throw new Error(getNotConfiguredMessage());
   }
 
   const raw = text.trim();

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -18,75 +18,56 @@ export function isTtsConfigured(): boolean {
 }
 
 /**
- * Strip markdown formatting from text before sending to TTS.
- * Removes: **bold**, *italic*, `code`, ```code blocks```, ~~strikethrough~~,
- *          [link text](url), # headings, > blockquotes, - / * list markers,
- *          bare URLs, HTML tags.
+ * Removes markdown syntax that TTS engines would read aloud
+ * (asterisks, backticks, heading markers, etc.).
  */
-function stripMarkdownForSpeech(text: string): string {
+export function stripMarkdownForSpeech(text: string): string {
   let clean = text;
 
-  // Code blocks (```...```) — replace with content on one line
+  // fenced code blocks → inline content
   clean = clean.replace(/```[\s\S]*?```/g, (match) => {
     const inner = match.replace(/^```\w*\n?/, "").replace(/\n?```$/, "");
     return inner.replace(/\n/g, " ");
   });
 
-  // Inline code (`...`) — just remove backticks
   clean = clean.replace(/`([^`]+)`/g, "$1");
-
-  // Bold + italic (***) — remove markers only
   clean = clean.replace(/\*\*\*(.+?)\*\*\*/g, "$1");
-
-  // Bold (**) — remove markers only
   clean = clean.replace(/\*\*(.+?)\*\*/g, "$1");
-
-  // Italic (*) — remove markers only
   clean = clean.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-
-  // Strikethrough (~~)
   clean = clean.replace(/~~(.+?)~~/g, "$1");
-
-  // Links [text](url) → text
   clean = clean.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
-
-  // Headings (# at start of line)
   clean = clean.replace(/^#{1,6}\s+/gm, "");
-
-  // Blockquotes (> at start of line)
   clean = clean.replace(/^>\s?/gm, "");
-
-  // Unordered list markers (- or * at start of line) — keep the text
-  clean = clean.replace(/^[\-\*]\s+/gm, "");
-
-  // Ordered list markers (1. at start of line)
+  clean = clean.replace(/^[-*]\s+/gm, "");
   clean = clean.replace(/^\d+\.\s+/gm, "");
-
-  // Horizontal rules (---, ***, ___)
-  clean = clean.replace(/^[\-\*\_]{3,}\s*$/gm, "");
-
-  // HTML tags
+  clean = clean.replace(/^[-*_]{3,}\s*$/gm, "");
   clean = clean.replace(/<[^>]+>/g, "");
-
-  // Collapse multiple whitespace into single space
   clean = clean.replace(/[ \t]+/g, " ");
-
-  // Collapse multiple newlines into max one
   clean = clean.replace(/\n{3,}/g, "\n\n");
 
   return clean.trim();
 }
 
-function extractLanguageCode(voiceName: string): string {
-  // Voice names follow the pattern: ll-CC-Type-Gender (e.g. "de-DE-Neural2-B")
+/** Extracts "ll-CC" from Google voice names like "de-DE-Neural2-B". */
+export function extractLanguageCode(voiceName: string): string {
   const match = voiceName.match(/^([a-z]{2}-[A-Z]{2})/);
   return match ? match[1] : "en-US";
 }
 
-async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
-  const client = new textToSpeech.TextToSpeechClient();
+// --- Provider implementations ---
 
-  const voiceName = config.tts.voice || "de-DE-Neural2-B";
+let googleClient: textToSpeech.TextToSpeechClient | null = null;
+
+function getGoogleClient(): textToSpeech.TextToSpeechClient {
+  if (!googleClient) {
+    googleClient = new textToSpeech.TextToSpeechClient();
+  }
+  return googleClient;
+}
+
+async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
+  const client = getGoogleClient();
+  const voiceName = config.tts.voice || "en-US-Studio-O";
   const languageCode = extractLanguageCode(voiceName);
 
   logger.debug(
@@ -95,10 +76,7 @@ async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
 
   const [response] = await client.synthesizeSpeech({
     input: { text },
-    voice: {
-      languageCode,
-      name: voiceName,
-    },
+    voice: { languageCode, name: voiceName },
     audioConfig: { audioEncoding: "MP3" },
   });
 
@@ -107,25 +85,20 @@ async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
     throw new Error("Google TTS API returned an empty audio response");
   }
 
-  return {
-    buffer,
-    filename: "assistant-reply.mp3",
-    mimeType: "audio/mpeg",
-  };
+  return { buffer, filename: "assistant-reply.mp3", mimeType: "audio/mpeg" };
 }
 
 async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
-  const input = text.trim();
+  const url = `${config.tts.apiUrl}/audio/speech`;
+
+  logger.debug(
+    `[TTS] OpenAI-compatible: url=${url}, model=${config.tts.model}, voice=${config.tts.voice}, chars=${text.length}`,
+  );
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TTS_REQUEST_TIMEOUT_MS);
 
   try {
-    const url = `${config.tts.apiUrl}/audio/speech`;
-
-    logger.debug(
-      `[TTS] Sending speech synthesis request: url=${url}, model=${config.tts.model}, voice=${config.tts.voice}, chars=${input.length}`,
-    );
-
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -135,7 +108,7 @@ async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
       body: JSON.stringify({
         model: config.tts.model,
         voice: config.tts.voice,
-        input,
+        input: text,
         response_format: "mp3",
       }),
       signal: controller.signal,
@@ -148,24 +121,19 @@ async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
       );
     }
 
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-
+    const buffer = Buffer.from(await response.arrayBuffer());
     if (buffer.length === 0) {
       throw new Error("TTS API returned an empty audio response");
     }
 
     logger.debug(`[TTS] Generated speech audio: ${buffer.length} bytes`);
-
-    return {
-      buffer,
-      filename: "assistant-reply.mp3",
-      mimeType: "audio/mpeg",
-    };
+    return { buffer, filename: "assistant-reply.mp3", mimeType: "audio/mpeg" };
   } finally {
     clearTimeout(timeout);
   }
 }
+
+// --- Public API ---
 
 export async function synthesizeSpeech(text: string): Promise<TtsResult> {
   if (!isTtsConfigured()) {
@@ -188,7 +156,6 @@ export async function synthesizeSpeech(text: string): Promise<TtsResult> {
     if (err instanceof DOMException && err.name === "AbortError") {
       throw new Error(`TTS request timed out after ${TTS_REQUEST_TIMEOUT_MS}ms`);
     }
-
     throw err;
   }
 }

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -1,5 +1,6 @@
 import { config } from "../config.js";
 import { logger } from "../utils/logger.js";
+import textToSpeech from "@google-cloud/text-to-speech";
 
 const TTS_REQUEST_TIMEOUT_MS = 60_000;
 
@@ -10,19 +11,111 @@ export interface TtsResult {
 }
 
 export function isTtsConfigured(): boolean {
+  if (config.tts.provider === "google") {
+    return Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+  }
   return Boolean(config.tts.apiUrl && config.tts.apiKey);
 }
 
-export async function synthesizeSpeech(text: string): Promise<TtsResult> {
-  if (!isTtsConfigured()) {
-    throw new Error("TTS is not configured: set TTS API credentials");
+/**
+ * Strip markdown formatting from text before sending to TTS.
+ * Removes: **bold**, *italic*, `code`, ```code blocks```, ~~strikethrough~~,
+ *          [link text](url), # headings, > blockquotes, - / * list markers,
+ *          bare URLs, HTML tags.
+ */
+function stripMarkdownForSpeech(text: string): string {
+  let clean = text;
+
+  // Code blocks (```...```) — replace with content on one line
+  clean = clean.replace(/```[\s\S]*?```/g, (match) => {
+    const inner = match.replace(/^```\w*\n?/, "").replace(/\n?```$/, "");
+    return inner.replace(/\n/g, " ");
+  });
+
+  // Inline code (`...`) — just remove backticks
+  clean = clean.replace(/`([^`]+)`/g, "$1");
+
+  // Bold + italic (***) — remove markers only
+  clean = clean.replace(/\*\*\*(.+?)\*\*\*/g, "$1");
+
+  // Bold (**) — remove markers only
+  clean = clean.replace(/\*\*(.+?)\*\*/g, "$1");
+
+  // Italic (*) — remove markers only
+  clean = clean.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
+
+  // Strikethrough (~~)
+  clean = clean.replace(/~~(.+?)~~/g, "$1");
+
+  // Links [text](url) → text
+  clean = clean.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+  // Headings (# at start of line)
+  clean = clean.replace(/^#{1,6}\s+/gm, "");
+
+  // Blockquotes (> at start of line)
+  clean = clean.replace(/^>\s?/gm, "");
+
+  // Unordered list markers (- or * at start of line) — keep the text
+  clean = clean.replace(/^[\-\*]\s+/gm, "");
+
+  // Ordered list markers (1. at start of line)
+  clean = clean.replace(/^\d+\.\s+/gm, "");
+
+  // Horizontal rules (---, ***, ___)
+  clean = clean.replace(/^[\-\*\_]{3,}\s*$/gm, "");
+
+  // HTML tags
+  clean = clean.replace(/<[^>]+>/g, "");
+
+  // Collapse multiple whitespace into single space
+  clean = clean.replace(/[ \t]+/g, " ");
+
+  // Collapse multiple newlines into max one
+  clean = clean.replace(/\n{3,}/g, "\n\n");
+
+  return clean.trim();
+}
+
+function extractLanguageCode(voiceName: string): string {
+  // Voice names follow the pattern: ll-CC-Type-Gender (e.g. "de-DE-Neural2-B")
+  const match = voiceName.match(/^([a-z]{2}-[A-Z]{2})/);
+  return match ? match[1] : "en-US";
+}
+
+async function synthesizeWithGoogle(text: string): Promise<TtsResult> {
+  const client = new textToSpeech.TextToSpeechClient();
+
+  const voiceName = config.tts.voice || "de-DE-Neural2-B";
+  const languageCode = extractLanguageCode(voiceName);
+
+  logger.debug(
+    `[TTS] Google Cloud TTS: voice=${voiceName}, languageCode=${languageCode}, chars=${text.length}`,
+  );
+
+  const [response] = await client.synthesizeSpeech({
+    input: { text },
+    voice: {
+      languageCode,
+      name: voiceName,
+    },
+    audioConfig: { audioEncoding: "MP3" },
+  });
+
+  const buffer = response.audioContent as Buffer;
+  if (!buffer || buffer.length === 0) {
+    throw new Error("Google TTS API returned an empty audio response");
   }
 
+  return {
+    buffer,
+    filename: "assistant-reply.mp3",
+    mimeType: "audio/mpeg",
+  };
+}
+
+async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
   const input = text.trim();
-  if (!input) {
-    throw new Error("TTS input text is empty");
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TTS_REQUEST_TIMEOUT_MS);
 
@@ -69,13 +162,33 @@ export async function synthesizeSpeech(text: string): Promise<TtsResult> {
       filename: "assistant-reply.mp3",
       mimeType: "audio/mpeg",
     };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function synthesizeSpeech(text: string): Promise<TtsResult> {
+  if (!isTtsConfigured()) {
+    throw new Error("TTS is not configured: set TTS API credentials");
+  }
+
+  const raw = text.trim();
+  if (!raw) {
+    throw new Error("TTS input text is empty");
+  }
+
+  const input = stripMarkdownForSpeech(raw);
+
+  try {
+    if (config.tts.provider === "google") {
+      return await synthesizeWithGoogle(input);
+    }
+    return await synthesizeWithOpenAi(input);
   } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") {
       throw new Error(`TTS request timed out after ${TTS_REQUEST_TIMEOUT_MS}ms`);
     }
 
     throw err;
-  } finally {
-    clearTimeout(timeout);
   }
 }

--- a/src/tts/client.ts
+++ b/src/tts/client.ts
@@ -12,7 +12,7 @@ export interface TtsResult {
 
 export function isTtsConfigured(): boolean {
   if (config.tts.provider === "google") {
-    return true;
+    return Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS);
   }
   return Boolean(config.tts.apiUrl && config.tts.apiKey);
 }
@@ -50,7 +50,7 @@ export function stripMarkdownForSpeech(text: string): string {
 
 /** Extracts "ll-CC" from Google voice names like "de-DE-Neural2-B". */
 export function extractLanguageCode(voiceName: string): string {
-  const match = voiceName.match(/^([a-z]{2}-[A-Z]{2})/);
+  const match = voiceName.match(/^([a-z]{2,3}-[A-Z]{2})/);
   return match ? match[1] : "en-US";
 }
 

--- a/tests/tts/client.test.ts
+++ b/tests/tts/client.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../src/utils/logger.js", () => ({
 const mockTts = vi.hoisted(() => ({
   apiUrl: "",
   apiKey: "",
+  provider: "openai",
   model: "gpt-4o-mini-tts",
   voice: "alloy",
 }));
@@ -49,25 +50,132 @@ vi.mock("../../src/config.js", () => ({
   },
 }));
 
-import { isTtsConfigured, synthesizeSpeech } from "../../src/tts/client.js";
+import {
+  isTtsConfigured,
+  synthesizeSpeech,
+  stripMarkdownForSpeech,
+  extractLanguageCode,
+} from "../../src/tts/client.js";
 
 describe("isTtsConfigured", () => {
   beforeEach(() => {
     mockTts.apiUrl = "";
     mockTts.apiKey = "";
-    mockTts.model = "gpt-4o-mini-tts";
-    mockTts.voice = "alloy";
+    mockTts.provider = "openai";
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
 
-  it("returns false when credentials are missing", () => {
+  it("returns false when OpenAI credentials are missing", () => {
     mockTts.apiUrl = "https://api.openai.com/v1";
     expect(isTtsConfigured()).toBe(false);
   });
 
-  it("returns true when credentials are set", () => {
+  it("returns true when OpenAI credentials are set", () => {
     mockTts.apiUrl = "https://api.openai.com/v1";
     mockTts.apiKey = "sk-test-key";
     expect(isTtsConfigured()).toBe(true);
+  });
+
+  it("returns false for google provider without GOOGLE_APPLICATION_CREDENTIALS", () => {
+    mockTts.provider = "google";
+    expect(isTtsConfigured()).toBe(false);
+  });
+
+  it("returns true for google provider with GOOGLE_APPLICATION_CREDENTIALS", () => {
+    mockTts.provider = "google";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/to/key.json";
+    expect(isTtsConfigured()).toBe(true);
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  });
+});
+
+describe("stripMarkdownForSpeech", () => {
+  it("strips bold markers", () => {
+    expect(stripMarkdownForSpeech("this is **bold** text")).toBe("this is bold text");
+  });
+
+  it("strips italic markers", () => {
+    expect(stripMarkdownForSpeech("this is *italic* text")).toBe("this is italic text");
+  });
+
+  it("strips bold+italic markers", () => {
+    expect(stripMarkdownForSpeech("this is ***both*** text")).toBe("this is both text");
+  });
+
+  it("strips inline code backticks", () => {
+    expect(stripMarkdownForSpeech("run `npm install` now")).toBe("run npm install now");
+  });
+
+  it("strips fenced code blocks but keeps content", () => {
+    const input = "before\n```js\nconst x = 1\n```\nafter";
+    expect(stripMarkdownForSpeech(input)).toBe("before\nconst x = 1\nafter");
+  });
+
+  it("strips strikethrough", () => {
+    expect(stripMarkdownForSpeech("this is ~~deleted~~ text")).toBe("this is deleted text");
+  });
+
+  it("extracts link text and drops URL", () => {
+    expect(stripMarkdownForSpeech("click [here](https://example.com) now")).toBe(
+      "click here now",
+    );
+  });
+
+  it("strips heading markers", () => {
+    expect(stripMarkdownForSpeech("## Title")).toBe("Title");
+    expect(stripMarkdownForSpeech("### Subtitle")).toBe("Subtitle");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(stripMarkdownForSpeech("> quoted text")).toBe("quoted text");
+  });
+
+  it("strips unordered list markers", () => {
+    expect(stripMarkdownForSpeech("- item one\n* item two")).toBe("item one\nitem two");
+  });
+
+  it("strips ordered list markers", () => {
+    expect(stripMarkdownForSpeech("1. first\n2. second")).toBe("first\nsecond");
+  });
+
+  it("strips HTML tags", () => {
+    expect(stripMarkdownForSpeech("see <code>this</code>")).toBe("see this");
+  });
+
+  it("collapses excessive whitespace", () => {
+    expect(stripMarkdownForSpeech("too   many   spaces")).toBe("too many spaces");
+  });
+
+  it("handles complex markdown from LLM output", () => {
+    const input = "## Result\n\nThe **answer** is `42`. See [docs](https://example.com) for details.\n\n> Important note\n\n- Point one\n- Point two";
+    const result = stripMarkdownForSpeech(input);
+    expect(result).not.toContain("**");
+    expect(result).not.toContain("`");
+    expect(result).not.toContain("##");
+    expect(result).not.toContain("[docs]");
+    expect(result).not.toContain("(https:");
+    expect(result).not.toContain("> ");
+    expect(result).not.toContain("- ");
+    expect(result).toContain("answer");
+    expect(result).toContain("42");
+    expect(result).toContain("docs");
+  });
+});
+
+describe("extractLanguageCode", () => {
+  it("extracts de-DE from German voice names", () => {
+    expect(extractLanguageCode("de-DE-Neural2-B")).toBe("de-DE");
+    expect(extractLanguageCode("de-DE-Studio-C")).toBe("de-DE");
+    expect(extractLanguageCode("de-DE-Chirp3-HD-Aoede")).toBe("de-DE");
+  });
+
+  it("extracts en-US from English voice names", () => {
+    expect(extractLanguageCode("en-US-Studio-O")).toBe("en-US");
+    expect(extractLanguageCode("en-US-Neural2-F")).toBe("en-US");
+  });
+
+  it("falls back to en-US for unrecognized patterns", () => {
+    expect(extractLanguageCode("unknown")).toBe("en-US");
   });
 });
 
@@ -75,6 +183,7 @@ describe("synthesizeSpeech", () => {
   beforeEach(() => {
     mockTts.apiUrl = "https://api.openai.com/v1";
     mockTts.apiKey = "sk-test-key";
+    mockTts.provider = "openai";
     mockTts.model = "gpt-4o-mini-tts";
     mockTts.voice = "alloy";
     vi.restoreAllMocks();
@@ -84,6 +193,20 @@ describe("synthesizeSpeech", () => {
     mockTts.apiKey = "";
 
     await expect(synthesizeSpeech("hello")).rejects.toThrow("TTS is not configured");
+  });
+
+  it("strips markdown before sending to TTS", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(Uint8Array.from([1, 2, 3]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+    );
+
+    await synthesizeSpeech("Hello **bold** world");
+
+    const body = JSON.parse(String(fetchSpy.mock.calls[0][1]?.body));
+    expect(body.input).toBe("Hello bold world");
   });
 
   it("sends correct request and returns audio bytes", async () => {

--- a/tests/tts/client.test.ts
+++ b/tests/tts/client.test.ts
@@ -93,9 +93,17 @@ describe("isTtsConfigured", () => {
     expect(isTtsConfigured()).toBe(true);
   });
 
-  it("returns true for google provider (ADC support)", () => {
+  it("returns false for google provider without GOOGLE_APPLICATION_CREDENTIALS", () => {
     mockTts.provider = "google";
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    expect(isTtsConfigured()).toBe(false);
+  });
+
+  it("returns true for google provider with GOOGLE_APPLICATION_CREDENTIALS", () => {
+    mockTts.provider = "google";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/to/key.json";
     expect(isTtsConfigured()).toBe(true);
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
 });
 
@@ -188,6 +196,11 @@ describe("extractLanguageCode", () => {
     expect(extractLanguageCode("en-US-Neural2-F")).toBe("en-US");
   });
 
+  it("extracts 3-letter language codes like cmn-CN and yue-HK", () => {
+    expect(extractLanguageCode("cmn-CN-Wavenet-A")).toBe("cmn-CN");
+    expect(extractLanguageCode("yue-HK-Standard-A")).toBe("yue-HK");
+  });
+
   it("falls back to en-US for unrecognized patterns", () => {
     expect(extractLanguageCode("unknown")).toBe("en-US");
   });
@@ -271,15 +284,18 @@ describe("synthesizeSpeech (Google)", () => {
   beforeEach(() => {
     mockTts.provider = "google";
     mockTts.voice = "en-US-Studio-O";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/to/key.json";
     _resetGoogleClient();
     mockSynthesizeSpeech.mockResolvedValue([{ audioContent: Buffer.from([4, 5, 6]) }]);
   });
 
   afterEach(() => {
     mockSynthesizeSpeech.mockReset();
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
 
   it("sends correct parameters to Google TTS", async () => {
+    mockTts.voice = "";
     const result = await synthesizeSpeech("Hello world");
 
     expect(mockSynthesizeSpeech).toHaveBeenCalledOnce();

--- a/tests/tts/client.test.ts
+++ b/tests/tts/client.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSynthesizeSpeech = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/utils/logger.js", () => ({
   logger: {
@@ -9,10 +11,25 @@ vi.mock("../../src/utils/logger.js", () => ({
   },
 }));
 
+vi.mock("@google-cloud/text-to-speech", () => {
+  const instance = { synthesizeSpeech: mockSynthesizeSpeech };
+  return {
+    __esModule: true,
+    default: {
+      TextToSpeechClient: function () {
+        return instance;
+      },
+    },
+    TextToSpeechClient: function () {
+      return instance;
+    },
+  };
+});
+
 const mockTts = vi.hoisted(() => ({
   apiUrl: "",
   apiKey: "",
-  provider: "openai",
+  provider: "openai" as string,
   model: "gpt-4o-mini-tts",
   voice: "alloy",
 }));
@@ -55,6 +72,7 @@ import {
   synthesizeSpeech,
   stripMarkdownForSpeech,
   extractLanguageCode,
+  _resetGoogleClient,
 } from "../../src/tts/client.js";
 
 describe("isTtsConfigured", () => {
@@ -62,7 +80,6 @@ describe("isTtsConfigured", () => {
     mockTts.apiUrl = "";
     mockTts.apiKey = "";
     mockTts.provider = "openai";
-    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
 
   it("returns false when OpenAI credentials are missing", () => {
@@ -76,16 +93,9 @@ describe("isTtsConfigured", () => {
     expect(isTtsConfigured()).toBe(true);
   });
 
-  it("returns false for google provider without GOOGLE_APPLICATION_CREDENTIALS", () => {
+  it("returns true for google provider (ADC support)", () => {
     mockTts.provider = "google";
-    expect(isTtsConfigured()).toBe(false);
-  });
-
-  it("returns true for google provider with GOOGLE_APPLICATION_CREDENTIALS", () => {
-    mockTts.provider = "google";
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/path/to/key.json";
     expect(isTtsConfigured()).toBe(true);
-    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
 });
 
@@ -116,9 +126,7 @@ describe("stripMarkdownForSpeech", () => {
   });
 
   it("extracts link text and drops URL", () => {
-    expect(stripMarkdownForSpeech("click [here](https://example.com) now")).toBe(
-      "click here now",
-    );
+    expect(stripMarkdownForSpeech("click [here](https://example.com) now")).toBe("click here now");
   });
 
   it("strips heading markers", () => {
@@ -140,6 +148,11 @@ describe("stripMarkdownForSpeech", () => {
 
   it("strips HTML tags", () => {
     expect(stripMarkdownForSpeech("see <code>this</code>")).toBe("see this");
+    expect(stripMarkdownForSpeech("see <em>this</em> now")).toBe("see this now");
+  });
+
+  it("preserves angle brackets that are not HTML-like", () => {
+    expect(stripMarkdownForSpeech("check 2 < 3")).toBe("check 2 < 3");
   });
 
   it("collapses excessive whitespace", () => {
@@ -147,7 +160,8 @@ describe("stripMarkdownForSpeech", () => {
   });
 
   it("handles complex markdown from LLM output", () => {
-    const input = "## Result\n\nThe **answer** is `42`. See [docs](https://example.com) for details.\n\n> Important note\n\n- Point one\n- Point two";
+    const input =
+      "## Result\n\nThe **answer** is `42`. See [docs](https://example.com) for details.\n\n> Important note\n\n- Point one\n- Point two";
     const result = stripMarkdownForSpeech(input);
     expect(result).not.toContain("**");
     expect(result).not.toContain("`");
@@ -179,7 +193,7 @@ describe("extractLanguageCode", () => {
   });
 });
 
-describe("synthesizeSpeech", () => {
+describe("synthesizeSpeech (OpenAI)", () => {
   beforeEach(() => {
     mockTts.apiUrl = "https://api.openai.com/v1";
     mockTts.apiKey = "sk-test-key";
@@ -189,10 +203,10 @@ describe("synthesizeSpeech", () => {
     vi.restoreAllMocks();
   });
 
-  it("throws when TTS is not configured", async () => {
+  it("throws with provider-specific message when not configured", async () => {
     mockTts.apiKey = "";
 
-    await expect(synthesizeSpeech("hello")).rejects.toThrow("TTS is not configured");
+    await expect(synthesizeSpeech("hello")).rejects.toThrow("TTS_API_URL and TTS_API_KEY");
   });
 
   it("strips markdown before sending to TTS", async () => {
@@ -250,5 +264,62 @@ describe("synthesizeSpeech", () => {
     await expect(synthesizeSpeech("Hello world")).rejects.toThrow(
       "TTS API returned HTTP 400: Bad request",
     );
+  });
+});
+
+describe("synthesizeSpeech (Google)", () => {
+  beforeEach(() => {
+    mockTts.provider = "google";
+    mockTts.voice = "en-US-Studio-O";
+    _resetGoogleClient();
+    mockSynthesizeSpeech.mockResolvedValue([{ audioContent: Buffer.from([4, 5, 6]) }]);
+  });
+
+  afterEach(() => {
+    mockSynthesizeSpeech.mockReset();
+  });
+
+  it("sends correct parameters to Google TTS", async () => {
+    const result = await synthesizeSpeech("Hello world");
+
+    expect(mockSynthesizeSpeech).toHaveBeenCalledOnce();
+    const callArgs = mockSynthesizeSpeech.mock.calls[0];
+    expect(callArgs[0].input).toEqual({ text: "Hello world" });
+    expect(callArgs[0].voice).toEqual({ languageCode: "en-US", name: "en-US-Studio-O" });
+    expect(callArgs[0].audioConfig).toEqual({ audioEncoding: "MP3" });
+
+    expect(result.filename).toBe("assistant-reply.mp3");
+    expect(result.mimeType).toBe("audio/mpeg");
+    expect(result.buffer).toEqual(Buffer.from([4, 5, 6]));
+  });
+
+  it("passes timeout option to Google SDK", async () => {
+    await synthesizeSpeech("Hello");
+
+    const callArgs = mockSynthesizeSpeech.mock.calls[0];
+    expect(callArgs[1]).toHaveProperty("timeout");
+    expect(callArgs[1].timeout).toBe(60_000);
+  });
+
+  it("handles Uint8Array audioContent from Google SDK", async () => {
+    const uint8 = new Uint8Array([10, 20, 30]);
+    mockSynthesizeSpeech.mockResolvedValue([{ audioContent: uint8 }]);
+
+    const result = await synthesizeSpeech("test");
+
+    expect(result.buffer).toEqual(Buffer.from([10, 20, 30]));
+  });
+
+  it("throws on empty audio response", async () => {
+    mockSynthesizeSpeech.mockResolvedValue([{ audioContent: Buffer.alloc(0) }]);
+
+    await expect(synthesizeSpeech("test")).rejects.toThrow("empty audio response");
+  });
+
+  it("strips markdown before sending to Google TTS", async () => {
+    await synthesizeSpeech("Hello **bold** and `code`");
+
+    const callArgs = mockSynthesizeSpeech.mock.calls[0];
+    expect(callArgs[0].input).toEqual({ text: "Hello bold and code" });
   });
 });


### PR DESCRIPTION
Builds on #63 — adds an alternative TTS backend and ensures clean speech output.

## Summary

- **Google Cloud TTS provider**: New `TTS_PROVIDER=google` option alongside the existing OpenAI-compatible path. Uses `@google-cloud/text-to-speech` SDK with a singleton client. Language code is auto-extracted from the voice name (e.g. `de-DE` from `de-DE-Neural2-B`), so `BOT_LOCALE` doesn't need to match.
- **Markdown stripping**: All text is cleaned before synthesis — removes `**bold**`, `*italic*`, `` `code` ``, fenced code blocks, links, headings, list markers, HTML tags, etc. This prevents TTS engines from reading markdown syntax aloud (asterisks, backticks, etc.).
- **20 new tests**: Covers markdown stripping, language code extraction, Google provider detection, and markdown-stripped synthesis. All 713 tests pass.
- **Updated `.env.example`**: Includes Google Cloud setup instructions and free tier info (1M chars/month for Neural2/WaveNet, 4M/month for Standard).

## Config

```env
# OpenAI-compatible (default, no change for existing users)
TTS_PROVIDER=openai
TTS_API_URL=https://api.openai.com/v1
TTS_API_KEY=sk-...
TTS_VOICE=alloy

# Google Cloud TTS
TTS_PROVIDER=google
TTS_VOICE=en-US-Studio-O
GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
```

## Backward compatibility

Fully backward-compatible. Default provider is `"openai"`, so existing deployments continue to work without any changes. The `stripMarkdownForSpeech` function applies to both providers.

Closes #63