### PR TITLE
fix(bot): use promptAsync to avoid false OpenCode send failures

### DIFF
--- a/src/bot/handlers/prompt.ts
+++ b/src/bot/handlers/prompt.ts
@@ -275,7 +275,7 @@ export async function processUserPrompt(
     };
 
     logger.info(
-      `[Bot] Calling session.prompt (fire-and-forget) with agent=${currentAgent}, fileCount=${fileParts.length}...`,
+      `[Bot] Calling session.promptAsync (start-only) with agent=${currentAgent}, fileCount=${fileParts.length}...`,
     );
 
     foregroundSessionState.markBusy(currentSession.id);
@@ -292,13 +292,14 @@ export async function processUserPrompt(
       externalUserInputSuppressionManager.register(currentSession.id, text);
     }
 
-    // CRITICAL: DO NOT wait for session.prompt to complete.
-    // If we wait, the handler will not finish and grammY will not call getUpdates,
-    // which blocks receiving button callback_query updates.
-    // The processing result will arrive via SSE events.
+    // CRITICAL: Use the async prompt start endpoint here.
+    // session.prompt streams the full assistant response and can outlive the original
+    // Telegram message handler, which turns late transport failures into misleading
+    // "failed to send" messages even after the run has already started.
+    // The actual assistant result still arrives via the SSE event subscription.
     safeBackgroundTask({
-      taskName: "session.prompt",
-      task: () => opencodeClient.session.prompt(promptOptions),
+      taskName: "session.promptAsync",
+      task: () => opencodeClient.session.promptAsync(promptOptions),
       onSuccess: ({ error }) => {
         if (error) {
           foregroundSessionState.markIdle(currentSession.id);
@@ -307,18 +308,18 @@ export async function processUserPrompt(
           clearPromptResponseMode(currentSession.id);
           const details = formatErrorDetails(error, 6000);
           logger.error(
-            "[Bot] OpenCode API returned an error for session.prompt",
+            "[Bot] OpenCode API returned an error for session.promptAsync",
             promptErrorLogContext,
           );
-          logger.error("[Bot] session.prompt error details:", details);
-          logger.error("[Bot] session.prompt raw API error object:", error);
+          logger.error("[Bot] session.promptAsync error details:", details);
+          logger.error("[Bot] session.promptAsync raw API error object:", error);
 
           // Send user-friendly error via API directly because ctx is no longer available
           void bot.api.sendMessage(ctx.chat!.id, t("bot.prompt_send_error")).catch(() => {});
           return;
         }
 
-        logger.info("[Bot] session.prompt completed");
+        logger.info("[Bot] session.promptAsync accepted");
       },
       onError: (error) => {
         foregroundSessionState.markIdle(currentSession.id);
@@ -326,9 +327,9 @@ export async function processUserPrompt(
         assistantRunState.clearRun(currentSession.id, "session_prompt_background_error");
         clearPromptResponseMode(currentSession.id);
         const details = formatErrorDetails(error, 6000);
-        logger.error("[Bot] session.prompt background task failed", promptErrorLogContext);
-        logger.error("[Bot] session.prompt background failure details:", details);
-        logger.error("[Bot] session.prompt raw background error object:", error);
+        logger.error("[Bot] session.promptAsync background task failed", promptErrorLogContext);
+        logger.error("[Bot] session.promptAsync background failure details:", details);
+        logger.error("[Bot] session.promptAsync raw background error object:", error);
         void bot.api.sendMessage(ctx.chat!.id, t("bot.prompt_send_error")).catch(() => {});
       },
     });

--- a/tests/bot/handlers/prompt.test.ts
+++ b/tests/bot/handlers/prompt.test.ts
@@ -11,6 +11,7 @@ const mocked = vi.hoisted(() => ({
   } as { id: string; title: string; directory: string } | null,
   sessionStatusMock: vi.fn(),
   sessionPromptMock: vi.fn(),
+  sessionPromptAsyncMock: vi.fn(),
   sessionCreateMock: vi.fn(),
   suppressionRegisterMock: vi.fn(),
   safeBackgroundTaskMock: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("../../../src/opencode/client.js", () => ({
     session: {
       status: mocked.sessionStatusMock,
       prompt: mocked.sessionPromptMock,
+      promptAsync: mocked.sessionPromptAsyncMock,
       create: mocked.sessionCreateMock,
     },
   },
@@ -144,9 +146,23 @@ function createContext(): Context {
 
 function createDeps(): ProcessPromptDeps {
   return {
-    bot: { api: { sendMessage: vi.fn() } } as unknown as Bot<Context>,
+    bot: { api: { sendMessage: vi.fn().mockResolvedValue(undefined) } } as unknown as Bot<Context>,
     ensureEventSubscription: vi.fn().mockResolvedValue(undefined),
   };
+}
+
+function getScheduledBackgroundTask(): {
+  task: () => Promise<unknown>;
+  onSuccess?: (value: { error: unknown | null }) => void;
+  onError?: (error: unknown) => void;
+} {
+  const [[options]] = mocked.safeBackgroundTaskMock.mock.calls as [[{
+    task: () => Promise<unknown>;
+    onSuccess?: (value: { error: unknown | null }) => void;
+    onError?: (error: unknown) => void;
+  }]];
+
+  return options;
 }
 
 describe("bot/handlers/prompt", () => {
@@ -159,6 +175,7 @@ describe("bot/handlers/prompt", () => {
     };
     mocked.sessionStatusMock.mockReset();
     mocked.sessionPromptMock.mockReset();
+    mocked.sessionPromptAsyncMock.mockReset();
     mocked.sessionCreateMock.mockReset();
     mocked.suppressionRegisterMock.mockReset();
     mocked.safeBackgroundTaskMock.mockReset();
@@ -179,6 +196,7 @@ describe("bot/handlers/prompt", () => {
       error: null,
     });
     mocked.sessionPromptMock.mockResolvedValue({ data: {}, error: null });
+    mocked.sessionPromptAsyncMock.mockResolvedValue({ data: {}, error: null });
   });
 
   it("registers suppression entry for text prompts", async () => {
@@ -196,6 +214,67 @@ describe("bot/handlers/prompt", () => {
       ensureEventSubscription: expect.any(Function),
     });
     expect(mocked.suppressionRegisterMock).toHaveBeenCalledWith("session-1", "Review README");
+  });
+
+  it("starts prompts through promptAsync instead of the streaming prompt endpoint", async () => {
+    const handled = await processUserPrompt(createContext(), "Review README", createDeps());
+
+    expect(handled).toBe(true);
+
+    const backgroundTask = getScheduledBackgroundTask();
+    await backgroundTask.task();
+
+    expect(mocked.sessionPromptAsyncMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      directory: "D:\\Projects\\Repo",
+      parts: [{ type: "text", text: "Review README" }],
+      agent: "build",
+      model: {
+        providerID: "openai",
+        modelID: "gpt-5",
+      },
+      variant: "default",
+    });
+    expect(mocked.sessionPromptMock).not.toHaveBeenCalled();
+  });
+
+  it("still notifies the user when promptAsync reports a real start error", async () => {
+    const ctx = createContext();
+    const deps = createDeps();
+
+    const handled = await processUserPrompt(ctx, "Review README", deps);
+
+    expect(handled).toBe(true);
+
+    const backgroundTask = getScheduledBackgroundTask();
+    backgroundTask.onSuccess?.({ error: new Error("request start failed") });
+
+    expect(deps.bot.api.sendMessage).toHaveBeenCalledWith(
+      777,
+      "Failed to send request to OpenCode.",
+    );
+  });
+
+  it("still notifies the user when promptAsync rejects before the run starts", async () => {
+    const ctx = createContext();
+    const deps = createDeps();
+
+    const handled = await processUserPrompt(ctx, "Review README", deps);
+
+    expect(handled).toBe(true);
+
+    const backgroundTask = getScheduledBackgroundTask();
+    const startError = new Error("network down");
+    mocked.sessionPromptAsyncMock.mockRejectedValueOnce(startError);
+
+    await backgroundTask.task().catch((error) => {
+      backgroundTask.onError?.(error);
+    });
+
+    expect(deps.bot.api.sendMessage).toHaveBeenCalledWith(
+      777,
+      "Failed to send request to OpenCode.",
+    );
   });
 
   it("does not register suppression entry for file-only prompts", async () => {


### PR DESCRIPTION
## Summary
- The bot was using the long-lived `session.prompt(...)` path to start a run from the Telegram prompt handler.
- That call can stay open well past request start, so later transport failures could be misreported to Telegram as if the initial send failed.
- This switches prompt start to `session.promptAsync(...)`, while keeping the existing user-facing error path for real start failures (`{ error }` responses and rejected start attempts).

## Verification
- `npx vitest run tests/bot/handlers/prompt.test.ts`
  - Passed: 5 tests
  - Covers the new `promptAsync` start path and preserved real start-failure notifications
- `npm run build`
  - Passed
