### PR TITLE
feat(cache): auto-prune stale session directories on full sync

### DIFF
--- a/src/session/cache-manager.ts
+++ b/src/session/cache-manager.ts
@@ -191,10 +191,10 @@ function upsertDirectory(worktree: string, lastUpdated: number): boolean {
   return true;
 }
 
-function buildListParams(): { limit: number; start?: number } {
-  const hasWatermark = cacheData.lastSyncedUpdatedAt > 0;
-
-  if (!hasWatermark) {
+function buildListParams(options?: {
+  force?: boolean;
+}): { limit: number; start?: number } {
+  if (options?.force || cacheData.lastSyncedUpdatedAt === 0) {
     return { limit: INITIAL_WARMUP_LIMIT };
   }
 
@@ -272,10 +272,11 @@ function isServerUnavailableError(error: unknown): boolean {
   return false;
 }
 
-async function runSync(): Promise<void> {
+async function runSync(options?: { force?: boolean }): Promise<void> {
   await ensureCacheLoaded();
 
-  const params = buildListParams();
+  const shouldPrune = options?.force || cacheData.lastSyncedUpdatedAt === 0;
+  const params = buildListParams(options);
   const { data: sessions, error } = await opencodeClient.session.list(params);
 
   if (error || !sessions) {
@@ -284,6 +285,7 @@ async function runSync(): Promise<void> {
 
   let changed = false;
   let maxUpdated = cacheData.lastSyncedUpdatedAt;
+  const seenDirectories = new Set<string>();
 
   for (const session of sessions) {
     const updatedAt = session.time?.updated ?? Date.now();
@@ -291,8 +293,27 @@ async function runSync(): Promise<void> {
       changed = true;
     }
 
+    if (session.directory && isValidWorktree(session.directory)) {
+      seenDirectories.add(worktreeKey(session.directory.trim()));
+    }
+
     if (updatedAt > maxUpdated) {
       maxUpdated = updatedAt;
+    }
+  }
+
+  const responseIsTruncated = sessions.length >= INITIAL_WARMUP_LIMIT;
+
+  if (shouldPrune && !responseIsTruncated) {
+    const before = cacheData.directories.length;
+    cacheData.directories = cacheData.directories.filter((d) =>
+      seenDirectories.has(worktreeKey(d.worktree)),
+    );
+    if (cacheData.directories.length !== before) {
+      changed = true;
+      logger.info(
+        `[SessionCache] Pruned ${before - cacheData.directories.length} stale directories from cache`,
+      );
     }
   }
 
@@ -558,7 +579,7 @@ export async function syncSessionDirectoryCache(options?: { force?: boolean }): 
     return syncInFlight;
   }
 
-  syncInFlight = runSync()
+  syncInFlight = runSync(options)
     .then(() => {
       lastSyncAttemptAt = Date.now();
     })

--- a/tests/session/cache-manager.test.ts
+++ b/tests/session/cache-manager.test.ts
@@ -109,7 +109,7 @@ describe("session/cache-manager", () => {
     ]);
   });
 
-  it("runs incremental sync using start watermark", async () => {
+  it("runs full sync with pruning when force is set", async () => {
     sessionListMock
       .mockResolvedValueOnce({
         data: [createSession("D:/repo-a", 1_700_000_000_500)],
@@ -124,13 +124,10 @@ describe("session/cache-manager", () => {
     await syncSessionDirectoryCache({ force: true });
 
     expect(sessionListMock).toHaveBeenNthCalledWith(1, { limit: 1000 });
-    expect(sessionListMock).toHaveBeenNthCalledWith(2, {
-      limit: 1000,
-      start: 1_700_000_000_500 - 60_000,
-    });
+    expect(sessionListMock).toHaveBeenNthCalledWith(2, { limit: 1000 });
 
     const directories = await getCachedSessionDirectories();
-    expect(directories.map((item) => item.worktree)).toEqual(["D:/repo-c", "D:/repo-a"]);
+    expect(directories.map((item) => item.worktree)).toEqual(["D:/repo-c"]);
   });
 
   it("logs friendly message when server is not running during warmup sync", async () => {
@@ -145,6 +142,66 @@ describe("session/cache-manager", () => {
     expect(loggerWarnMock).toHaveBeenCalledWith(
       "[SessionCache] OpenCode server is not running. Start it with: opencode serve",
     );
+  });
+
+  it("prunes stale directories from cache on warmup", async () => {
+    // Populate cache with directories first
+    await upsertSessionDirectory("/repo/stale", 1_700_000_000_100);
+    await upsertSessionDirectory("/repo/active-a", 1_700_000_000_200);
+    await upsertSessionDirectory("/repo/active-b", 1_700_000_000_300);
+
+    // Reset in-memory state; cache persists in settings.json
+    __resetSessionDirectoryCacheForTests();
+
+    // Mock lists only active directories
+    sessionListMock.mockResolvedValueOnce({
+      data: [
+        createSession("/repo/active-b", 1_700_000_000_400),
+        createSession("/repo/active-a", 1_700_000_000_350),
+      ],
+      error: null,
+    });
+
+    await syncSessionDirectoryCache({ force: true });
+
+    const directories = await getCachedSessionDirectories();
+    const worktrees = directories.map((d) => d.worktree);
+    expect(worktrees).toEqual(["/repo/active-b", "/repo/active-a"]);
+  });
+
+  it("logs prune count when stale directories are removed", async () => {
+    await upsertSessionDirectory("/repo/stale", 1_700_000_000_100);
+
+    __resetSessionDirectoryCacheForTests();
+    loggerInfoMock.mockClear();
+
+    sessionListMock.mockResolvedValueOnce({
+      data: [createSession("/repo/active", 1_700_000_000_200)],
+      error: null,
+    });
+
+    await syncSessionDirectoryCache({ force: true });
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      "[SessionCache] Pruned 1 stale directories from cache",
+    );
+  });
+
+  it("clears cache when server returns empty session list", async () => {
+    await upsertSessionDirectory("/repo/stale-a", 1_700_000_000_100);
+    await upsertSessionDirectory("/repo/stale-b", 1_700_000_000_200);
+
+    __resetSessionDirectoryCacheForTests();
+
+    sessionListMock.mockResolvedValueOnce({
+      data: [],
+      error: null,
+    });
+
+    await syncSessionDirectoryCache({ force: true });
+
+    const directories = await getCachedSessionDirectories();
+    expect(directories).toEqual([]);
   });
 
   it("updates existing directory with newer timestamp", async () => {


### PR DESCRIPTION
## Summary

When session directories are deleted from the OpenCode server (e.g. via TUI `project set` or the SDK DELETE endpoint), the bot's local session directory cache in `settings.json` keeps stale entries forever.

This change adds automatic pruning: on startup warmup (and whenever `syncSessionDirectoryCache` is called with `force:true`), the bot fetches the full session list from the server and removes any cached directory that is no longer referenced by any session.

## Changes

- `src/session/cache-manager.ts`: `runSync()` now tracks directories seen in the server response and prunes stale entries when `force:true` or on the initial full sync
- `tests/session/cache-manager.test.ts`: updated existing test and added three new tests for prune behavior

## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [ ] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described