### PR TITLE
feat(telegram): support message_thread_id routing

### DIFF
--- a/src/attach/service.ts
+++ b/src/attach/service.ts
@@ -12,17 +12,18 @@ import type { SessionInfo } from "../session/manager.js";
 import { getCurrentSession } from "../session/manager.js";
 import { getCurrentProject } from "../settings/manager.js";
 import { attachManager } from "./manager.js";
+import type { TelegramTarget } from "../telegram/target.js";
 import { logger } from "../utils/logger.js";
 
 interface EnsureAttachPinnedSessionParams {
   api: Context["api"];
-  chatId: number;
+  target: TelegramTarget;
   session: SessionInfo;
 }
 
 export interface AttachSessionDeps {
   bot: Bot<Context>;
-  chatId: number;
+  target: TelegramTarget;
   session: SessionInfo;
   ensureEventSubscription: (directory: string) => Promise<void>;
 }
@@ -36,7 +37,7 @@ export interface AttachSessionResult {
 
 export interface RestoreAttachedCurrentSessionDeps {
   bot: Bot<Context>;
-  chatId: number;
+  target: TelegramTarget;
   ensureEventSubscription: (directory: string) => Promise<void>;
 }
 
@@ -51,14 +52,14 @@ function getAttachBusyStatus(sessionId: string, statuses: unknown): boolean {
 
 async function ensureAttachPinnedSession({
   api,
-  chatId,
+  target,
   session,
 }: EnsureAttachPinnedSessionParams): Promise<void> {
   if (!pinnedMessageManager.isInitialized()) {
-    pinnedMessageManager.initialize(api, chatId);
+    pinnedMessageManager.initialize(api, target);
   }
 
-  keyboardManager.initialize(api, chatId);
+  keyboardManager.initialize(api, target);
 
   const pinnedState = pinnedMessageManager.getState();
   if (pinnedState.sessionId === session.id && pinnedState.messageId) {
@@ -90,7 +91,7 @@ async function syncPinnedAttachState(): Promise<void> {
 
 async function restorePendingQuestion(
   bot: Bot<Context>,
-  chatId: number,
+  target: TelegramTarget,
   sessionId: string,
   directory: string,
 ): Promise<boolean> {
@@ -109,13 +110,13 @@ async function restorePendingQuestion(
   }
 
   questionManager.startQuestions(pendingQuestion.questions, pendingQuestion.id);
-  await showCurrentQuestion(bot.api, chatId);
+  await showCurrentQuestion(bot.api, target);
   return true;
 }
 
 async function restorePendingPermissions(
   bot: Bot<Context>,
-  chatId: number,
+  target: TelegramTarget,
   sessionId: string,
   directory: string,
 ): Promise<number> {
@@ -130,30 +131,30 @@ async function restorePendingPermissions(
 
   const pendingPermissions = data.filter((request) => request.sessionID === sessionId);
   for (const request of pendingPermissions) {
-    await showPermissionRequest(bot.api, chatId, request);
+    await showPermissionRequest(bot.api, target, request);
   }
 
   return pendingPermissions.length;
 }
 
 export async function attachToSession(deps: AttachSessionDeps): Promise<AttachSessionResult> {
-  const { bot, chatId, session, ensureEventSubscription } = deps;
+  const { bot, target, session, ensureEventSubscription } = deps;
   const alreadyAttached = attachManager.isAttachedSession(session.id, session.directory);
 
   await ensureAttachPinnedSession({
     api: bot.api,
-    chatId,
+    target,
     session,
   });
 
   if (!alreadyAttached) {
     await ensureEventSubscription(session.directory);
     summaryAggregator.setSession(session.id);
-    summaryAggregator.setBotAndChatId(bot, chatId);
+    summaryAggregator.setBotAndTarget(bot, target);
     attachManager.attach(session.id, session.directory);
   } else {
     summaryAggregator.setSession(session.id);
-    summaryAggregator.setBotAndChatId(bot, chatId);
+    summaryAggregator.setBotAndTarget(bot, target);
   }
 
   const { data: statuses, error: statusesError } = await opencodeClient.session.status({
@@ -177,12 +178,12 @@ export async function attachToSession(deps: AttachSessionDeps): Promise<AttachSe
   let restoredPermissions = 0;
 
   if (!alreadyAttached && !questionManager.isActive() && !permissionManager.isActive()) {
-    restoredQuestion = await restorePendingQuestion(bot, chatId, session.id, session.directory);
+    restoredQuestion = await restorePendingQuestion(bot, target, session.id, session.directory);
 
     if (!restoredQuestion) {
       restoredPermissions = await restorePendingPermissions(
         bot,
-        chatId,
+        target,
         session.id,
         session.directory,
       );
@@ -217,7 +218,7 @@ export async function restoreAttachedCurrentSession(
   try {
     await attachToSession({
       bot: deps.bot,
-      chatId: deps.chatId,
+      target: deps.target,
       session: currentSession,
       ensureEventSubscription: deps.ensureEventSubscription,
     });

--- a/src/bot/commands/commands.ts
+++ b/src/bot/commands/commands.ts
@@ -26,6 +26,7 @@ import {
   markAttachedSessionIdle,
 } from "../../attach/service.js";
 import { externalUserInputSuppressionManager } from "../../external-input/suppression.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 
 const COMMANDS_CALLBACK_PREFIX = "commands:";
 const COMMANDS_CALLBACK_SELECT_PREFIX = `${COMMANDS_CALLBACK_PREFIX}select:`;
@@ -417,6 +418,11 @@ async function executeCommand(
     return;
   }
 
+  const target = getTelegramTargetFromContext(ctx);
+  if (!target) {
+    return;
+  }
+
   const args = params.argumentsText.trim();
   const executingMessage = formatExecutingCommandMessage(params.commandName, args);
   await ctx.reply(executingMessage.text, { entities: executingMessage.entities });
@@ -428,7 +434,7 @@ async function executeCommand(
 
   await attachToSession({
     bot: deps.bot,
-    chatId: ctx.chat.id,
+    target,
     session,
     ensureEventSubscription: deps.ensureEventSubscription,
   });

--- a/src/bot/commands/new.ts
+++ b/src/bot/commands/new.ts
@@ -12,6 +12,7 @@ import { formatVariantForButton } from "../../variant/manager.js";
 import { createMainKeyboard } from "../utils/keyboard.js";
 import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
 import { logger } from "../../utils/logger.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { t } from "../../i18n/index.js";
 import { attachToSession } from "../../attach/service.js";
 
@@ -31,6 +32,11 @@ export async function newCommand(ctx: CommandContext<Context>, deps: NewCommandD
 
     if (!currentProject) {
       await ctx.reply(t("new.project_not_selected"));
+      return;
+    }
+
+    const target = getTelegramTargetFromContext(ctx);
+    if (!target) {
       return;
     }
 
@@ -59,7 +65,7 @@ export async function newCommand(ctx: CommandContext<Context>, deps: NewCommandD
 
     await attachToSession({
       bot: deps.bot,
-      chatId: ctx.chat.id,
+      target,
       session: sessionInfo,
       ensureEventSubscription: deps.ensureEventSubscription,
     });

--- a/src/bot/commands/sessions.ts
+++ b/src/bot/commands/sessions.ts
@@ -16,6 +16,11 @@ import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
 import { logger } from "../../utils/logger.js";
 import { safeBackgroundTask } from "../../utils/safe-background-task.js";
 import { config } from "../../config.js";
+import {
+  getTelegramTargetFromContext,
+  getTelegramTargetSendOptions,
+  type TelegramTarget,
+} from "../../telegram/target.js";
 import { getDateLocale, t } from "../../i18n/index.js";
 import { attachToSession } from "../../attach/service.js";
 
@@ -265,9 +270,11 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
     let loadingMessageId: number | null = null;
     if (ctx.chat) {
       try {
+        const target = getTelegramTargetFromContext(ctx) ?? { chatId: ctx.chat.id };
         const loadingMessage = await ctx.api.sendMessage(
           ctx.chat.id,
           t("sessions.loading_context"),
+          getTelegramTargetSendOptions(target),
         );
         loadingMessageId = loadingMessage.message_id;
       } catch (err) {
@@ -276,9 +283,14 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
     }
 
     try {
+      const target = getTelegramTargetFromContext(ctx);
+      if (!target) {
+        throw new Error("Telegram target is missing for session selection");
+      }
+
       await attachToSession({
         bot: deps.bot,
-        chatId: ctx.chat!.id,
+        target,
         session: sessionInfo,
         ensureEventSubscription: deps.ensureEventSubscription,
       });
@@ -296,6 +308,7 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
 
     if (ctx.chat) {
       const chatId = ctx.chat.id;
+      const target = getTelegramTargetFromContext(ctx) ?? { chatId };
       const currentAgent = await resolveProjectAgent();
 
       keyboardManager.updateAgent(currentAgent);
@@ -318,6 +331,7 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
       const keyboard = keyboardManager.getKeyboard();
       try {
         await ctx.api.sendMessage(chatId, t("sessions.selected", { title: session.title }), {
+          ...getTelegramTargetSendOptions(target),
           reply_markup: keyboard,
         });
       } catch (err) {
@@ -330,7 +344,7 @@ export async function handleSessionSelect(ctx: Context, deps: SessionSelectDeps)
         task: () =>
           sendSessionPreview(
             ctx.api,
-            chatId,
+            target,
             null,
             session.title,
             session.id,
@@ -454,7 +468,7 @@ function formatSessionPreview(_sessionTitle: string, items: SessionPreviewItem[]
 
 async function sendSessionPreview(
   api: Context["api"],
-  chatId: number,
+  target: TelegramTarget,
   messageId: number | null,
   sessionTitle: string,
   sessionId: string,
@@ -465,7 +479,7 @@ async function sendSessionPreview(
 
   if (messageId) {
     try {
-      await api.editMessageText(chatId, messageId, finalText);
+      await api.editMessageText(target.chatId, messageId, finalText);
       return;
     } catch (err) {
       logger.warn("[Sessions] Failed to edit preview message, sending new one:", err);
@@ -473,7 +487,7 @@ async function sendSessionPreview(
   }
 
   try {
-    await api.sendMessage(chatId, finalText);
+    await api.sendMessage(target.chatId, finalText, getTelegramTargetSendOptions(target));
   } catch (err) {
     logger.error("[Sessions] Failed to send session preview message:", err);
   }

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -9,16 +9,19 @@ import { clearSession } from "../../session/manager.js";
 import { clearProject } from "../../settings/manager.js";
 import { foregroundSessionState } from "../../scheduled-task/foreground-state.js";
 import { abortCurrentOperation } from "./abort.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { t } from "../../i18n/index.js";
 import { assistantRunState } from "../assistant-run-state.js";
 import { detachAttachedSession } from "../../attach/service.js";
 
 export async function startCommand(ctx: Context): Promise<void> {
-  if (ctx.chat) {
+  const target = getTelegramTargetFromContext(ctx);
+
+  if (target) {
     if (!pinnedMessageManager.isInitialized()) {
-      pinnedMessageManager.initialize(ctx.api, ctx.chat.id);
+      pinnedMessageManager.initialize(ctx.api, target);
     }
-    keyboardManager.initialize(ctx.api, ctx.chat.id);
+    keyboardManager.initialize(ctx.api, target);
   }
 
   await abortCurrentOperation(ctx, { notifyUser: false });

--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -8,6 +8,7 @@ import { getAgentDisplayName } from "../../agent/types.js";
 import { fetchCurrentModel } from "../../model/manager.js";
 import { keyboardManager } from "../../keyboard/manager.js";
 import { pinnedMessageManager } from "../../pinned/manager.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import { sendBotText } from "../utils/telegram-text.js";
@@ -78,15 +79,17 @@ export async function statusCommand(ctx: CommandContext<Context>) {
       message += t("status.session_hint");
     }
 
-    if (ctx.chat) {
+    const target = getTelegramTargetFromContext(ctx);
+
+    if (target) {
       if (!pinnedMessageManager.isInitialized()) {
-        pinnedMessageManager.initialize(ctx.api, ctx.chat.id);
+        pinnedMessageManager.initialize(ctx.api, target);
       }
       // Fetch context limit if not yet loaded (e.g. fresh bot start)
       if (pinnedMessageManager.getContextLimit() === 0) {
         await pinnedMessageManager.refreshContextLimit();
       }
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
+      keyboardManager.initialize(ctx.api, target);
     }
     // Sync current context (tokens used + limit) into keyboard state
     const contextInfo = pinnedMessageManager.getContextInfo();
@@ -94,10 +97,10 @@ export async function statusCommand(ctx: CommandContext<Context>) {
       keyboardManager.updateContext(contextInfo.tokensUsed, contextInfo.tokensLimit);
     }
     const keyboard = keyboardManager.getKeyboard();
-    if (ctx.chat) {
+    if (target) {
       await sendBotText({
         api: ctx.api,
-        chatId: ctx.chat.id,
+        target,
         text: message,
         options: { reply_markup: keyboard },
       });

--- a/src/bot/handlers/agent.ts
+++ b/src/bot/handlers/agent.ts
@@ -13,6 +13,7 @@ import {
   replyWithInlineMenu,
 } from "./inline-menu.js";
 import { t } from "../../i18n/index.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 
 /**
  * Handle agent selection callback
@@ -35,7 +36,10 @@ export async function handleAgentSelect(ctx: Context): Promise<boolean> {
 
   try {
     if (ctx.chat) {
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
+      const target = getTelegramTargetFromContext(ctx);
+      if (target) {
+        keyboardManager.initialize(ctx.api, target);
+      }
     }
 
     if (pinnedMessageManager.getContextLimit() === 0) {

--- a/src/bot/handlers/model.ts
+++ b/src/bot/handlers/model.ts
@@ -13,6 +13,7 @@ import {
   ensureActiveInlineMenu,
   replyWithInlineMenu,
 } from "./inline-menu.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { t } from "../../i18n/index.js";
 
 function buildModelSelectionMenuText(modelLists: ModelSelectionLists): string {
@@ -52,7 +53,10 @@ export async function handleModelSelect(ctx: Context): Promise<boolean> {
 
   try {
     if (ctx.chat) {
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
+      const target = getTelegramTargetFromContext(ctx);
+      if (target) {
+        keyboardManager.initialize(ctx.api, target);
+      }
     }
 
     // Parse callback data: "model:providerID:modelID"

--- a/src/bot/handlers/permission.ts
+++ b/src/bot/handlers/permission.ts
@@ -8,6 +8,11 @@ import { interactionManager } from "../../interaction/manager.js";
 import { logger } from "../../utils/logger.js";
 import { safeBackgroundTask } from "../../utils/safe-background-task.js";
 import { PermissionRequest, PermissionReply } from "../../permission/types.js";
+import {
+  getTelegramTargetFromContext,
+  getTelegramTargetSendOptions,
+  type TelegramTarget,
+} from "../../telegram/target.js";
 import type { I18nKey } from "../../i18n/en.js";
 import { t } from "../../i18n/index.js";
 
@@ -159,10 +164,10 @@ async function handlePermissionReply(
 ): Promise<void> {
   const currentProject = getCurrentProject();
   const currentSession = getCurrentSession();
-  const chatId = ctx.chat?.id;
+  const target = getTelegramTargetFromContext(ctx);
   const directory = currentSession?.directory ?? currentProject?.worktree;
 
-  if (!directory || !chatId) {
+  if (!directory || !target) {
     permissionManager.clear();
     clearPermissionInteraction("permission_invalid_runtime_context");
 
@@ -202,8 +207,14 @@ async function handlePermissionReply(
     onSuccess: ({ error }) => {
       if (error) {
         logger.error("[PermissionHandler] Failed to send permission reply:", error);
-        if (ctx.api && chatId) {
-          void ctx.api.sendMessage(chatId, t("permission.send_reply_error")).catch(() => {});
+        if (ctx.api) {
+          void ctx.api
+            .sendMessage(
+              target.chatId,
+              t("permission.send_reply_error"),
+              getTelegramTargetSendOptions(target),
+            )
+            .catch(() => {});
         }
         return;
       }
@@ -229,7 +240,7 @@ async function handlePermissionReply(
  */
 export async function showPermissionRequest(
   bot: Context["api"],
-  chatId: number,
+  target: TelegramTarget,
   request: PermissionRequest,
 ): Promise<void> {
   logger.debug(`[PermissionHandler] Showing permission request: ${request.permission}`);
@@ -238,7 +249,8 @@ export async function showPermissionRequest(
   const keyboard = buildPermissionKeyboard();
 
   try {
-    const message = await bot.sendMessage(chatId, text, {
+    const message = await bot.sendMessage(target.chatId, text, {
+      ...getTelegramTargetSendOptions(target),
       reply_markup: keyboard,
     });
 

--- a/src/bot/handlers/prompt.ts
+++ b/src/bot/handlers/prompt.ts
@@ -27,6 +27,7 @@ import {
   markAttachedSessionIdle,
 } from "../../attach/service.js";
 import { externalUserInputSuppressionManager } from "../../external-input/suppression.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 
 /** Module-level references for async callbacks that don't have ctx. */
 let botInstance: Bot<Context> | null = null;
@@ -137,6 +138,10 @@ export async function processUserPrompt(
 
   botInstance = bot;
   chatIdInstance = ctx.chat!.id;
+  const target = getTelegramTargetFromContext(ctx);
+  if (!target) {
+    return false;
+  }
 
   let currentSession = getCurrentSession();
   let createdNewSession = false;
@@ -183,7 +188,7 @@ export async function processUserPrompt(
 
   await attachToSession({
     bot,
-    chatId: ctx.chat!.id,
+    target,
     session: currentSession,
     ensureEventSubscription,
   });

--- a/src/bot/handlers/question.ts
+++ b/src/bot/handlers/question.ts
@@ -5,6 +5,11 @@ import { getCurrentProject } from "../../settings/manager.js";
 import { getCurrentSession } from "../../session/manager.js";
 import { summaryAggregator } from "../../summary/aggregator.js";
 import { interactionManager } from "../../interaction/manager.js";
+import {
+  getTelegramTargetFromContext,
+  getTelegramTargetSendOptions,
+  type TelegramTarget,
+} from "../../telegram/target.js";
 import { logger } from "../../utils/logger.js";
 import { safeBackgroundTask } from "../../utils/safe-background-task.js";
 import { t } from "../../i18n/index.js";
@@ -251,11 +256,11 @@ async function updateQuestionMessage(ctx: Context): Promise<void> {
   }
 }
 
-export async function showCurrentQuestion(bot: Context["api"], chatId: number): Promise<void> {
+export async function showCurrentQuestion(bot: Context["api"], target: TelegramTarget): Promise<void> {
   const question = questionManager.getCurrentQuestion();
 
   if (!question) {
-    await showPollSummary(bot, chatId);
+    await showPollSummary(bot, target);
     return;
   }
 
@@ -267,10 +272,11 @@ export async function showCurrentQuestion(bot: Context["api"], chatId: number): 
     questionManager.getSelectedOptions(questionManager.getCurrentIndex()),
   );
 
-  logger.debug(`[QuestionHandler] Sending message with keyboard, chatId=${chatId}`);
+  logger.debug(`[QuestionHandler] Sending message with keyboard, chatId=${target.chatId}`);
 
   try {
-    const message = await bot.sendMessage(chatId, text, {
+    const message = await bot.sendMessage(target.chatId, text, {
+      ...getTelegramTargetSendOptions(target),
       reply_markup: keyboard,
     });
 
@@ -329,18 +335,19 @@ export async function handleQuestionTextAnswer(ctx: Context): Promise<void> {
 async function showNextQuestion(ctx: Context): Promise<void> {
   questionManager.nextQuestion();
 
-  if (!ctx.chat) {
+  const target = getTelegramTargetFromContext(ctx);
+  if (!target) {
     return;
   }
 
   if (questionManager.hasNextQuestion()) {
-    await showCurrentQuestion(ctx.api, ctx.chat.id);
+    await showCurrentQuestion(ctx.api, target);
   } else {
-    await showPollSummary(ctx.api, ctx.chat.id);
+    await showPollSummary(ctx.api, target);
   }
 }
 
-async function showPollSummary(bot: Context["api"], chatId: number): Promise<void> {
+async function showPollSummary(bot: Context["api"], target: TelegramTarget): Promise<void> {
   const answers = questionManager.getAllAnswers();
   const totalQuestions = questionManager.getTotalQuestions();
 
@@ -349,13 +356,17 @@ async function showPollSummary(bot: Context["api"], chatId: number): Promise<voi
   );
 
   // Send all answers to the OpenCode API
-  await sendAllAnswersToAgent(bot, chatId);
+  await sendAllAnswersToAgent(bot, target);
 
   if (answers.length === 0) {
-    await bot.sendMessage(chatId, t("question.completed_no_answers"));
+    await bot.sendMessage(
+      target.chatId,
+      t("question.completed_no_answers"),
+      getTelegramTargetSendOptions(target),
+    );
   } else {
     const summary = formatAnswersSummary(answers);
-    await bot.sendMessage(chatId, summary);
+    await bot.sendMessage(target.chatId, summary, getTelegramTargetSendOptions(target));
   }
 
   clearQuestionInteraction("question_completed");
@@ -363,7 +374,7 @@ async function showPollSummary(bot: Context["api"], chatId: number): Promise<voi
   logger.debug("[QuestionHandler] Poll completed and cleared");
 }
 
-async function sendAllAnswersToAgent(bot: Context["api"], chatId: number): Promise<void> {
+async function sendAllAnswersToAgent(bot: Context["api"], target: TelegramTarget): Promise<void> {
   const currentProject = getCurrentProject();
   const currentSession = getCurrentSession();
   const requestID = questionManager.getRequestID();
@@ -372,13 +383,21 @@ async function sendAllAnswersToAgent(bot: Context["api"], chatId: number): Promi
 
   if (!directory) {
     logger.error("[QuestionHandler] No project for sending answers");
-    await bot.sendMessage(chatId, t("question.no_active_project"));
+    await bot.sendMessage(
+      target.chatId,
+      t("question.no_active_project"),
+      getTelegramTargetSendOptions(target),
+    );
     return;
   }
 
   if (!requestID) {
     logger.error("[QuestionHandler] No requestID for sending answers");
-    await bot.sendMessage(chatId, t("question.no_active_request"));
+    await bot.sendMessage(
+      target.chatId,
+      t("question.no_active_request"),
+      getTelegramTargetSendOptions(target),
+    );
     return;
   }
 
@@ -422,7 +441,9 @@ async function sendAllAnswersToAgent(bot: Context["api"], chatId: number): Promi
     onSuccess: ({ error }) => {
       if (error) {
         logger.error("[QuestionHandler] Failed to send answers via question.reply:", error);
-        void bot.sendMessage(chatId, t("question.send_answers_error")).catch(() => {});
+        void bot
+          .sendMessage(target.chatId, t("question.send_answers_error"), getTelegramTargetSendOptions(target))
+          .catch(() => {});
         return;
       }
 

--- a/src/bot/handlers/variant.ts
+++ b/src/bot/handlers/variant.ts
@@ -17,6 +17,7 @@ import {
   ensureActiveInlineMenu,
   replyWithInlineMenu,
 } from "./inline-menu.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { t } from "../../i18n/index.js";
 
 /**
@@ -40,7 +41,10 @@ export async function handleVariantSelect(ctx: Context): Promise<boolean> {
 
   try {
     if (ctx.chat) {
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
+      const target = getTelegramTargetFromContext(ctx);
+      if (target) {
+        keyboardManager.initialize(ctx.api, target);
+      }
     }
 
     if (pinnedMessageManager.getContextLimit() === 0) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -103,9 +103,17 @@ import {
   renderAssistantFinalPartsSafe,
 } from "./utils/assistant-rendering.js";
 import { deliverExternalUserInputNotification } from "./utils/external-user-input.js";
+import {
+  createTelegramTarget,
+  getTelegramTargetFromContext,
+  getTelegramTargetSendOptions,
+  type TelegramTarget,
+} from "../telegram/target.js";
+import { getTelegramTarget, setTelegramTarget } from "../settings/manager.js";
 
 let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
+let telegramTargetInstance: TelegramTarget | null = null;
 let commandsInitialized = false;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -118,6 +126,29 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const TEMP_DIR = path.join(__dirname, "..", ".tmp");
 const sessionCompletionTasks = new Map<string, Promise<void>>();
+
+function getActiveTelegramTarget(): TelegramTarget | null {
+  if (telegramTargetInstance) {
+    return telegramTargetInstance;
+  }
+
+  if (chatIdInstance && chatIdInstance > 0) {
+    return createTelegramTarget(chatIdInstance);
+  }
+
+  return null;
+}
+
+function updateRuntimeTelegramTarget(ctx: Context): void {
+  const target = getTelegramTargetFromContext(ctx);
+  if (!target) {
+    return;
+  }
+
+  telegramTargetInstance = target;
+  chatIdInstance = target.chatId;
+  setTelegramTarget(target);
+}
 
 function getCurrentReplyKeyboard() {
   if (!keyboardManager.isInitialized()) {
@@ -178,6 +209,7 @@ const toolMessageBatcher = new ToolMessageBatcher({
 
     await botInstance.api.sendMessage(chatIdInstance, text, {
       disable_notification: true,
+      ...(getActiveTelegramTarget() ? getTelegramTargetSendOptions(getActiveTelegramTarget()!) : {}),
       ...(keyboard ? { reply_markup: keyboard } : {}),
     });
   },
@@ -206,6 +238,7 @@ const toolMessageBatcher = new ToolMessageBatcher({
       await botInstance.api.sendDocument(chatIdInstance, new InputFile(tempFilePath), {
         caption: fileData.caption,
         disable_notification: true,
+        ...(getActiveTelegramTarget() ? getTelegramTargetSendOptions(getActiveTelegramTarget()!) : {}),
         ...(keyboard ? { reply_markup: keyboard } : {}),
       });
     } finally {
@@ -223,7 +256,7 @@ const responseStreamer = new ResponseStreamer({
 
     return sendRenderedBotPart({
       api: botInstance.api,
-      chatId: chatIdInstance,
+      target: getActiveTelegramTarget() ?? createTelegramTarget(chatIdInstance),
       part,
       options,
     });
@@ -287,6 +320,7 @@ const toolCallStreamer = new ToolCallStreamer({
 
     const sentMessage = await botInstance.api.sendMessage(chatIdInstance, text, {
       disable_notification: true,
+      ...(getActiveTelegramTarget() ? getTelegramTargetSendOptions(getActiveTelegramTarget()!) : {}),
     });
 
     return sentMessage.message_id;
@@ -493,7 +527,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
           sendRenderedPart: async (part, options) => {
             await sendRenderedBotPart({
               api: botApi,
-              chatId,
+              target: getActiveTelegramTarget() ?? createTelegramTarget(chatId),
               part,
               options: options as Parameters<typeof sendBotText>[0]["options"],
             });
@@ -503,7 +537,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         await sendTtsResponseForSession({
           api: botApi,
           sessionId,
-          chatId,
+          target: getActiveTelegramTarget() ?? createTelegramTarget(chatId),
           text: messageText,
         });
       } catch (err) {
@@ -529,7 +563,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
       try {
         await deliverExternalUserInputNotification({
           api: botInstance.api,
-          chatId: chatIdInstance,
+          target: getActiveTelegramTarget() ?? createTelegramTarget(chatIdInstance),
           currentSessionId: getCurrentSession()?.id ?? null,
           sessionId,
           text: messageText,
@@ -665,7 +699,10 @@ async function ensureEventSubscription(directory: string): Promise<void> {
 
     logger.info(`[Bot] Received ${questions.length} questions from agent, requestID=${requestID}`);
     questionManager.startQuestions(questions, requestID);
-    await showCurrentQuestion(botInstance.api, chatIdInstance);
+    await showCurrentQuestion(
+      botInstance.api,
+      getActiveTelegramTarget() ?? createTelegramTarget(chatIdInstance),
+    );
   });
 
   summaryAggregator.setOnQuestionError(async () => {
@@ -703,7 +740,11 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     logger.info(
       `[Bot] Received permission request from agent: type=${request.permission}, requestID=${request.id}`,
     );
-    await showPermissionRequest(botInstance.api, chatIdInstance, request);
+    await showPermissionRequest(
+      botInstance.api,
+      getActiveTelegramTarget() ?? createTelegramTarget(chatIdInstance),
+      request,
+    );
   });
 
   summaryAggregator.setOnThinking(async (sessionId) => {
@@ -834,6 +875,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
               elapsedMs: Date.now() - completedRun.startedAt,
             }),
             {
+              ...(getActiveTelegramTarget() ? getTelegramTargetSendOptions(getActiveTelegramTarget()!) : {}),
               ...(keyboard ? { reply_markup: keyboard } : {}),
             },
           );
@@ -882,7 +924,11 @@ async function ensureEventSubscription(directory: string): Promise<void> {
         : normalizedMessage;
 
     await botInstance.api
-      .sendMessage(chatIdInstance, t("bot.session_error", { message: truncatedMessage }))
+      .sendMessage(
+        chatIdInstance,
+        t("bot.session_error", { message: truncatedMessage }),
+        getActiveTelegramTarget() ? getTelegramTargetSendOptions(getActiveTelegramTarget()!) : undefined,
+      )
       .catch((err) => {
         logger.error("[Bot] Failed to send session.error message:", err);
       });
@@ -1002,7 +1048,8 @@ export function createBot(): Bot<Context> {
 
   const bot = new Bot(config.telegram.token, botOptions);
   botInstance = bot;
-  chatIdInstance = config.telegram.allowedUserId;
+  telegramTargetInstance = getTelegramTarget() ?? createTelegramTarget(config.telegram.allowedUserId);
+  chatIdInstance = telegramTargetInstance.chatId;
 
   // Heartbeat for diagnostics: verify the event loop is not blocked
   let heartbeatCounter = 0;
@@ -1094,7 +1141,7 @@ export function createBot(): Bot<Context> {
 
     if (ctx.chat) {
       botInstance = bot;
-      chatIdInstance = ctx.chat.id;
+      updateRuntimeTelegramTarget(ctx);
     }
 
     try {
@@ -1262,7 +1309,7 @@ export function createBot(): Bot<Context> {
     task: () =>
       restoreAttachedCurrentSession({
         bot,
-        chatId: config.telegram.allowedUserId,
+        target: getTelegramTarget() ?? createTelegramTarget(config.telegram.allowedUserId),
         ensureEventSubscription,
       }),
   });
@@ -1270,14 +1317,14 @@ export function createBot(): Bot<Context> {
   bot.on("message:voice", async (ctx) => {
     logger.debug(`[Bot] Received voice message, chatId=${ctx.chat.id}`);
     botInstance = bot;
-    chatIdInstance = ctx.chat.id;
+    updateRuntimeTelegramTarget(ctx);
     await handleVoiceMessage(ctx, voicePromptDeps);
   });
 
   bot.on("message:audio", async (ctx) => {
     logger.debug(`[Bot] Received audio message, chatId=${ctx.chat.id}`);
     botInstance = bot;
-    chatIdInstance = ctx.chat.id;
+    updateRuntimeTelegramTarget(ctx);
     await handleVoiceMessage(ctx, voicePromptDeps);
   });
 
@@ -1309,7 +1356,7 @@ export function createBot(): Bot<Context> {
         // Fall back to caption-only if present
         if (caption.trim().length > 0) {
           botInstance = bot;
-          chatIdInstance = ctx.chat.id;
+          updateRuntimeTelegramTarget(ctx);
           const promptDeps = { bot, ensureEventSubscription };
           await processUserPrompt(ctx, caption, promptDeps);
         }
@@ -1334,7 +1381,7 @@ export function createBot(): Bot<Context> {
       logger.info(`[Bot] Sending photo (${downloadedFile.buffer.length} bytes) with prompt`);
 
       botInstance = bot;
-      chatIdInstance = ctx.chat.id;
+      updateRuntimeTelegramTarget(ctx);
 
       // Send via processUserPrompt with file part
       const promptDeps = { bot, ensureEventSubscription };
@@ -1349,7 +1396,7 @@ export function createBot(): Bot<Context> {
   bot.on("message:document", async (ctx) => {
     logger.debug(`[Bot] Received document message, chatId=${ctx.chat.id}`);
     botInstance = bot;
-    chatIdInstance = ctx.chat.id;
+    updateRuntimeTelegramTarget(ctx);
     const deps = { bot, ensureEventSubscription };
     await handleDocumentMessage(ctx, deps);
   });
@@ -1361,7 +1408,7 @@ export function createBot(): Bot<Context> {
     }
 
     botInstance = bot;
-    chatIdInstance = ctx.chat.id;
+    updateRuntimeTelegramTarget(ctx);
 
     if (text.startsWith("/")) {
       return;
@@ -1428,4 +1475,5 @@ export function cleanupBotRuntime(reason: string): void {
 
   botInstance = null;
   chatIdInstance = null;
+  telegramTargetInstance = null;
 }

--- a/src/bot/utils/external-user-input.ts
+++ b/src/bot/utils/external-user-input.ts
@@ -1,5 +1,6 @@
 import type { Api, RawApi } from "grammy";
 import { t } from "../../i18n/index.js";
+import type { TelegramTarget } from "../../telegram/target.js";
 import { escapePlainTextForTelegramMarkdownV2 } from "../../summary/formatter.js";
 import { sendBotText } from "./telegram-text.js";
 
@@ -12,7 +13,7 @@ interface ExternalUserInputNotification {
 
 interface DeliverExternalUserInputParams {
   api: SendMessageApi;
-  chatId: number;
+  target: TelegramTarget;
   currentSessionId: string | null;
   sessionId: string;
   text: string;
@@ -54,7 +55,7 @@ export function buildExternalUserInputNotification(text: string): ExternalUserIn
 
 export async function deliverExternalUserInputNotification({
   api,
-  chatId,
+  target,
   currentSessionId,
   sessionId,
   text,
@@ -71,7 +72,7 @@ export async function deliverExternalUserInputNotification({
 
   await sendBotText({
     api,
-    chatId,
+    target,
     text: notification.text,
     rawFallbackText: notification.rawFallbackText,
     format: "markdown_v2",

--- a/src/bot/utils/send-tts-response.ts
+++ b/src/bot/utils/send-tts-response.ts
@@ -2,19 +2,20 @@ import { InputFile } from "grammy";
 import { consumePromptResponseMode } from "../handlers/prompt.js";
 import { isTtsConfigured, synthesizeSpeech, type TtsResult } from "../../tts/client.js";
 import { t } from "../../i18n/index.js";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../../telegram/target.js";
 import { logger } from "../../utils/logger.js";
 
 const MAX_TTS_INPUT_CHARS = 4_000;
 
 interface TelegramAudioApi {
-  sendAudio: (chatId: number, audio: InputFile) => Promise<unknown>;
-  sendMessage: (chatId: number, text: string) => Promise<unknown>;
+  sendAudio: (chatId: number, audio: InputFile, other?: { message_thread_id?: number }) => Promise<unknown>;
+  sendMessage: (chatId: number, text: string, other?: { message_thread_id?: number }) => Promise<unknown>;
 }
 
 interface SendTtsResponseParams {
   api: TelegramAudioApi;
   sessionId: string;
-  chatId: number;
+  target: TelegramTarget;
   text: string;
   consumeResponseMode?: (sessionId: string) => "text_only" | "text_and_tts" | null;
   isTtsConfigured?: () => boolean;
@@ -24,7 +25,7 @@ interface SendTtsResponseParams {
 export async function sendTtsResponseForSession({
   api,
   sessionId,
-  chatId,
+  target,
   text,
   consumeResponseMode: consumeResponseModeImpl = consumePromptResponseMode,
   isTtsConfigured: isTtsConfiguredImpl = isTtsConfigured,
@@ -54,15 +55,23 @@ export async function sendTtsResponseForSession({
 
   try {
     const speech = await synthesizeSpeechImpl(normalizedText);
-    await api.sendAudio(chatId, new InputFile(speech.buffer, speech.filename));
+    const threadOptions = getTelegramTargetSendOptions(target);
+    await api.sendAudio(
+      target.chatId,
+      new InputFile(speech.buffer, speech.filename),
+      Object.keys(threadOptions).length > 0 ? threadOptions : undefined,
+    );
     logger.info(`[TTS] Sent audio reply for session ${sessionId}`);
     return true;
   } catch (error) {
     logger.warn(`[TTS] Failed to send audio reply for session ${sessionId}`, error);
 
-    await api.sendMessage(chatId, t("tts.failed")).catch((sendError) => {
-      logger.warn(`[TTS] Failed to send audio error message for session ${sessionId}`, sendError);
-    });
+    const threadOptions = getTelegramTargetSendOptions(target);
+    await api
+      .sendMessage(target.chatId, t("tts.failed"), Object.keys(threadOptions).length > 0 ? threadOptions : undefined)
+      .catch((sendError) => {
+        logger.warn(`[TTS] Failed to send audio error message for session ${sessionId}`, sendError);
+      });
 
     return false;
   }

--- a/src/bot/utils/send-with-markdown-fallback.ts
+++ b/src/bot/utils/send-with-markdown-fallback.ts
@@ -1,5 +1,6 @@
 import { logger } from "../../utils/logger.js";
 import type { Api, RawApi } from "grammy";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../../telegram/target.js";
 
 type SendMessageApi = Pick<Api<RawApi>, "sendMessage">;
 type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
@@ -8,7 +9,7 @@ type TelegramEditMessageOptions = Parameters<EditMessageApi["editMessageText"]>[
 
 interface SendMessageWithMarkdownFallbackParams {
   api: SendMessageApi;
-  chatId: Parameters<SendMessageApi["sendMessage"]>[0];
+  target: TelegramTarget;
   text: string;
   rawFallbackText?: string;
   options?: TelegramSendMessageOptions;
@@ -146,7 +147,7 @@ export function isTelegramMarkdownParseError(error: unknown): boolean {
 
 export async function sendMessageWithMarkdownFallback({
   api,
-  chatId,
+  target,
   text,
   rawFallbackText,
   options,
@@ -154,12 +155,16 @@ export async function sendMessageWithMarkdownFallback({
 }: SendMessageWithMarkdownFallbackParams): Promise<
   Awaited<ReturnType<SendMessageApi["sendMessage"]>>
 > {
+  const threadOptions = getTelegramTargetSendOptions(target);
+  const sendOptions =
+    Object.keys(threadOptions).length > 0 ? { ...(options || {}), ...threadOptions } : options;
+
   if (!parseMode) {
-    return api.sendMessage(chatId, text, options);
+    return api.sendMessage(target.chatId, text, sendOptions);
   }
 
   const markdownOptions: TelegramSendMessageOptions = {
-    ...(options || {}),
+    ...sendOptions,
     parse_mode: parseMode,
   };
 
@@ -167,7 +172,7 @@ export async function sendMessageWithMarkdownFallback({
     rawFallbackText ?? (parseMode === "MarkdownV2" ? unescapeTelegramMarkdownV2(text) : text);
 
   try {
-    return await api.sendMessage(chatId, text, markdownOptions);
+    return await api.sendMessage(target.chatId, text, markdownOptions);
   } catch (error) {
     if (!isTelegramMarkdownParseError(error)) {
       throw error;
@@ -179,7 +184,7 @@ export async function sendMessageWithMarkdownFallback({
         logger.warn("[Bot] Markdown parse failed, retrying message with escaped MarkdownV2", error);
 
         try {
-          return await api.sendMessage(chatId, escapedText, markdownOptions);
+          return await api.sendMessage(target.chatId, escapedText, markdownOptions);
         } catch (escapedError) {
           if (!isTelegramMarkdownParseError(escapedError)) {
             throw escapedError;
@@ -189,13 +194,17 @@ export async function sendMessageWithMarkdownFallback({
             "[Bot] Escaped Markdown parse failed, retrying message in raw mode",
             escapedError,
           );
-          return api.sendMessage(chatId, fallbackText, stripMarkdownFormattingOptions(options));
+          return api.sendMessage(
+            target.chatId,
+            fallbackText,
+            stripMarkdownFormattingOptions(sendOptions),
+          );
         }
       }
     }
 
     logger.warn("[Bot] Markdown parse failed, retrying message in raw mode", error);
-    return api.sendMessage(chatId, fallbackText, stripMarkdownFormattingOptions(options));
+    return api.sendMessage(target.chatId, fallbackText, stripMarkdownFormattingOptions(sendOptions));
   }
 }
 

--- a/src/bot/utils/switch-project.ts
+++ b/src/bot/utils/switch-project.ts
@@ -11,6 +11,7 @@ import { getStoredModel } from "../../model/manager.js";
 import { formatVariantForButton } from "../../variant/manager.js";
 import { clearAllInteractionState } from "../../interaction/cleanup.js";
 import { createMainKeyboard } from "./keyboard.js";
+import { getTelegramTargetFromContext } from "../../telegram/target.js";
 import { logger } from "../../utils/logger.js";
 
 /**
@@ -39,8 +40,9 @@ export async function switchToProject(ctx: Context, project: ProjectInfo, reason
     logger.error("[Bot] Error clearing pinned message:", err);
   }
 
-  if (ctx.chat) {
-    keyboardManager.initialize(ctx.api, ctx.chat.id);
+  const target = getTelegramTargetFromContext(ctx);
+  if (target) {
+    keyboardManager.initialize(ctx.api, target);
   }
 
   await pinnedMessageManager.refreshContextLimit();

--- a/src/bot/utils/telegram-text.ts
+++ b/src/bot/utils/telegram-text.ts
@@ -1,5 +1,6 @@
 import type { Api, RawApi } from "grammy";
 import { logger } from "../../utils/logger.js";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../../telegram/target.js";
 import {
   editMessageWithMarkdownFallback,
   isTelegramMarkdownParseError,
@@ -17,7 +18,7 @@ export type TelegramTextFormat = "raw" | "markdown_v2";
 
 interface SendBotTextParams {
   api: SendMessageApi;
-  chatId: Parameters<SendMessageApi["sendMessage"]>[0];
+  target: TelegramTarget;
   text: string;
   rawFallbackText?: string;
   options?: TelegramSendMessageOptions;
@@ -36,7 +37,7 @@ interface EditBotTextParams {
 
 interface SendRenderedBotPartParams {
   api: SendMessageApi;
-  chatId: Parameters<SendMessageApi["sendMessage"]>[0];
+  target: TelegramTarget;
   part: TelegramRenderedPart;
   options?: TelegramSendMessageOptions;
 }
@@ -93,7 +94,7 @@ export function getTelegramRenderedPartSignature(
 
 export async function sendBotText({
   api,
-  chatId,
+  target,
   text,
   rawFallbackText,
   options,
@@ -101,7 +102,7 @@ export async function sendBotText({
 }: SendBotTextParams): Promise<void> {
   await sendMessageWithMarkdownFallback({
     api,
-    chatId,
+    target,
     text,
     rawFallbackText,
     options,
@@ -111,11 +112,14 @@ export async function sendBotText({
 
 export async function sendRenderedBotPart({
   api,
-  chatId,
+  target,
   part,
   options,
 }: SendRenderedBotPartParams): Promise<RenderedPartSendResult> {
-  const rawOptions = stripRichFormattingOptions(options);
+  const threadOptions = getTelegramTargetSendOptions(target);
+  const sendOptions =
+    Object.keys(threadOptions).length > 0 ? { ...(options || {}), ...threadOptions } : options;
+  const rawOptions = stripRichFormattingOptions(sendOptions);
 
   logger.debug("[Bot] Sending rendered Telegram part", {
     source: part.source,
@@ -125,7 +129,7 @@ export async function sendRenderedBotPart({
   });
 
   if (!part.entities?.length) {
-    const sentMessage = await api.sendMessage(chatId, part.text, rawOptions);
+    const sentMessage = await api.sendMessage(target.chatId, part.text, rawOptions);
     return {
       messageId: sentMessage.message_id,
       deliveredSignature: getTelegramRenderedPartSignature({ text: part.text }),
@@ -133,7 +137,7 @@ export async function sendRenderedBotPart({
   }
 
   try {
-    const sentMessage = await api.sendMessage(chatId, part.text, {
+    const sentMessage = await api.sendMessage(target.chatId, part.text, {
       ...(rawOptions || {}),
       entities: part.entities,
     });
@@ -151,7 +155,7 @@ export async function sendRenderedBotPart({
       "[Bot] Entity payload rejected, retrying assistant message part in raw mode",
       error,
     );
-    const sentMessage = await api.sendMessage(chatId, part.fallbackText, rawOptions);
+    const sentMessage = await api.sendMessage(target.chatId, part.fallbackText, rawOptions);
     logger.debug("[Bot] Assistant message part sent in raw fallback mode", {
       fallbackTextLength: part.fallbackText.length,
     });

--- a/src/keyboard/manager.ts
+++ b/src/keyboard/manager.ts
@@ -3,6 +3,7 @@ import { createMainKeyboard } from "../bot/utils/keyboard.js";
 import type { ModelInfo } from "../model/types.js";
 import { getStoredAgent } from "../agent/manager.js";
 import { getStoredModel } from "../model/manager.js";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../telegram/target.js";
 import { formatVariantForButton } from "../variant/manager.js";
 import { logger } from "../utils/logger.js";
 import type { ContextInfo, KeyboardState } from "./types.js";
@@ -17,6 +18,7 @@ class KeyboardManager {
 
   private api: Api | null = null;
   private chatId: number | null = null;
+  private target: TelegramTarget | null = null;
   private lastUpdateTime: number = 0;
   private readonly UPDATE_DEBOUNCE_MS = 2000; // Don't update more than once per 2 seconds
 
@@ -24,9 +26,10 @@ class KeyboardManager {
    * Initialize the keyboard manager with Telegram API and chat ID
    * Loads initial state from settings/config
    */
-  public initialize(api: Api, chatId: number): void {
+  public initialize(api: Api, target: TelegramTarget): void {
     this.api = api;
-    this.chatId = chatId;
+    this.chatId = target.chatId;
+    this.target = target;
 
     // Initialize state from settings/config on first call
     if (!this.state) {
@@ -38,10 +41,10 @@ class KeyboardManager {
         variantName: formatVariantForButton(currentModel.variant || "default"),
       };
       logger.debug(
-        `[KeyboardManager] Initialized with agent="${this.state.currentAgent}", model="${this.state.currentModel.providerID}/${this.state.currentModel.modelID}", variant="${currentModel.variant || "default"}", chatId=${chatId}`,
+        `[KeyboardManager] Initialized with agent="${this.state.currentAgent}", model="${this.state.currentModel.providerID}/${this.state.currentModel.modelID}", variant="${currentModel.variant || "default"}", chatId=${target.chatId}`,
       );
     } else {
-      logger.debug("[KeyboardManager] Already initialized, updating chatId:", chatId);
+      logger.debug("[KeyboardManager] Already initialized, updating chatId:", target.chatId);
     }
   }
 
@@ -163,6 +166,7 @@ class KeyboardManager {
       // Send a dummy message with updated keyboard
       // This is needed because Reply Keyboard updates require a message
       await this.api.sendMessage(targetChatId, t("keyboard.updated"), {
+        ...(this.target ? getTelegramTargetSendOptions(this.target) : {}),
         reply_markup: keyboard,
       });
 

--- a/src/pinned/manager.ts
+++ b/src/pinned/manager.ts
@@ -19,13 +19,16 @@ import {
   formatCostLine,
   formatModelDisplayName,
 } from "./format.js";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../telegram/target.js";
 
 class PinnedMessageManager {
   private api: Api | null = null;
   private chatId: number | null = null;
+  private target: TelegramTarget | null = null;
   private state: PinnedMessageState = {
     messageId: null,
     chatId: null,
+    messageThreadId: null,
     sessionId: null,
     sessionTitle: t("pinned.default_session_title"),
     attachActive: false,
@@ -50,15 +53,17 @@ class PinnedMessageManager {
   /**
    * Initialize manager with bot API and chat ID
    */
-  initialize(api: Api, chatId: number): void {
+  initialize(api: Api, target: TelegramTarget): void {
     this.api = api;
-    this.chatId = chatId;
+    this.chatId = target.chatId;
+    this.target = target;
 
     // Restore pinned message ID from settings
     const savedMessageId = getPinnedMessageId();
     if (savedMessageId) {
       this.state.messageId = savedMessageId;
-      this.state.chatId = chatId;
+      this.state.chatId = target.chatId;
+      this.state.messageThreadId = target.messageThreadId ?? null;
     }
   }
 
@@ -724,12 +729,18 @@ class PinnedMessageManager {
 
     try {
       const text = this.formatMessage();
+      const threadOptions = this.target ? getTelegramTargetSendOptions(this.target) : undefined;
 
       // Send new message
-      const sentMessage = await this.api.sendMessage(this.chatId, text);
+      const sentMessage = await this.api.sendMessage(
+        this.chatId,
+        text,
+        threadOptions && Object.keys(threadOptions).length > 0 ? threadOptions : undefined,
+      );
 
       this.state.messageId = sentMessage.message_id;
       this.state.chatId = this.chatId;
+      this.state.messageThreadId = this.target?.messageThreadId ?? null;
       this.state.lastUpdated = Date.now();
       this.lastRenderedMessageText = text;
 
@@ -841,6 +852,7 @@ class PinnedMessageManager {
       await this.api.unpinAllChatMessages(this.chatId).catch(() => {});
 
       this.state.messageId = null;
+      this.state.messageThreadId = null;
       this.lastRenderedMessageText = null;
       this.pendingUpdate = false;
       this.pendingForceUpdate = false;
@@ -873,6 +885,7 @@ class PinnedMessageManager {
     if (!this.api || !this.chatId) {
       // Just reset state if not initialized
       this.state.messageId = null;
+      this.state.messageThreadId = null;
       this.state.sessionId = null;
       this.state.sessionTitle = t("pinned.default_session_title");
       this.state.attachActive = false;
@@ -896,6 +909,7 @@ class PinnedMessageManager {
 
       // Reset state
       this.state.messageId = null;
+      this.state.messageThreadId = null;
       this.state.sessionId = null;
       this.state.sessionTitle = t("pinned.default_session_title");
       this.state.attachActive = false;

--- a/src/pinned/types.ts
+++ b/src/pinned/types.ts
@@ -24,6 +24,7 @@ export interface FileChange {
 export interface PinnedMessageState {
   messageId: number | null;
   chatId: number | null;
+  messageThreadId?: number | null;
   sessionId: string | null;
   sessionTitle: string;
   attachActive: boolean;

--- a/src/scheduled-task/runtime.ts
+++ b/src/scheduled-task/runtime.ts
@@ -4,10 +4,12 @@ import {
   escapePlainTextForTelegramMarkdownV2,
   formatSummaryWithMode,
 } from "../summary/formatter.js";
+import { createTelegramTarget, type TelegramTarget } from "../telegram/target.js";
 import { t } from "../i18n/index.js";
 import { logger } from "../utils/logger.js";
 import { safeBackgroundTask } from "../utils/safe-background-task.js";
 import { sendBotText } from "../bot/utils/telegram-text.js";
+import { getTelegramTarget } from "../settings/manager.js";
 import { executeScheduledTask } from "./executor.js";
 import { foregroundSessionState } from "./foreground-state.js";
 import { computeNextRunAt, isTaskDue } from "./next-run.js";
@@ -102,7 +104,7 @@ function buildErrorDelivery(
 
 export class ScheduledTaskRuntime {
   private botApi: Bot<Context>["api"] | null = null;
-  private chatId: number | null = null;
+  private target: TelegramTarget | null = null;
   private initialized = false;
   private timersByTaskId = new Map<string, ReturnType<typeof setTimeout>>();
   private runningTaskIds = new Set<string>();
@@ -111,7 +113,7 @@ export class ScheduledTaskRuntime {
 
   async initialize(bot: Bot<Context>): Promise<void> {
     this.botApi = bot.api;
-    this.chatId = config.telegram.allowedUserId;
+    this.target = getTelegramTarget() ?? createTelegramTarget(config.telegram.allowedUserId);
 
     if (this.initialized) {
       return;
@@ -145,7 +147,7 @@ export class ScheduledTaskRuntime {
     if (
       this.flushInProgress ||
       !this.botApi ||
-      this.chatId === null ||
+      this.target === null ||
       foregroundSessionState.isBusy() ||
       this.deliveryQueue.length === 0
     ) {
@@ -185,7 +187,7 @@ export class ScheduledTaskRuntime {
     }
 
     this.botApi = null;
-    this.chatId = null;
+    this.target = null;
     this.initialized = false;
     this.timersByTaskId.clear();
     this.runningTaskIds.clear();
@@ -461,7 +463,7 @@ export class ScheduledTaskRuntime {
   }
 
   private async sendDelivery(delivery: QueuedScheduledTaskDelivery): Promise<boolean> {
-    if (!this.botApi || this.chatId === null) {
+    if (!this.botApi || this.target === null) {
       return false;
     }
 
@@ -475,7 +477,7 @@ export class ScheduledTaskRuntime {
       for (const part of messageParts) {
         await sendBotText({
           api: this.botApi,
-          chatId: this.chatId,
+          target: this.target,
           text: part,
           format,
         });

--- a/src/settings/manager.ts
+++ b/src/settings/manager.ts
@@ -1,5 +1,6 @@
 import type { ModelInfo } from "../model/types.js";
 import { cloneScheduledTask, type ScheduledTask } from "../scheduled-task/types.js";
+import type { TelegramTarget } from "../telegram/target.js";
 import path from "node:path";
 import { getRuntimePaths } from "../runtime/paths.js";
 import { logger } from "../utils/logger.js";
@@ -28,6 +29,7 @@ export interface SessionDirectoryCacheInfo {
 export interface Settings {
   currentProject?: ProjectInfo;
   currentSession?: SessionInfo;
+  telegramTarget?: TelegramTarget;
   currentAgent?: string;
   currentModel?: ModelInfo;
   pinnedMessageId?: number;
@@ -105,6 +107,20 @@ export function setCurrentSession(sessionInfo: SessionInfo): void {
 
 export function clearSession(): void {
   currentSettings.currentSession = undefined;
+  void writeSettingsFile(currentSettings);
+}
+
+export function getTelegramTarget(): TelegramTarget | undefined {
+  return currentSettings.telegramTarget;
+}
+
+export function setTelegramTarget(target: TelegramTarget): void {
+  currentSettings.telegramTarget = target;
+  void writeSettingsFile(currentSettings);
+}
+
+export function clearTelegramTarget(): void {
+  currentSettings.telegramTarget = undefined;
   void writeSettingsFile(currentSettings);
 }
 

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -5,6 +5,7 @@ import { normalizePathForDisplay, prepareCodeFile } from "./formatter.js";
 import type { Question } from "../question/types.js";
 import type { PermissionRequest } from "../permission/types.js";
 import type { FileChange } from "../pinned/types.js";
+import { getTelegramTargetSendOptions, type TelegramTarget } from "../telegram/target.js";
 import { logger } from "../utils/logger.js";
 import { getCurrentProject } from "../settings/manager.js";
 
@@ -234,7 +235,7 @@ class SummaryAggregator {
   private deliveredExternalUserMessageIds: Set<string> = new Set();
   private knownTextPartIds: Map<string, Set<string>> = new Map();
   private bot: Bot | null = null;
-  private chatId: number | null = null;
+  private target: TelegramTarget | null = null;
   private typingTimer: ReturnType<typeof setInterval> | null = null;
   private typingIndicatorEnabled = true;
   private partHashes: Map<string, Set<string>> = new Map();
@@ -247,9 +248,9 @@ class SummaryAggregator {
   private fallbackSubagentCardIdsByParent: Map<string, string[]> = new Map();
   private lastSubagentSnapshot = "";
 
-  setBotAndChatId(bot: Bot, chatId: number): void {
+  setBotAndTarget(bot: Bot, target: TelegramTarget): void {
     this.bot = bot;
-    this.chatId = chatId;
+    this.target = target;
   }
 
   setOnComplete(callback: MessageCompleteCallback): void {
@@ -346,8 +347,10 @@ class SummaryAggregator {
     }
 
     const sendTyping = () => {
-      if (this.bot && this.chatId) {
-        this.bot.api.sendChatAction(this.chatId, "typing").catch((err) => {
+      if (this.bot && this.target) {
+        this.bot.api
+          .sendChatAction(this.target.chatId, "typing", getTelegramTargetSendOptions(this.target))
+          .catch((err) => {
           logger.error("Failed to send typing action:", err);
         });
       }

--- a/src/telegram/target.ts
+++ b/src/telegram/target.ts
@@ -1,0 +1,53 @@
+import type { Context } from "grammy";
+
+export interface TelegramTarget {
+  chatId: number;
+  messageThreadId?: number;
+}
+
+export function createTelegramTarget(
+  chatId: number,
+  messageThreadId?: number | null,
+): TelegramTarget {
+  if (typeof messageThreadId === "number") {
+    return { chatId, messageThreadId };
+  }
+
+  return { chatId };
+}
+
+export function getTelegramTargetSendOptions(target: TelegramTarget): {
+  message_thread_id?: number;
+} {
+  if (typeof target.messageThreadId === "number") {
+    return { message_thread_id: target.messageThreadId };
+  }
+
+  return {};
+}
+
+export function getMessageThreadIdFromContext(
+  ctx: Pick<Context, "message" | "callbackQuery">,
+): number | undefined {
+  const messageThreadId = (ctx.message as { message_thread_id?: unknown } | undefined)
+    ?.message_thread_id;
+  if (typeof messageThreadId === "number") {
+    return messageThreadId;
+  }
+
+  const callbackMessage = ctx.callbackQuery?.message as { message_thread_id?: unknown } | undefined;
+  if (typeof callbackMessage?.message_thread_id === "number") {
+    return callbackMessage.message_thread_id;
+  }
+
+  return undefined;
+}
+
+export function getTelegramTargetFromContext(ctx: Context): TelegramTarget | null {
+  const chatId = ctx.chat?.id;
+  if (typeof chatId !== "number") {
+    return null;
+  }
+
+  return createTelegramTarget(chatId, getMessageThreadIdFromContext(ctx));
+}

--- a/tests/attach/service.test.ts
+++ b/tests/attach/service.test.ts
@@ -22,7 +22,7 @@ const mocked = vi.hoisted(() => ({
   questionListMock: vi.fn(),
   permissionListMock: vi.fn(),
   setSessionSummaryMock: vi.fn(),
-  setBotAndChatIdMock: vi.fn(),
+  setBotAndTargetMock: vi.fn(),
   pinnedIsInitializedMock: vi.fn(() => true),
   pinnedInitializeMock: vi.fn(),
   pinnedGetStateMock: vi.fn(),
@@ -63,7 +63,7 @@ vi.mock("../../src/opencode/client.js", () => ({
 vi.mock("../../src/summary/aggregator.js", () => ({
   summaryAggregator: {
     setSession: mocked.setSessionSummaryMock,
-    setBotAndChatId: mocked.setBotAndChatIdMock,
+    setBotAndTarget: mocked.setBotAndTargetMock,
     clear: vi.fn(),
   },
 }));
@@ -132,7 +132,7 @@ describe("attach/service", () => {
     mocked.permissionListMock.mockReset();
     mocked.permissionListMock.mockResolvedValue({ data: [], error: null });
     mocked.setSessionSummaryMock.mockReset();
-    mocked.setBotAndChatIdMock.mockReset();
+    mocked.setBotAndTargetMock.mockReset();
     mocked.pinnedIsInitializedMock.mockReset();
     mocked.pinnedIsInitializedMock.mockReturnValue(true);
     mocked.pinnedInitializeMock.mockReset();
@@ -164,7 +164,7 @@ describe("attach/service", () => {
   it("follows an idle session and updates attach state", async () => {
     const result = await attachToSession({
       bot: createBot(),
-      chatId: 777,
+      target: { chatId: 777 },
       session: mocked.currentSession!,
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
@@ -177,7 +177,7 @@ describe("attach/service", () => {
     });
     expect(mocked.ensureEventSubscriptionMock).toHaveBeenCalledWith("D:\\Projects\\Repo");
     expect(mocked.setSessionSummaryMock).toHaveBeenCalledWith("session-1");
-    expect(mocked.setBotAndChatIdMock).toHaveBeenCalled();
+    expect(mocked.setBotAndTargetMock).toHaveBeenCalled();
     expect(mocked.pinnedSetAttachStateMock).toHaveBeenCalledWith(true, false);
     expect(attachManager.getSnapshot()).toMatchObject({
       sessionId: "session-1",
@@ -191,14 +191,14 @@ describe("attach/service", () => {
 
     await attachToSession({
       bot,
-      chatId: 777,
+      target: { chatId: 777 },
       session: mocked.currentSession!,
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
 
     const result = await attachToSession({
       bot,
-      chatId: 777,
+      target: { chatId: 777 },
       session: mocked.currentSession!,
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
@@ -227,7 +227,7 @@ describe("attach/service", () => {
 
     const result = await attachToSession({
       bot: createBot(),
-      chatId: 777,
+      target: { chatId: 777 },
       session: mocked.currentSession!,
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
@@ -239,7 +239,7 @@ describe("attach/service", () => {
   it("restores the saved current session on startup", async () => {
     const restored = await restoreAttachedCurrentSession({
       bot: createBot(),
-      chatId: 777,
+      target: { chatId: 777 },
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
 
@@ -256,7 +256,7 @@ describe("attach/service", () => {
 
     const restored = await restoreAttachedCurrentSession({
       bot: createBot(),
-      chatId: 777,
+      target: { chatId: 777 },
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
 
@@ -280,7 +280,7 @@ describe("attach/service", () => {
 
     const restored = await restoreAttachedCurrentSession({
       bot: createBot(),
-      chatId: 777,
+      target: { chatId: 777 },
       ensureEventSubscription: mocked.ensureEventSubscriptionMock,
     });
 

--- a/tests/bot/commands/commands.test.ts
+++ b/tests/bot/commands/commands.test.ts
@@ -323,7 +323,7 @@ describe("bot/commands/commands", () => {
     });
     expect(mocked.attachToSessionMock).toHaveBeenCalledWith({
       bot: expect.any(Object),
-      chatId: 777,
+      target: { chatId: 777 },
       session: {
         id: "session-1",
         title: "Session",

--- a/tests/bot/commands/new.test.ts
+++ b/tests/bot/commands/new.test.ts
@@ -129,7 +129,7 @@ describe("bot/commands/new", () => {
 
     expect(mocked.attachToSessionMock).toHaveBeenCalledWith({
       bot: expect.any(Object),
-      chatId: 123,
+      target: { chatId: 123 },
       session: {
         id: "session-2",
         title: "Session Two",

--- a/tests/bot/commands/sessions.test.ts
+++ b/tests/bot/commands/sessions.test.ts
@@ -365,7 +365,7 @@ describe("bot/commands/sessions", () => {
     expect(mocked.keyboardUpdateAgentMock).toHaveBeenCalledWith("plan");
     expect(mocked.attachToSessionMock).toHaveBeenCalledWith({
       bot: expect.any(Object),
-      chatId: 111,
+      target: { chatId: 111 },
       session: {
         id: "session-1",
         title: "Session 1",

--- a/tests/bot/commands/start.test.ts
+++ b/tests/bot/commands/start.test.ts
@@ -139,8 +139,8 @@ describe("bot/commands/start", () => {
     expect(mocked.keyboardClearContextMock).toHaveBeenCalledTimes(1);
     expect(mocked.pinnedClearMock).toHaveBeenCalledTimes(1);
 
-    expect(mocked.pinnedInitializeMock).toHaveBeenCalledWith(ctx.api, 100);
-    expect(mocked.keyboardInitializeMock).toHaveBeenCalledWith(ctx.api, 100);
+    expect(mocked.pinnedInitializeMock).toHaveBeenCalledWith(ctx.api, { chatId: 100 });
+    expect(mocked.keyboardInitializeMock).toHaveBeenCalledWith(ctx.api, { chatId: 100 });
     expect(mocked.pinnedRefreshContextLimitMock).toHaveBeenCalledTimes(1);
 
     expect(ctx.reply).toHaveBeenCalledWith(t("start.welcome"), {

--- a/tests/bot/handlers/prompt.test.ts
+++ b/tests/bot/handlers/prompt.test.ts
@@ -205,7 +205,7 @@ describe("bot/handlers/prompt", () => {
     expect(handled).toBe(true);
     expect(mocked.attachToSessionMock).toHaveBeenCalledWith({
       bot: expect.any(Object),
-      chatId: 777,
+      target: { chatId: 777 },
       session: {
         id: "session-1",
         title: "Session",

--- a/tests/bot/utils/external-user-input.test.ts
+++ b/tests/bot/utils/external-user-input.test.ts
@@ -30,7 +30,7 @@ describe("bot/utils/external-user-input", () => {
   it("sends external user input when session matches and it is not suppressed", async () => {
     const delivered = await deliverExternalUserInputNotification({
       api: { sendMessage: vi.fn() } as never,
-      chatId: 777,
+      target: { chatId: 777 },
       currentSessionId: "session-1",
       sessionId: "session-1",
       text: "Review the parser",
@@ -40,7 +40,7 @@ describe("bot/utils/external-user-input", () => {
     expect(delivered).toBe(true);
     expect(mocked.sendBotTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatId: 777,
+        target: { chatId: 777 },
         format: "markdown_v2",
         rawFallbackText: "👤 External user input\n\n> Review the parser",
       }),
@@ -52,7 +52,7 @@ describe("bot/utils/external-user-input", () => {
 
     const delivered = await deliverExternalUserInputNotification({
       api: { sendMessage: vi.fn() } as never,
-      chatId: 777,
+      target: { chatId: 777 },
       currentSessionId: "session-1",
       sessionId: "session-1",
       text: "Review the parser",
@@ -67,7 +67,7 @@ describe("bot/utils/external-user-input", () => {
   it("does not send notification when the current session differs", async () => {
     const delivered = await deliverExternalUserInputNotification({
       api: { sendMessage: vi.fn() } as never,
-      chatId: 777,
+      target: { chatId: 777 },
       currentSessionId: "session-2",
       sessionId: "session-1",
       text: "Review the parser",

--- a/tests/bot/utils/send-tts-response.test.ts
+++ b/tests/bot/utils/send-tts-response.test.ts
@@ -25,7 +25,7 @@ describe("bot/utils/send-tts-response", () => {
     const result = await sendTtsResponseForSession({
       api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
-      chatId: 123,
+      target: { chatId: 123 },
       text: "Hello from audio",
       consumeResponseMode: () => "text_and_tts",
       isTtsConfigured: () => true,
@@ -49,7 +49,7 @@ describe("bot/utils/send-tts-response", () => {
     const result = await sendTtsResponseForSession({
       api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
-      chatId: 123,
+      target: { chatId: 123 },
       text: "Hello from text",
       consumeResponseMode: () => "text_only",
       isTtsConfigured: () => true,
@@ -70,7 +70,7 @@ describe("bot/utils/send-tts-response", () => {
     const result = await sendTtsResponseForSession({
       api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
-      chatId: 123,
+      target: { chatId: 123 },
       text: "Hello from audio",
       consumeResponseMode: () => "text_and_tts",
       isTtsConfigured: () => false,
@@ -95,7 +95,7 @@ describe("bot/utils/send-tts-response", () => {
     const result = await sendTtsResponseForSession({
       api: { sendAudio: sendAudioMock, sendMessage: sendMessageMock },
       sessionId: "session-1",
-      chatId: 123,
+      target: { chatId: 123 },
       text: "Hello from audio",
       consumeResponseMode: () => "text_and_tts",
       isTtsConfigured: () => true,
@@ -103,6 +103,6 @@ describe("bot/utils/send-tts-response", () => {
     });
 
     expect(result).toBe(false);
-    expect(sendMessageMock).toHaveBeenCalledWith(123, t("tts.failed"));
+    expect(sendMessageMock).toHaveBeenCalledWith(123, t("tts.failed"), undefined);
   });
 });

--- a/tests/bot/utils/send-with-markdown-fallback.test.ts
+++ b/tests/bot/utils/send-with-markdown-fallback.test.ts
@@ -12,7 +12,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 123,
+      target: { chatId: 123 },
       text: "**hello**",
       options: { reply_markup: replyMarkup },
       parseMode: "MarkdownV2",
@@ -33,7 +33,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 123,
+      target: { chatId: 123 },
       text: "<broken>",
       options: { reply_markup: { keyboard: [] } },
       parseMode: "MarkdownV2",
@@ -63,7 +63,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 777,
+      target: { chatId: 777 },
       text: "a+b",
       options: {
         reply_markup: { keyboard: [] },
@@ -100,7 +100,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 444,
+      target: { chatId: 444 },
       text: "Done.",
       rawFallbackText: "Done.",
       parseMode: "MarkdownV2",
@@ -121,7 +121,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 445,
+      target: { chatId: 445 },
       text: "Done.",
       parseMode: "MarkdownV2",
     });
@@ -140,7 +140,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 888,
+      target: { chatId: 888 },
       text: "Cost (USD)",
       parseMode: "MarkdownV2",
     });
@@ -164,7 +164,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 889,
+      target: { chatId: 889 },
       text: "Table \\| row \\| and dot .",
       parseMode: "MarkdownV2",
     });
@@ -186,7 +186,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
     await expect(
       sendMessageWithMarkdownFallback({
         api: { sendMessage },
-        chatId: 123,
+        target: { chatId: 123 },
         text: "hello",
         parseMode: "MarkdownV2",
       }),
@@ -214,7 +214,7 @@ describe("bot/utils/send-with-markdown-fallback", () => {
 
     await sendMessageWithMarkdownFallback({
       api: { sendMessage },
-      chatId: 321,
+      target: { chatId: 321 },
       text: "*status* project_name",
       parseMode: "Markdown",
     });

--- a/tests/bot/utils/switch-project.test.ts
+++ b/tests/bot/utils/switch-project.test.ts
@@ -115,7 +115,7 @@ describe("switch-project", () => {
     const ctx = createCtx(456);
     await switchToProject(ctx, testProject, "test_reason");
 
-    expect(mocked.keyboardInitMock).toHaveBeenCalledWith(ctx.api, 456);
+    expect(mocked.keyboardInitMock).toHaveBeenCalledWith(ctx.api, { chatId: 456 });
     expect(mocked.keyboardUpdateMock).toHaveBeenCalledWith(0, 128000);
   });
 

--- a/tests/bot/utils/telegram-text.test.ts
+++ b/tests/bot/utils/telegram-text.test.ts
@@ -13,7 +13,7 @@ describe("bot/utils/telegram-text", () => {
 
     await sendBotText({
       api: { sendMessage },
-      chatId: 100,
+      target: { chatId: 100 },
       text: "plain text",
       options: { reply_markup: { keyboard: [] } },
     });
@@ -29,7 +29,7 @@ describe("bot/utils/telegram-text", () => {
 
     await sendBotText({
       api: { sendMessage },
-      chatId: 100,
+      target: { chatId: 100 },
       text: "**formatted**",
       format: "markdown_v2",
     });
@@ -51,7 +51,7 @@ describe("bot/utils/telegram-text", () => {
 
     await sendBotText({
       api: { sendMessage },
-      chatId: 100,
+      target: { chatId: 100 },
       text: "Build succeeded.",
       rawFallbackText: "Build succeeded.",
       format: "markdown_v2",
@@ -81,7 +81,7 @@ describe("bot/utils/telegram-text", () => {
     await expect(
       sendRenderedBotPart({
         api: { sendMessage },
-        chatId: 100,
+        target: { chatId: 100 },
         part: {
           text: "Hello",
           entities: [{ type: "bold", offset: 0, length: 5 }],
@@ -111,7 +111,7 @@ describe("bot/utils/telegram-text", () => {
     await expect(
       sendRenderedBotPart({
         api: { sendMessage },
-        chatId: 100,
+        target: { chatId: 100 },
         part: {
           text: "plain text",
           fallbackText: "plain text",
@@ -139,7 +139,7 @@ describe("bot/utils/telegram-text", () => {
     await expect(
       sendRenderedBotPart({
         api: { sendMessage },
-        chatId: 100,
+        target: { chatId: 100 },
         part: {
           text: "Hello",
           entities: [{ type: "bold", offset: 0, length: 5 }],

--- a/tests/pinned/manager.test.ts
+++ b/tests/pinned/manager.test.ts
@@ -74,7 +74,7 @@ describe("pinned/manager", () => {
     };
 
     // Reset manager state by re-initializing
-    pinnedMessageManager.initialize(fakeApi as never, 123);
+    pinnedMessageManager.initialize(fakeApi as never, { chatId: 123 });
 
     mocked.getCurrentSession.mockReturnValue({ id: "ses-1", title: "Test Session" });
     mocked.getCurrentProject.mockReturnValue({ id: "p1", worktree: "D:/repo", name: "repo" });
@@ -178,6 +178,7 @@ describe("pinned/manager", () => {
       expect(fakeApi.sendMessage).toHaveBeenCalledWith(
         123,
         expect.stringContaining("Project: D:/repo: main"),
+        undefined,
       );
     });
 
@@ -195,10 +196,12 @@ describe("pinned/manager", () => {
       expect(fakeApi.sendMessage).toHaveBeenCalledWith(
         123,
         expect.stringContaining("Project: D:/repo"),
+        undefined,
       );
       expect(fakeApi.sendMessage).not.toHaveBeenCalledWith(
         123,
         expect.stringContaining("Project: D:/repo:"),
+        undefined,
       );
     });
 
@@ -221,10 +224,12 @@ describe("pinned/manager", () => {
       expect(fakeApi.sendMessage).toHaveBeenCalledWith(
         123,
         expect.stringContaining("Project: D:/repo: feature/worktree"),
+        undefined,
       );
       expect(fakeApi.sendMessage).toHaveBeenCalledWith(
         123,
         expect.stringContaining("Worktree: D:/repo-feature"),
+        undefined,
       );
     });
   });

--- a/tests/scheduled-task/runtime.test.ts
+++ b/tests/scheduled-task/runtime.test.ts
@@ -185,7 +185,7 @@ describe("scheduled-task/runtime", () => {
     expect(mocked.sendBotTextMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        chatId: 777,
+        target: { chatId: 777 },
         format: "markdown_v2",
         text: expect.stringMatching(/Send report[\s\S]*All good/),
       }),
@@ -224,7 +224,7 @@ describe("scheduled-task/runtime", () => {
     expect(mocked.tasks[0]?.nextRunAt).toBe("2026-03-17T17:00:00.000Z");
     expect(mocked.sendBotTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatId: 777,
+        target: { chatId: 777 },
         format: "raw",
         text: expect.stringContaining("Task failed"),
       }),
@@ -260,7 +260,7 @@ describe("scheduled-task/runtime", () => {
 
     expect(mocked.sendBotTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatId: 777,
+        target: { chatId: 777 },
         format: "raw",
         text: expect.stringContaining("https://opencode.ai/docs/config/#models"),
       }),


### PR DESCRIPTION
## Summary
- Add `TelegramTarget { chatId, messageThreadId? }` and propagate it through message sending/editing so the bot replies inside the correct forum topic.
- Persist the last seen target in settings to survive restarts and use it for scheduled tasks.

## Notes
- No behavior change for regular chats (no `message_thread_id`).
- Tests and build pass.