### PR TITLE
feat(commands): add /ls command for explorer and downloader

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -111,6 +111,7 @@ Current command set:
 - `/opencode_start` - start local OpenCode server
 - `/opencode_stop` - stop local OpenCode server
 - `/help` - show command help
+- `/ls` - interactive file browser for the current project directory
 
 Model, agent, variant, and context actions are available from the persistent bottom keyboard.
 
@@ -161,6 +162,7 @@ Model picker behavior:
 - [x] Create new OpenCode projects directly from Telegram
 - [x] `/mcps` command: browse available MCP servers
 - [x] Optional local OpenCode server monitoring with automatic restart
+- [x] Interactive project file browsing and file download from Telegram (`/ls`)
 
 ## Current Task List
 
@@ -170,4 +172,3 @@ Open tasks for upcoming iterations:
 - [ ] Model search in model switcher
 - [ ] Docker runtime support and deployment guide
 - [ ] Add a bot settings command with in-chat UI
-- [ ] Add project file browsing helpers (for example, `ls`-like flows with ability to send file to Telegram)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Languages: English (`en`), Deutsch (`de`), Español (`es`), Français (`fr`), Р
 - **Git worktree switching** — browse and switch between existing git worktrees for the current repository with `/worktree`
 - **Security** — strict user ID whitelist; no one else can access your bot, even if they find it
 - **Localization** — UI localization is supported for multiple languages (`BOT_LOCALE`)
+- **Interactive file browser** — use `/ls` to browse files and directories inside the current project, open subdirectories, go back, and download files by tapping them
 
 Planned features currently in development are listed in [Current Task List](PRODUCT.md#current-task-list).
 
@@ -134,6 +135,7 @@ opencode-telegram config
 | `/projects`       | Switch between OpenCode projects                        |
 | `/worktree`       | Switch between existing git worktrees                   |
 | `/open`           | Add a project by browsing directories                   |
+| `/ls`             | List directory contents, then tap to open or download   |
 | `/tts`            | Toggle audio replies                                    |
 | `/rename`         | Rename the current session                              |
 | `/commands`       | Browse and run custom commands                          |

--- a/src/bot/commands/definitions.ts
+++ b/src/bot/commands/definitions.ts
@@ -37,6 +37,7 @@ const COMMAND_DEFINITIONS: BotCommandI18nDefinition[] = [
   { command: "opencode_start", descriptionKey: "cmd.description.opencode_start" },
   { command: "opencode_stop", descriptionKey: "cmd.description.opencode_stop" },
   { command: "open", descriptionKey: "cmd.description.open" },
+  { command: "ls", descriptionKey: "cmd.description.ls" },
   { command: "help", descriptionKey: "cmd.description.help" },
 ];
 

--- a/src/bot/commands/ls.ts
+++ b/src/bot/commands/ls.ts
@@ -16,7 +16,7 @@ const CALLBACK_NAV_PREFIX = "ls:nav:";
 const CALLBACK_FILE_PREFIX = "ls:file:";
 const CALLBACK_PAGE_PREFIX = "ls:pg:";
 const PAGE_SEPARATOR = "|";
-const MAX_ENTRIES_PER_PAGE = 20;
+const MAX_ENTRIES_PER_PAGE = 8;
 const MAX_BUTTON_LABEL_LENGTH = 64;
 
 const sessionDirectories = new Map<number, string>();

--- a/src/bot/commands/ls.ts
+++ b/src/bot/commands/ls.ts
@@ -1,0 +1,382 @@
+import { CommandContext, Context, InlineKeyboard } from "grammy";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import { appendInlineMenuCancelButton, ensureActiveInlineMenu } from "../handlers/inline-menu.js";
+import { interactionManager } from "../../interaction/manager.js";
+import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
+import { getBrowserRoots, isAllowedRoot, isWithinAllowedRoot } from "../utils/browser-roots.js";
+import { getCurrentProject } from "../../settings/manager.js";
+import { sendDownloadedFile } from "../utils/send-downloaded-file.js";
+import { logger } from "../../utils/logger.js";
+import { t } from "../../i18n/index.js";
+
+const CALLBACK_PREFIX = "ls:";
+const CALLBACK_NAV_PREFIX = "ls:nav:";
+const CALLBACK_FILE_PREFIX = "ls:file:";
+const CALLBACK_PAGE_PREFIX = "ls:pg:";
+const PAGE_SEPARATOR = "|";
+const MAX_ENTRIES_PER_PAGE = 20;
+const MAX_BUTTON_LABEL_LENGTH = 64;
+
+const sessionDirectories = new Map<number, string>();
+const pathIndex = new Map<string, string>();
+let pathCounter = 0;
+
+interface LsEntry {
+  name: string;
+  fullPath: string;
+  type: "file" | "directory";
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function truncateLabel(label: string, maxLen: number = MAX_BUTTON_LABEL_LENGTH): string {
+  if (label.length <= maxLen) {
+    return label;
+  }
+
+  return `${label.slice(0, Math.max(0, maxLen - 3))}...`;
+}
+
+function pathToDisplayPath(absolutePath: string): string {
+  const home = os.homedir();
+  if (absolutePath === home) {
+    return "~";
+  }
+
+  if (absolutePath.startsWith(home + path.sep)) {
+    return `~${absolutePath.slice(home.length)}`;
+  }
+
+  return absolutePath;
+}
+
+function buildEntryLabel(entry: LsEntry): string {
+  return `${entry.type === "directory" ? "📁" : "📄"} ${entry.name}`;
+}
+
+function isPathWithinDirectory(targetPath: string, directoryPath: string): boolean {
+  const relativePath = path.relative(directoryPath, targetPath);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+function buildLsHeader(displayPath: string, totalCount: number, page: number, totalPages: number): string {
+  let header = `📁 ${t("ls.header")}\n<code>${escapeHtml(displayPath)}</code>`;
+  if (totalPages > 1) {
+    header += `\n(${page + 1}/${totalPages})`;
+  }
+  header += `\n${t("ls.total", { count: totalCount })}`;
+  return header;
+}
+
+function encodePathForCallback(prefix: string, fullPath: string, reserveBytes: number = 0): string {
+  const naive = `${prefix}${fullPath}`;
+  if (Buffer.byteLength(naive, "utf-8") + reserveBytes <= 64) {
+    return naive;
+  }
+
+  const key = `#${pathCounter++}`;
+  pathIndex.set(key, fullPath);
+  return `${prefix}${key}`;
+}
+
+function decodePathFromCallback(prefix: string, data: string): string | null {
+  if (!data.startsWith(prefix)) {
+    return null;
+  }
+
+  const raw = data.slice(prefix.length);
+  if (raw.startsWith("#")) {
+    return pathIndex.get(raw) ?? null;
+  }
+
+  return raw;
+}
+
+function encodePaginationCallback(currentPath: string, page: number): string {
+  const pageSuffix = `${PAGE_SEPARATOR}${page}`;
+  const reserveBytes = Buffer.byteLength(pageSuffix, "utf-8");
+  const pathRef = encodePathForCallback(CALLBACK_PAGE_PREFIX, currentPath, reserveBytes);
+  return `${pathRef}${pageSuffix}`;
+}
+
+function decodePaginationCallback(data: string): { path: string; page: number } | null {
+  if (!data.startsWith(CALLBACK_PAGE_PREFIX)) {
+    return null;
+  }
+
+  const payload = data.slice(CALLBACK_PAGE_PREFIX.length);
+  const separatorIndex = payload.lastIndexOf(PAGE_SEPARATOR);
+  if (separatorIndex < 0) {
+    return null;
+  }
+
+  const pathRef = payload.slice(0, separatorIndex);
+  const page = Number.parseInt(payload.slice(separatorIndex + 1), 10);
+  if (Number.isNaN(page)) {
+    return null;
+  }
+
+  const resolvedPath = pathRef.startsWith("#") ? (pathIndex.get(pathRef) ?? null) : pathRef;
+  if (resolvedPath === null) {
+    return null;
+  }
+
+  return { path: resolvedPath, page };
+}
+
+async function scanDirectory(
+  dirPath: string,
+  page: number = 0,
+): Promise<
+  | {
+      entries: LsEntry[];
+      totalCount: number;
+      currentPath: string;
+      displayPath: string;
+      hasParent: boolean;
+      page: number;
+    }
+  | { error: string }
+> {
+  try {
+    if (!isWithinAllowedRoot(dirPath)) {
+      return { error: t("ls.access_denied") };
+    }
+
+    const dirEntries = await fs.readdir(dirPath, { withFileTypes: true });
+    const entries: LsEntry[] = dirEntries
+      .map((entry): LsEntry => ({
+        name: entry.name,
+        fullPath: path.join(dirPath, entry.name),
+        type: entry.isDirectory() ? "directory" : "file",
+      }))
+      .sort((left, right) => {
+        if (left.type !== right.type) {
+          return left.type === "directory" ? -1 : 1;
+        }
+
+        return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+      });
+
+    const totalPages = Math.max(1, Math.ceil(entries.length / MAX_ENTRIES_PER_PAGE));
+    const safePage = Math.max(0, Math.min(page, totalPages - 1));
+    const startIndex = safePage * MAX_ENTRIES_PER_PAGE;
+
+    return {
+      entries: entries.slice(startIndex, startIndex + MAX_ENTRIES_PER_PAGE),
+      totalCount: entries.length,
+      currentPath: dirPath,
+      displayPath: pathToDisplayPath(dirPath),
+      hasParent: dirPath !== path.parse(dirPath).root,
+      page: safePage,
+    };
+  } catch (error) {
+    return {
+      error: `${t("ls.scan_error")}: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+function buildBrowseKeyboard(
+  entries: LsEntry[],
+  currentPath: string,
+  hasParent: boolean,
+  page: number,
+  totalCount: number,
+): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const totalPages = Math.max(1, Math.ceil(totalCount / MAX_ENTRIES_PER_PAGE));
+  const projectRoot = getCurrentProject()?.worktree;
+  const atProjectRoot = !!projectRoot && currentPath === projectRoot;
+
+  for (const entry of entries) {
+    const label = truncateLabel(buildEntryLabel(entry));
+    const callbackData =
+      entry.type === "directory"
+        ? encodePathForCallback(CALLBACK_NAV_PREFIX, entry.fullPath)
+        : encodePathForCallback(CALLBACK_FILE_PREFIX, entry.fullPath);
+    keyboard.text(label, callbackData).row();
+  }
+
+  if (hasParent && !isAllowedRoot(currentPath) && !atProjectRoot) {
+    keyboard.text(t("open.back"), encodePathForCallback(CALLBACK_NAV_PREFIX, path.dirname(currentPath))).row();
+  }
+
+  if (totalPages > 1) {
+    if (page > 0) {
+      keyboard.text(t("open.prev_page"), encodePaginationCallback(currentPath, page - 1));
+    }
+    if (page < totalPages - 1) {
+      keyboard.text(t("open.next_page"), encodePaginationCallback(currentPath, page + 1));
+    }
+    keyboard.row();
+  }
+
+  appendInlineMenuCancelButton(keyboard, "ls");
+  return keyboard;
+}
+
+async function renderBrowseView(dirPath: string, page: number = 0) {
+  const result = await scanDirectory(dirPath, page);
+  if ("error" in result) {
+    return result;
+  }
+
+  const totalPages = Math.max(1, Math.ceil(result.totalCount / MAX_ENTRIES_PER_PAGE));
+  return {
+    text: buildLsHeader(result.displayPath, result.totalCount, result.page, totalPages),
+    keyboard: buildBrowseKeyboard(
+      result.entries,
+      result.currentPath,
+      result.hasParent,
+      result.page,
+      result.totalCount,
+    ),
+  };
+}
+
+function resolveInitialDirectory(userId?: number): string | null {
+  const currentProject = getCurrentProject()?.worktree;
+
+  if (userId) {
+    const cachedDirectory = sessionDirectories.get(userId);
+    if (cachedDirectory) {
+      if (!currentProject || isPathWithinDirectory(cachedDirectory, currentProject)) {
+        return cachedDirectory;
+      }
+    }
+  }
+
+  if (currentProject) {
+    return currentProject;
+  }
+
+  const browserRoots = getBrowserRoots();
+  return browserRoots[0] ?? null;
+}
+
+export function clearLsPathIndex(): void {
+  pathIndex.clear();
+  pathCounter = 0;
+}
+
+export function clearSessionDirectories(): void {
+  sessionDirectories.clear();
+}
+
+export async function lsCommand(ctx: CommandContext<Context>): Promise<void> {
+  if (isForegroundBusy()) {
+    await replyBusyBlocked(ctx);
+    return;
+  }
+
+  clearLsPathIndex();
+
+  const args = typeof ctx.match === "string" ? ctx.match.trim() : undefined;
+  const targetDir = args || resolveInitialDirectory(ctx.from?.id);
+  if (!targetDir) {
+    await ctx.reply(`❌ ${t("commands.download.no_roots")}`);
+    return;
+  }
+
+  const view = await renderBrowseView(targetDir);
+  if ("error" in view) {
+    await ctx.reply(`❌ ${view.error}`);
+    return;
+  }
+
+  if (ctx.from) {
+    sessionDirectories.set(ctx.from.id, targetDir);
+  }
+
+  const message = await ctx.reply(view.text, { parse_mode: "HTML", reply_markup: view.keyboard });
+  interactionManager.start({
+    kind: "inline",
+    expectedInput: "callback",
+    metadata: {
+      menuKind: "ls",
+      messageId: message.message_id,
+    },
+  });
+}
+
+async function navigateTo(ctx: Context, dirPath: string, page: number = 0): Promise<void> {
+  const view = await renderBrowseView(dirPath, page);
+  if ("error" in view) {
+    await ctx.answerCallbackQuery({ text: view.error });
+    return;
+  }
+
+  if (ctx.from) {
+    sessionDirectories.set(ctx.from.id, dirPath);
+  }
+
+  await ctx.answerCallbackQuery();
+  await ctx.editMessageText(view.text, { parse_mode: "HTML", reply_markup: view.keyboard });
+}
+
+export async function handleLsCallback(ctx: Context): Promise<boolean> {
+  const data = ctx.callbackQuery?.data;
+  if (!data || !data.startsWith(CALLBACK_PREFIX)) {
+    return false;
+  }
+
+  if (isForegroundBusy()) {
+    await replyBusyBlocked(ctx);
+    return true;
+  }
+
+  const isActiveMenu = await ensureActiveInlineMenu(ctx, "ls");
+  if (!isActiveMenu) {
+    return true;
+  }
+
+  try {
+    const navPath = decodePathFromCallback(CALLBACK_NAV_PREFIX, data);
+    if (navPath !== null) {
+      if (!isWithinAllowedRoot(navPath)) {
+        await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
+        return true;
+      }
+      await navigateTo(ctx, navPath);
+      return true;
+    }
+
+    const pageInfo = decodePaginationCallback(data);
+    if (pageInfo !== null) {
+      if (!isWithinAllowedRoot(pageInfo.path)) {
+        await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
+        return true;
+      }
+      await navigateTo(ctx, pageInfo.path, pageInfo.page);
+      return true;
+    }
+
+    const filePath = decodePathFromCallback(CALLBACK_FILE_PREFIX, data);
+    if (filePath !== null) {
+      if (!isWithinAllowedRoot(filePath)) {
+        await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
+        return true;
+      }
+
+      await ctx.answerCallbackQuery({ text: t("commands.download.downloading") });
+      await sendDownloadedFile(ctx, filePath, { announce: false });
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    logger.error("[Ls] Error handling callback:", error);
+    await ctx.answerCallbackQuery({ text: t("callback.processing_error") });
+    return true;
+  }
+}

--- a/src/bot/commands/ls.ts
+++ b/src/bot/commands/ls.ts
@@ -2,18 +2,24 @@ import { CommandContext, Context, InlineKeyboard } from "grammy";
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import os from "node:os";
-import { appendInlineMenuCancelButton, ensureActiveInlineMenu } from "../handlers/inline-menu.js";
+import {
+  appendInlineMenuCancelButton,
+  clearActiveInlineMenu,
+  ensureActiveInlineMenu,
+} from "../handlers/inline-menu.js";
 import { interactionManager } from "../../interaction/manager.js";
 import { isForegroundBusy, replyBusyBlocked } from "../utils/busy-guard.js";
-import { getBrowserRoots, isAllowedRoot, isWithinAllowedRoot } from "../utils/browser-roots.js";
 import { getCurrentProject } from "../../settings/manager.js";
 import { sendDownloadedFile } from "../utils/send-downloaded-file.js";
+import { formatFileSize } from "../utils/file-download.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 
 const CALLBACK_PREFIX = "ls:";
 const CALLBACK_NAV_PREFIX = "ls:nav:";
 const CALLBACK_FILE_PREFIX = "ls:file:";
+const CALLBACK_DOWNLOAD_PREFIX = "ls:download:";
+const CALLBACK_BACK_PREFIX = "ls:back:";
 const CALLBACK_PAGE_PREFIX = "ls:pg:";
 const PAGE_SEPARATOR = "|";
 const MAX_ENTRIES_PER_PAGE = 8;
@@ -27,6 +33,13 @@ interface LsEntry {
   name: string;
   fullPath: string;
   type: "file" | "directory";
+}
+
+interface FileDetails {
+  name: string;
+  fullPath: string;
+  size: number;
+  modified: Date;
 }
 
 function escapeHtml(text: string): string {
@@ -68,6 +81,20 @@ function isPathWithinDirectory(targetPath: string, directoryPath: string): boole
   return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
+function getProjectRoot(): string | null {
+  return getCurrentProject()?.worktree ?? null;
+}
+
+function isWithinProjectRoot(targetPath: string): boolean {
+  const projectRoot = getProjectRoot();
+  return projectRoot !== null && isPathWithinDirectory(targetPath, projectRoot);
+}
+
+function isProjectRoot(targetPath: string): boolean {
+  const projectRoot = getProjectRoot();
+  return projectRoot !== null && targetPath === projectRoot;
+}
+
 function buildLsHeader(displayPath: string, totalCount: number, page: number, totalPages: number): string {
   let header = `📁 ${t("ls.header")}\n<code>${escapeHtml(displayPath)}</code>`;
   if (totalPages > 1) {
@@ -75,6 +102,14 @@ function buildLsHeader(displayPath: string, totalCount: number, page: number, to
   }
   header += `\n${t("ls.total", { count: totalCount })}`;
   return header;
+}
+
+function buildFileDetailsText(fileDetails: FileDetails): string {
+  return (
+    `📄 ${t("ls.file.header")}\n<code>${escapeHtml(fileDetails.name)}</code>\n` +
+    `${t("commands.download.size")}: ${formatFileSize(fileDetails.size)}\n` +
+    `${t("commands.download.modified")}: ${fileDetails.modified.toLocaleDateString()}`
+  );
 }
 
 function encodePathForCallback(prefix: string, fullPath: string, reserveBytes: number = 0): string {
@@ -101,19 +136,19 @@ function decodePathFromCallback(prefix: string, data: string): string | null {
   return raw;
 }
 
-function encodePaginationCallback(currentPath: string, page: number): string {
+function encodePathWithPageCallback(prefix: string, fullPath: string, page: number): string {
   const pageSuffix = `${PAGE_SEPARATOR}${page}`;
   const reserveBytes = Buffer.byteLength(pageSuffix, "utf-8");
-  const pathRef = encodePathForCallback(CALLBACK_PAGE_PREFIX, currentPath, reserveBytes);
+  const pathRef = encodePathForCallback(prefix, fullPath, reserveBytes);
   return `${pathRef}${pageSuffix}`;
 }
 
-function decodePaginationCallback(data: string): { path: string; page: number } | null {
-  if (!data.startsWith(CALLBACK_PAGE_PREFIX)) {
+function decodePathWithPageCallback(data: string, prefix: string): { path: string; page: number } | null {
+  if (!data.startsWith(prefix)) {
     return null;
   }
 
-  const payload = data.slice(CALLBACK_PAGE_PREFIX.length);
+  const payload = data.slice(prefix.length);
   const separatorIndex = payload.lastIndexOf(PAGE_SEPARATOR);
   if (separatorIndex < 0) {
     return null;
@@ -133,6 +168,30 @@ function decodePaginationCallback(data: string): { path: string; page: number } 
   return { path: resolvedPath, page };
 }
 
+function encodePaginationCallback(currentPath: string, page: number): string {
+  return encodePathWithPageCallback(CALLBACK_PAGE_PREFIX, currentPath, page);
+}
+
+function decodePaginationCallback(data: string): { path: string; page: number } | null {
+  return decodePathWithPageCallback(data, CALLBACK_PAGE_PREFIX);
+}
+
+function encodeFileCallback(fullPath: string, page: number): string {
+  return encodePathWithPageCallback(CALLBACK_FILE_PREFIX, fullPath, page);
+}
+
+function decodeFileCallback(data: string): { path: string; page: number } | null {
+  return decodePathWithPageCallback(data, CALLBACK_FILE_PREFIX);
+}
+
+function encodeBackCallback(directoryPath: string, page: number): string {
+  return encodePathWithPageCallback(CALLBACK_BACK_PREFIX, directoryPath, page);
+}
+
+function decodeBackCallback(data: string): { path: string; page: number } | null {
+  return decodePathWithPageCallback(data, CALLBACK_BACK_PREFIX);
+}
+
 async function scanDirectory(
   dirPath: string,
   page: number = 0,
@@ -148,7 +207,7 @@ async function scanDirectory(
   | { error: string }
 > {
   try {
-    if (!isWithinAllowedRoot(dirPath)) {
+    if (!isWithinProjectRoot(dirPath)) {
       return { error: t("ls.access_denied") };
     }
 
@@ -195,19 +254,17 @@ function buildBrowseKeyboard(
 ): InlineKeyboard {
   const keyboard = new InlineKeyboard();
   const totalPages = Math.max(1, Math.ceil(totalCount / MAX_ENTRIES_PER_PAGE));
-  const projectRoot = getCurrentProject()?.worktree;
-  const atProjectRoot = !!projectRoot && currentPath === projectRoot;
 
   for (const entry of entries) {
     const label = truncateLabel(buildEntryLabel(entry));
     const callbackData =
       entry.type === "directory"
         ? encodePathForCallback(CALLBACK_NAV_PREFIX, entry.fullPath)
-        : encodePathForCallback(CALLBACK_FILE_PREFIX, entry.fullPath);
+        : encodeFileCallback(entry.fullPath, page);
     keyboard.text(label, callbackData).row();
   }
 
-  if (hasParent && !isAllowedRoot(currentPath) && !atProjectRoot) {
+  if (hasParent && !isProjectRoot(currentPath)) {
     keyboard.text(t("open.back"), encodePathForCallback(CALLBACK_NAV_PREFIX, path.dirname(currentPath))).row();
   }
 
@@ -225,6 +282,25 @@ function buildBrowseKeyboard(
   return keyboard;
 }
 
+function buildFileDetailsKeyboard(filePath: string, page: number): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const parentPath = path.dirname(filePath);
+
+  keyboard.text(t("ls.file.download"), encodePathForCallback(CALLBACK_DOWNLOAD_PREFIX, filePath));
+  keyboard.text(t("ls.file.back"), encodeBackCallback(parentPath, page));
+  keyboard.row();
+  appendInlineMenuCancelButton(keyboard, "ls");
+  return keyboard;
+}
+
+function hasBrowseActions(currentPath: string, hasParent: boolean, totalCount: number): boolean {
+  if (totalCount > 0) {
+    return true;
+  }
+
+  return hasParent && !isProjectRoot(currentPath);
+}
+
 async function renderBrowseView(dirPath: string, page: number = 0) {
   const result = await scanDirectory(dirPath, page);
   if ("error" in result) {
@@ -234,6 +310,7 @@ async function renderBrowseView(dirPath: string, page: number = 0) {
   const totalPages = Math.max(1, Math.ceil(result.totalCount / MAX_ENTRIES_PER_PAGE));
   return {
     text: buildLsHeader(result.displayPath, result.totalCount, result.page, totalPages),
+    hasActions: hasBrowseActions(result.currentPath, result.hasParent, result.totalCount),
     keyboard: buildBrowseKeyboard(
       result.entries,
       result.currentPath,
@@ -244,24 +321,56 @@ async function renderBrowseView(dirPath: string, page: number = 0) {
   };
 }
 
+async function getFileDetails(filePath: string): Promise<FileDetails | { error: string }> {
+  try {
+    if (!isWithinProjectRoot(filePath)) {
+      return { error: t("ls.access_denied") };
+    }
+
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      return { error: t("commands.download.not_file") };
+    }
+
+    return {
+      name: path.basename(filePath),
+      fullPath: filePath,
+      size: stat.size,
+      modified: stat.mtime,
+    };
+  } catch (error) {
+    return {
+      error: `${t("ls.scan_error")}: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+async function renderFileDetailsView(filePath: string, page: number) {
+  const fileDetails = await getFileDetails(filePath);
+  if ("error" in fileDetails) {
+    return fileDetails;
+  }
+
+  return {
+    text: buildFileDetailsText(fileDetails),
+    keyboard: buildFileDetailsKeyboard(fileDetails.fullPath, page),
+  };
+}
+
 function resolveInitialDirectory(userId?: number): string | null {
-  const currentProject = getCurrentProject()?.worktree;
+  const currentProject = getProjectRoot();
+  if (!currentProject) {
+    return null;
+  }
 
   if (userId) {
     const cachedDirectory = sessionDirectories.get(userId);
-    if (cachedDirectory) {
-      if (!currentProject || isPathWithinDirectory(cachedDirectory, currentProject)) {
-        return cachedDirectory;
-      }
+    if (cachedDirectory && isPathWithinDirectory(cachedDirectory, currentProject)) {
+      return cachedDirectory;
     }
   }
 
-  if (currentProject) {
-    return currentProject;
-  }
-
-  const browserRoots = getBrowserRoots();
-  return browserRoots[0] ?? null;
+  return currentProject;
 }
 
 export function clearLsPathIndex(): void {
@@ -281,10 +390,21 @@ export async function lsCommand(ctx: CommandContext<Context>): Promise<void> {
 
   clearLsPathIndex();
 
+  const projectRoot = getProjectRoot();
+  if (!projectRoot) {
+    await ctx.reply(t("bot.project_not_selected"));
+    return;
+  }
+
   const args = typeof ctx.match === "string" ? ctx.match.trim() : undefined;
   const targetDir = args || resolveInitialDirectory(ctx.from?.id);
   if (!targetDir) {
-    await ctx.reply(`❌ ${t("commands.download.no_roots")}`);
+    await ctx.reply(t("bot.project_not_selected"));
+    return;
+  }
+
+  if (!isWithinProjectRoot(targetDir)) {
+    await ctx.reply(`❌ ${t("ls.access_denied")}`);
     return;
   }
 
@@ -296,6 +416,11 @@ export async function lsCommand(ctx: CommandContext<Context>): Promise<void> {
 
   if (ctx.from) {
     sessionDirectories.set(ctx.from.id, targetDir);
+  }
+
+  if (!view.hasActions) {
+    await ctx.reply(view.text, { parse_mode: "HTML" });
+    return;
   }
 
   const message = await ctx.reply(view.text, { parse_mode: "HTML", reply_markup: view.keyboard });
@@ -324,6 +449,29 @@ async function navigateTo(ctx: Context, dirPath: string, page: number = 0): Prom
   await ctx.editMessageText(view.text, { parse_mode: "HTML", reply_markup: view.keyboard });
 }
 
+async function showFileDetails(ctx: Context, filePath: string, page: number): Promise<void> {
+  const view = await renderFileDetailsView(filePath, page);
+  if ("error" in view) {
+    await ctx.answerCallbackQuery({ text: view.error });
+    return;
+  }
+
+  await ctx.answerCallbackQuery();
+  await ctx.editMessageText(view.text, { parse_mode: "HTML", reply_markup: view.keyboard });
+}
+
+async function downloadFileAndClose(ctx: Context, filePath: string): Promise<void> {
+  await ctx.answerCallbackQuery({ text: t("commands.download.downloading") });
+  const downloaded = await sendDownloadedFile(ctx, filePath, { announce: false });
+  if (!downloaded) {
+    return;
+  }
+
+  clearActiveInlineMenu("ls_downloaded");
+  clearLsPathIndex();
+  await ctx.deleteMessage().catch(() => {});
+}
+
 export async function handleLsCallback(ctx: Context): Promise<boolean> {
   const data = ctx.callbackQuery?.data;
   if (!data || !data.startsWith(CALLBACK_PREFIX)) {
@@ -343,7 +491,7 @@ export async function handleLsCallback(ctx: Context): Promise<boolean> {
   try {
     const navPath = decodePathFromCallback(CALLBACK_NAV_PREFIX, data);
     if (navPath !== null) {
-      if (!isWithinAllowedRoot(navPath)) {
+      if (!isWithinProjectRoot(navPath)) {
         await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
         return true;
       }
@@ -353,7 +501,7 @@ export async function handleLsCallback(ctx: Context): Promise<boolean> {
 
     const pageInfo = decodePaginationCallback(data);
     if (pageInfo !== null) {
-      if (!isWithinAllowedRoot(pageInfo.path)) {
+      if (!isWithinProjectRoot(pageInfo.path)) {
         await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
         return true;
       }
@@ -361,15 +509,33 @@ export async function handleLsCallback(ctx: Context): Promise<boolean> {
       return true;
     }
 
-    const filePath = decodePathFromCallback(CALLBACK_FILE_PREFIX, data);
-    if (filePath !== null) {
-      if (!isWithinAllowedRoot(filePath)) {
+    const fileInfo = decodeFileCallback(data);
+    if (fileInfo !== null) {
+      if (!isWithinProjectRoot(fileInfo.path)) {
         await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
         return true;
       }
+      await showFileDetails(ctx, fileInfo.path, fileInfo.page);
+      return true;
+    }
 
-      await ctx.answerCallbackQuery({ text: t("commands.download.downloading") });
-      await sendDownloadedFile(ctx, filePath, { announce: false });
+    const downloadPath = decodePathFromCallback(CALLBACK_DOWNLOAD_PREFIX, data);
+    if (downloadPath !== null) {
+      if (!isWithinProjectRoot(downloadPath)) {
+        await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
+        return true;
+      }
+      await downloadFileAndClose(ctx, downloadPath);
+      return true;
+    }
+
+    const backInfo = decodeBackCallback(data);
+    if (backInfo !== null) {
+      if (!isWithinProjectRoot(backInfo.path)) {
+        await ctx.answerCallbackQuery({ text: t("ls.access_denied") });
+        return true;
+      }
+      await navigateTo(ctx, backInfo.path, backInfo.page);
       return true;
     }
 

--- a/src/bot/handlers/inline-menu.ts
+++ b/src/bot/handlers/inline-menu.ts
@@ -15,6 +15,7 @@ const INLINE_MENU_KINDS = [
   "variant",
   "context",
   "open",
+  "ls",
   "worktree",
 ] as const;
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -22,6 +22,7 @@ import { newCommand } from "./commands/new.js";
 import { projectsCommand, handleProjectSelect } from "./commands/projects.js";
 import { worktreeCommand, handleWorktreeCallback } from "./commands/worktree.js";
 import { openCommand, handleOpenCallback, clearOpenPathIndex } from "./commands/open.js";
+import { clearLsPathIndex, handleLsCallback, lsCommand } from "./commands/ls.js";
 import { abortCommand } from "./commands/abort.js";
 import { opencodeStartCommand } from "./commands/opencode-start.js";
 import { opencodeStopCommand } from "./commands/opencode-stop.js";
@@ -1076,6 +1077,7 @@ export function createBot(): Bot<Context> {
   bot.command("projects", projectsCommand);
   bot.command("worktree", worktreeCommand);
   bot.command("open", openCommand);
+  bot.command("ls", lsCommand);
   bot.command("sessions", sessionsCommand);
   bot.command("new", (ctx) => newCommand(ctx, { bot, ensureEventSubscription }));
   bot.command("abort", abortCommand);
@@ -1102,11 +1104,13 @@ export function createBot(): Bot<Context> {
       if (handledInlineCancel) {
         // Clean up path index when the open-directory menu is cancelled
         clearOpenPathIndex();
+        clearLsPathIndex();
       }
       const handledSession = await handleSessionSelect(ctx, { bot, ensureEventSubscription });
       const handledProject = await handleProjectSelect(ctx);
       const handledWorktree = await handleWorktreeCallback(ctx);
       const handledOpen = await handleOpenCallback(ctx);
+      const handledLs = await handleLsCallback(ctx);
       const handledQuestion = await handleQuestionCallback(ctx);
       const handledPermission = await handlePermissionCallback(ctx);
       const handledAgent = await handleAgentSelect(ctx);
@@ -1121,7 +1125,7 @@ export function createBot(): Bot<Context> {
       const handledMcps = await handleMcpsCallback(ctx);
 
       logger.debug(
-        `[Bot] Callback handled: inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, skills=${handledSkills}, mcps=${handledMcps}`,
+        `[Bot] Callback handled: inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, ls=${handledLs}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, skills=${handledSkills}, mcps=${handledMcps}`,
       );
 
       if (
@@ -1130,6 +1134,7 @@ export function createBot(): Bot<Context> {
         !handledProject &&
         !handledWorktree &&
         !handledOpen &&
+        !handledLs &&
         !handledQuestion &&
         !handledPermission &&
         !handledAgent &&

--- a/src/bot/utils/send-downloaded-file.ts
+++ b/src/bot/utils/send-downloaded-file.ts
@@ -1,7 +1,6 @@
 import { Context, InputFile } from "grammy";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { isWithinAllowedRoot } from "./browser-roots.js";
 import { formatFileSize } from "./file-download.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
@@ -23,13 +22,6 @@ export async function sendDownloadedFile(
   options?: { announce?: boolean },
 ): Promise<boolean> {
   try {
-    if (!isWithinAllowedRoot(filePath)) {
-      await ctx.reply(`❌ ${t("ls.access_denied")}: <code>${escapeHtml(filePath)}</code>`, {
-        parse_mode: "HTML",
-      });
-      return false;
-    }
-
     const stat = await fs.stat(filePath).catch(() => null);
     if (!stat) {
       await ctx.reply(`❌ ${t("commands.download.not_found")}: <code>${escapeHtml(filePath)}</code>`, {

--- a/src/bot/utils/send-downloaded-file.ts
+++ b/src/bot/utils/send-downloaded-file.ts
@@ -1,0 +1,81 @@
+import { Context, InputFile } from "grammy";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { isWithinAllowedRoot } from "./browser-roots.js";
+import { formatFileSize } from "./file-download.js";
+import { logger } from "../../utils/logger.js";
+import { t } from "../../i18n/index.js";
+
+const MAX_FILE_SIZE_MB = 50;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export async function sendDownloadedFile(
+  ctx: Context,
+  filePath: string,
+  options?: { announce?: boolean },
+): Promise<boolean> {
+  try {
+    if (!isWithinAllowedRoot(filePath)) {
+      await ctx.reply(`❌ ${t("ls.access_denied")}: <code>${escapeHtml(filePath)}</code>`, {
+        parse_mode: "HTML",
+      });
+      return false;
+    }
+
+    const stat = await fs.stat(filePath).catch(() => null);
+    if (!stat) {
+      await ctx.reply(`❌ ${t("commands.download.not_found")}: <code>${escapeHtml(filePath)}</code>`, {
+        parse_mode: "HTML",
+      });
+      return false;
+    }
+
+    if (!stat.isFile()) {
+      await ctx.reply(`❌ ${t("commands.download.not_file")}: <code>${escapeHtml(filePath)}</code>`, {
+        parse_mode: "HTML",
+      });
+      return false;
+    }
+
+    if (stat.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      await ctx.reply(
+        `❌ ${t("commands.download.file_too_large")}: ${formatFileSize(stat.size)} (max: ${MAX_FILE_SIZE_MB}MB)`,
+      );
+      return false;
+    }
+
+    const fileName = path.basename(filePath);
+
+    if (options?.announce !== false) {
+      await ctx.reply(`📥 ${t("commands.download.downloading")} <code>${escapeHtml(fileName)}</code>`, {
+        parse_mode: "HTML",
+      });
+    }
+
+    const fileContent = await fs.readFile(filePath);
+    const caption =
+      `📄 <code>${escapeHtml(fileName)}</code>\n` +
+      `${t("commands.download.size")}: ${formatFileSize(stat.size)}\n` +
+      `${t("commands.download.modified")}: ${stat.mtime.toLocaleDateString()}`;
+
+    await ctx.replyWithDocument(new InputFile(fileContent, fileName), {
+      caption: caption.slice(0, 1024),
+      parse_mode: "HTML",
+    });
+
+    logger.info(`[Download] User ${ctx.from?.id} downloaded file: ${filePath}`);
+    return true;
+  } catch (error) {
+    logger.error("[Download] Error:", error);
+    await ctx.reply(`❌ ${t("commands.download.error")}`);
+    return false;
+  }
+}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -567,7 +567,7 @@ export const de: I18nDictionary = {
   "open.no_subfolders": "📭 Keine Unterordner",
   "open.subfolder_count": "{count} Unterordner",
   "open.subfolders_count": "{count} Unterordner",
-  "ls.access_denied": "⛔ Zugriff verweigert: Pfad liegt außerhalb erlaubter Verzeichnisse",
+  "ls.access_denied": "⛔ Zugriff verweigert: Pfad liegt außerhalb des aktuellen Projekts",
   "ls.scan_error": "🔴 Verzeichnis kann nicht aufgelistet werden",
   "ls.header": "Verzeichnisinhalt",
   "ls.total": "Gesamt: {count} Einträge",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -15,6 +15,7 @@ export const de: I18nDictionary = {
   "cmd.description.mcps": "MCP servers",
   "cmd.description.opencode_start": "OpenCode-Server starten",
   "cmd.description.opencode_stop": "OpenCode-Server stoppen",
+  "cmd.description.ls": "Verzeichnisinhalt auflisten",
   "cmd.description.help": "Hilfe",
 
   "callback.unknown_command": "Unbekannter Befehl",
@@ -469,6 +470,14 @@ export const de: I18nDictionary = {
   "commands.page_empty_callback": "Keine Befehle auf dieser Seite",
   "commands.page_load_error_callback":
     "Diese Seite konnte nicht geladen werden. Bitte versuche es erneut.",
+  "commands.download.no_roots": "Es sind keine erlaubten Browser-Wurzeln konfiguriert.",
+  "commands.download.downloading": "Datei wird heruntergeladen...",
+  "commands.download.not_found": "Datei nicht gefunden",
+  "commands.download.not_file": "Pfad ist keine Datei",
+  "commands.download.file_too_large": "Datei ist zu groß",
+  "commands.download.size": "Größe",
+  "commands.download.modified": "Geändert",
+  "commands.download.error": "Datei konnte nicht heruntergeladen werden.",
 
   "skills.select": "Wähle einen OpenCode-Skill:",
   "skills.empty": "📭 Für dieses Projekt sind keine OpenCode-Skills verfügbar.",
@@ -558,4 +567,8 @@ export const de: I18nDictionary = {
   "open.no_subfolders": "📭 Keine Unterordner",
   "open.subfolder_count": "{count} Unterordner",
   "open.subfolders_count": "{count} Unterordner",
+  "ls.access_denied": "⛔ Zugriff verweigert: Pfad liegt außerhalb erlaubter Verzeichnisse",
+  "ls.scan_error": "🔴 Verzeichnis kann nicht aufgelistet werden",
+  "ls.header": "Verzeichnisinhalt",
+  "ls.total": "Gesamt: {count} Einträge",
 };

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -571,4 +571,7 @@ export const de: I18nDictionary = {
   "ls.scan_error": "🔴 Verzeichnis kann nicht aufgelistet werden",
   "ls.header": "Verzeichnisinhalt",
   "ls.total": "Gesamt: {count} Einträge",
+  "ls.file.header": "Dateidetails",
+  "ls.file.download": "📥 Herunterladen",
+  "ls.file.back": "⬅️ Zurück",
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -13,6 +13,7 @@ export const en = {
   "cmd.description.mcps": "MCP servers",
   "cmd.description.opencode_start": "Start OpenCode server",
   "cmd.description.opencode_stop": "Stop OpenCode server",
+  "cmd.description.ls": "List directory contents",
   "cmd.description.help": "Help",
 
   "callback.unknown_command": "Unknown command",
@@ -451,6 +452,14 @@ export const en = {
   "commands.button.next_page": "Next ➡️",
   "commands.page_empty_callback": "No commands on this page",
   "commands.page_load_error_callback": "Cannot load this page. Please try again.",
+  "commands.download.no_roots": "No allowed browser roots are configured.",
+  "commands.download.downloading": "Downloading file...",
+  "commands.download.not_found": "File not found",
+  "commands.download.not_file": "Path is not a file",
+  "commands.download.file_too_large": "File is too large",
+  "commands.download.size": "Size",
+  "commands.download.modified": "Modified",
+  "commands.download.error": "Failed to download file.",
 
   "skills.select": "Choose an OpenCode skill:",
   "skills.empty": "📭 No OpenCode skills are available for this project.",
@@ -536,6 +545,10 @@ export const en = {
   "open.no_subfolders": "📭 No subfolders",
   "open.subfolder_count": "{count} subfolder",
   "open.subfolders_count": "{count} subfolders",
+  "ls.access_denied": "⛔ Access denied: path is outside allowed roots",
+  "ls.scan_error": "🔴 Cannot list directory",
+  "ls.header": "Directory Listing",
+  "ls.total": "Total: {count} items",
 } as const;
 
 export type I18nKey = keyof typeof en;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -545,7 +545,7 @@ export const en = {
   "open.no_subfolders": "📭 No subfolders",
   "open.subfolder_count": "{count} subfolder",
   "open.subfolders_count": "{count} subfolders",
-  "ls.access_denied": "⛔ Access denied: path is outside allowed roots",
+  "ls.access_denied": "⛔ Access denied: path is outside the current project",
   "ls.scan_error": "🔴 Cannot list directory",
   "ls.header": "Directory Listing",
   "ls.total": "Total: {count} items",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -549,6 +549,9 @@ export const en = {
   "ls.scan_error": "🔴 Cannot list directory",
   "ls.header": "Directory Listing",
   "ls.total": "Total: {count} items",
+  "ls.file.header": "File Details",
+  "ls.file.download": "📥 Download",
+  "ls.file.back": "⬅️ Back",
 } as const;
 
 export type I18nKey = keyof typeof en;

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -567,7 +567,7 @@ export const es: I18nDictionary = {
   "open.no_subfolders": "📭 Sin subcarpetas",
   "open.subfolder_count": "{count} subcarpeta",
   "open.subfolders_count": "{count} subcarpetas",
-  "ls.access_denied": "⛔ Acceso denegado: la ruta está fuera de las raíces permitidas",
+  "ls.access_denied": "⛔ Acceso denegado: la ruta está fuera del proyecto actual",
   "ls.scan_error": "🔴 No se puede listar el directorio",
   "ls.header": "Listado del directorio",
   "ls.total": "Total: {count} elementos",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -571,4 +571,7 @@ export const es: I18nDictionary = {
   "ls.scan_error": "🔴 No se puede listar el directorio",
   "ls.header": "Listado del directorio",
   "ls.total": "Total: {count} elementos",
+  "ls.file.header": "Detalles del archivo",
+  "ls.file.download": "📥 Descargar",
+  "ls.file.back": "⬅️ Volver",
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -15,6 +15,7 @@ export const es: I18nDictionary = {
   "cmd.description.mcps": "MCP servers",
   "cmd.description.opencode_start": "Iniciar servidor OpenCode",
   "cmd.description.opencode_stop": "Detener servidor OpenCode",
+  "cmd.description.ls": "Listar contenidos del directorio",
   "cmd.description.help": "Ayuda",
 
   "callback.unknown_command": "Comando desconocido",
@@ -469,6 +470,14 @@ export const es: I18nDictionary = {
   "commands.page_empty_callback": "No hay comandos en esta página",
   "commands.page_load_error_callback":
     "No se pudo cargar esta página. Por favor, inténtalo de nuevo.",
+  "commands.download.no_roots": "No hay raíces de navegación permitidas configuradas.",
+  "commands.download.downloading": "Descargando archivo...",
+  "commands.download.not_found": "Archivo no encontrado",
+  "commands.download.not_file": "La ruta no es un archivo",
+  "commands.download.file_too_large": "El archivo es demasiado grande",
+  "commands.download.size": "Tamaño",
+  "commands.download.modified": "Modificado",
+  "commands.download.error": "No se pudo descargar el archivo.",
 
   "skills.select": "Elige un skill de OpenCode:",
   "skills.empty": "📭 No hay skills de OpenCode disponibles para este proyecto.",
@@ -558,4 +567,8 @@ export const es: I18nDictionary = {
   "open.no_subfolders": "📭 Sin subcarpetas",
   "open.subfolder_count": "{count} subcarpeta",
   "open.subfolders_count": "{count} subcarpetas",
+  "ls.access_denied": "⛔ Acceso denegado: la ruta está fuera de las raíces permitidas",
+  "ls.scan_error": "🔴 No se puede listar el directorio",
+  "ls.header": "Listado del directorio",
+  "ls.total": "Total: {count} elementos",
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -15,6 +15,7 @@ export const fr: I18nDictionary = {
   "cmd.description.mcps": "MCP servers",
   "cmd.description.opencode_start": "Démarrer le serveur OpenCode",
   "cmd.description.opencode_stop": "Arrêter le serveur OpenCode",
+  "cmd.description.ls": "Lister le contenu du répertoire",
   "cmd.description.help": "Aide",
 
   "callback.unknown_command": "Commande inconnue",
@@ -470,6 +471,14 @@ export const fr: I18nDictionary = {
   "commands.button.next_page": "Suivant ➡️",
   "commands.page_empty_callback": "Aucune commande sur cette page",
   "commands.page_load_error_callback": "Impossible de charger cette page. Veuillez réessayer.",
+  "commands.download.no_roots": "Aucune racine de navigation autorisée n'est configurée.",
+  "commands.download.downloading": "Téléchargement du fichier...",
+  "commands.download.not_found": "Fichier introuvable",
+  "commands.download.not_file": "Le chemin n'est pas un fichier",
+  "commands.download.file_too_large": "Le fichier est trop volumineux",
+  "commands.download.size": "Taille",
+  "commands.download.modified": "Modifié",
+  "commands.download.error": "Impossible de télécharger le fichier.",
 
   "skills.select": "Choisissez un skill OpenCode :",
   "skills.empty": "📭 Aucun skill OpenCode n'est disponible pour ce projet.",
@@ -557,4 +566,8 @@ export const fr: I18nDictionary = {
   "open.no_subfolders": "📭 Aucun sous-dossier",
   "open.subfolder_count": "{count} sous-dossier",
   "open.subfolders_count": "{count} sous-dossiers",
+  "ls.access_denied": "⛔ Accès refusé : le chemin est en dehors des répertoires autorisés",
+  "ls.scan_error": "🔴 Impossible de lister le répertoire",
+  "ls.header": "Liste du répertoire",
+  "ls.total": "Total : {count} éléments",
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -570,4 +570,7 @@ export const fr: I18nDictionary = {
   "ls.scan_error": "🔴 Impossible de lister le répertoire",
   "ls.header": "Liste du répertoire",
   "ls.total": "Total : {count} éléments",
+  "ls.file.header": "Détails du fichier",
+  "ls.file.download": "📥 Télécharger",
+  "ls.file.back": "⬅️ Retour",
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -566,7 +566,7 @@ export const fr: I18nDictionary = {
   "open.no_subfolders": "📭 Aucun sous-dossier",
   "open.subfolder_count": "{count} sous-dossier",
   "open.subfolders_count": "{count} sous-dossiers",
-  "ls.access_denied": "⛔ Accès refusé : le chemin est en dehors des répertoires autorisés",
+  "ls.access_denied": "⛔ Accès refusé : le chemin est en dehors du projet actuel",
   "ls.scan_error": "🔴 Impossible de lister le répertoire",
   "ls.header": "Liste du répertoire",
   "ls.total": "Total : {count} éléments",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -553,7 +553,7 @@ export const ru: I18nDictionary = {
   "open.no_subfolders": "📭 Нет подпапок",
   "open.subfolder_count": "{count} подпапка",
   "open.subfolders_count": "{count} подпапок",
-  "ls.access_denied": "⛔ Доступ запрещён: путь за пределами разрешённых каталогов",
+  "ls.access_denied": "⛔ Доступ запрещён: путь находится за пределами текущего проекта",
   "ls.scan_error": "🔴 Не удается перечислить каталог",
   "ls.header": "Список каталога",
   "ls.total": "Всего: {count} элементов",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -15,6 +15,7 @@ export const ru: I18nDictionary = {
   "cmd.description.mcps": "MCP серверы",
   "cmd.description.opencode_start": "Запустить OpenCode сервер",
   "cmd.description.opencode_stop": "Остановить OpenCode сервер",
+  "cmd.description.ls": "Список содержимого каталога",
   "cmd.description.help": "Справка",
 
   "callback.unknown_command": "Неизвестная команда",
@@ -455,6 +456,14 @@ export const ru: I18nDictionary = {
   "commands.page_empty_callback": "На этой странице нет команд",
   "commands.page_load_error_callback":
     "Не удалось загрузить эту страницу. Пожалуйста, попробуйте снова.",
+  "commands.download.no_roots": "Не настроены разрешённые корневые каталоги для просмотра.",
+  "commands.download.downloading": "Скачиваю файл...",
+  "commands.download.not_found": "Файл не найден",
+  "commands.download.not_file": "Путь не является файлом",
+  "commands.download.file_too_large": "Файл слишком большой",
+  "commands.download.size": "Размер",
+  "commands.download.modified": "Изменён",
+  "commands.download.error": "Не удалось скачать файл.",
 
   "skills.select": "Выберите скилл OpenCode:",
   "skills.empty": "📭 Для этого проекта нет доступных скиллов OpenCode.",
@@ -544,4 +553,8 @@ export const ru: I18nDictionary = {
   "open.no_subfolders": "📭 Нет подпапок",
   "open.subfolder_count": "{count} подпапка",
   "open.subfolders_count": "{count} подпапок",
+  "ls.access_denied": "⛔ Доступ запрещён: путь за пределами разрешённых каталогов",
+  "ls.scan_error": "🔴 Не удается перечислить каталог",
+  "ls.header": "Список каталога",
+  "ls.total": "Всего: {count} элементов",
 };

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -557,4 +557,7 @@ export const ru: I18nDictionary = {
   "ls.scan_error": "🔴 Не удается перечислить каталог",
   "ls.header": "Список каталога",
   "ls.total": "Всего: {count} элементов",
+  "ls.file.header": "Сведения о файле",
+  "ls.file.download": "📥 Скачать",
+  "ls.file.back": "⬅️ Назад",
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -15,6 +15,7 @@ export const zh: I18nDictionary = {
   "cmd.description.mcps": "MCP servers",
   "cmd.description.opencode_start": "启动 OpenCode 服务器",
   "cmd.description.opencode_stop": "停止 OpenCode 服务器",
+  "cmd.description.ls": "列出目录内容",
   "cmd.description.help": "帮助",
 
   "callback.unknown_command": "未知命令",
@@ -409,6 +410,14 @@ export const zh: I18nDictionary = {
   "commands.button.next_page": "下一页 ➡️",
   "commands.page_empty_callback": "这一页没有命令",
   "commands.page_load_error_callback": "无法加载此页面。请重试。",
+  "commands.download.no_roots": "未配置允许浏览的根目录。",
+  "commands.download.downloading": "正在下载文件...",
+  "commands.download.not_found": "未找到文件",
+  "commands.download.not_file": "该路径不是文件",
+  "commands.download.file_too_large": "文件过大",
+  "commands.download.size": "大小",
+  "commands.download.modified": "修改时间",
+  "commands.download.error": "下载文件失败。",
 
   "skills.select": "请选择一个 OpenCode 技能：",
   "skills.empty": "📭 当前项目没有可用的 OpenCode 技能。",
@@ -491,4 +500,8 @@ export const zh: I18nDictionary = {
   "open.no_subfolders": "📭 无子文件夹",
   "open.subfolder_count": "{count} 个子文件夹",
   "open.subfolders_count": "{count} 个子文件夹",
+  "ls.access_denied": "⛔ 访问被拒绝：路径在允许的根目录之外",
+  "ls.scan_error": "🔴 无法列出目录",
+  "ls.header": "目录列表",
+  "ls.total": "总计：{count} 个项目",
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -504,4 +504,7 @@ export const zh: I18nDictionary = {
   "ls.scan_error": "🔴 无法列出目录",
   "ls.header": "目录列表",
   "ls.total": "总计：{count} 个项目",
+  "ls.file.header": "文件详情",
+  "ls.file.download": "📥 下载",
+  "ls.file.back": "⬅️ 返回",
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -500,7 +500,7 @@ export const zh: I18nDictionary = {
   "open.no_subfolders": "📭 无子文件夹",
   "open.subfolder_count": "{count} 个子文件夹",
   "open.subfolders_count": "{count} 个子文件夹",
-  "ls.access_denied": "⛔ 访问被拒绝：路径在允许的根目录之外",
+  "ls.access_denied": "⛔ 访问被拒绝：路径在当前项目之外",
   "ls.scan_error": "🔴 无法列出目录",
   "ls.header": "目录列表",
   "ls.total": "总计：{count} 个项目",

--- a/tests/bot/commands/ls.test.ts
+++ b/tests/bot/commands/ls.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+import { t } from "../../../src/i18n/index.js";
+
+const mocked = vi.hoisted(() => ({
+  readdirMock: vi.fn(),
+  isForegroundBusyMock: vi.fn(),
+  replyBusyBlockedMock: vi.fn(),
+  getBrowserRootsMock: vi.fn(),
+  isWithinAllowedRootMock: vi.fn(),
+  isAllowedRootMock: vi.fn(),
+  getCurrentProjectMock: vi.fn(),
+  ensureActiveInlineMenuMock: vi.fn(),
+  interactionStartMock: vi.fn(),
+  sendDownloadedFileMock: vi.fn(),
+  loggerDebugMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  promises: {
+    readdir: mocked.readdirMock,
+  },
+}));
+
+vi.mock("../../../src/bot/utils/busy-guard.js", () => ({
+  isForegroundBusy: mocked.isForegroundBusyMock,
+  replyBusyBlocked: mocked.replyBusyBlockedMock,
+}));
+
+vi.mock("../../../src/bot/utils/browser-roots.js", () => ({
+  getBrowserRoots: mocked.getBrowserRootsMock,
+  isWithinAllowedRoot: mocked.isWithinAllowedRootMock,
+  isAllowedRoot: mocked.isAllowedRootMock,
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  getCurrentProject: mocked.getCurrentProjectMock,
+}));
+
+vi.mock("../../../src/bot/handlers/inline-menu.js", () => ({
+  appendInlineMenuCancelButton: vi.fn((kb: unknown) => kb),
+  ensureActiveInlineMenu: mocked.ensureActiveInlineMenuMock,
+}));
+
+vi.mock("../../../src/interaction/manager.js", () => ({
+  interactionManager: {
+    start: mocked.interactionStartMock,
+    getSnapshot: vi.fn(() => null),
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock("../../../src/bot/utils/send-downloaded-file.js", () => ({
+  sendDownloadedFile: mocked.sendDownloadedFileMock,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    debug: mocked.loggerDebugMock,
+    error: mocked.loggerErrorMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { clearLsPathIndex, clearSessionDirectories, handleLsCallback, lsCommand } from "../../../src/bot/commands/ls.js";
+
+function createCommandContext(): Context {
+  return {
+    chat: { id: 123 },
+    from: { id: 42 },
+    match: "",
+    reply: vi.fn().mockResolvedValue({ message_id: 77 }),
+  } as unknown as Context;
+}
+
+function createCallbackContext(data: string, messageId: number = 77): Context {
+  return {
+    chat: { id: 123 },
+    from: { id: 42 },
+    callbackQuery: {
+      data,
+      message: { message_id: messageId },
+    } as Context["callbackQuery"],
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    api: {},
+  } as unknown as Context;
+}
+
+describe("bot/commands/ls", () => {
+  beforeEach(() => {
+    clearSessionDirectories();
+    clearLsPathIndex();
+    mocked.readdirMock.mockReset().mockResolvedValue([
+      { name: "docs", isDirectory: () => true },
+      { name: "README.md", isDirectory: () => false },
+    ]);
+    mocked.isForegroundBusyMock.mockReset().mockReturnValue(false);
+    mocked.replyBusyBlockedMock.mockReset().mockResolvedValue(undefined);
+    mocked.getBrowserRootsMock.mockReset().mockReturnValue(["/home/user"]);
+    mocked.isWithinAllowedRootMock.mockReset().mockReturnValue(true);
+    mocked.isAllowedRootMock.mockReset().mockReturnValue(false);
+    mocked.getCurrentProjectMock.mockReset().mockReturnValue({
+      id: "project-1",
+      worktree: "/repo/project",
+      name: "project",
+    });
+    mocked.ensureActiveInlineMenuMock.mockReset().mockResolvedValue(true);
+    mocked.interactionStartMock.mockReset();
+    mocked.sendDownloadedFileMock.mockReset().mockResolvedValue(true);
+    mocked.loggerDebugMock.mockReset();
+    mocked.loggerErrorMock.mockReset();
+  });
+
+  it("opens an inline browser for the current project", async () => {
+    const ctx = createCommandContext();
+
+    await lsCommand(ctx as never);
+
+    expect(mocked.readdirMock).toHaveBeenCalledWith("/repo/project", { withFileTypes: true });
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining("<code>/repo/project</code>"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+    expect(mocked.interactionStartMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "inline",
+        expectedInput: "callback",
+        metadata: expect.objectContaining({ menuKind: "ls", messageId: 77 }),
+      }),
+    );
+  });
+
+  it("lists directories before files", async () => {
+    mocked.readdirMock.mockResolvedValue([
+      { name: "z-last-dir", isDirectory: () => true },
+      { name: "a-file.txt", isDirectory: () => false },
+      { name: "b-dir", isDirectory: () => true },
+      { name: "c-file.txt", isDirectory: () => false },
+    ]);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    const keyboard = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const labels = keyboard.inline_keyboard.slice(0, 4).map((row: Array<{ text: string }>) => row[0]?.text);
+
+    expect(labels).toEqual(["📁 b-dir", "📁 z-last-dir", "📄 a-file.txt", "📄 c-file.txt"]);
+  });
+
+  it("navigates into a directory when tapping its button", async () => {
+    const commandCtx = createCommandContext();
+    await lsCommand(commandCtx as never);
+
+    const keyboard = (commandCtx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const callbackData = keyboard.inline_keyboard[0][0].callback_data as string;
+
+    mocked.readdirMock.mockResolvedValue([{ name: "nested.txt", isDirectory: () => false }]);
+
+    const callbackCtx = createCallbackContext(callbackData);
+    const handled = await handleLsCallback(callbackCtx);
+
+    expect(handled).toBe(true);
+    expect(mocked.readdirMock).toHaveBeenLastCalledWith("/repo/project/docs", { withFileTypes: true });
+    expect(callbackCtx.editMessageText).toHaveBeenCalled();
+  });
+
+  it("downloads a file when tapping its button", async () => {
+    const commandCtx = createCommandContext();
+    await lsCommand(commandCtx as never);
+
+    const keyboard = (commandCtx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const callbackData = keyboard.inline_keyboard[1][0].callback_data as string;
+
+    const callbackCtx = createCallbackContext(callbackData);
+    const handled = await handleLsCallback(callbackCtx);
+
+    expect(handled).toBe(true);
+    expect(callbackCtx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("commands.download.downloading") });
+    expect(mocked.sendDownloadedFileMock).toHaveBeenCalledWith(callbackCtx, "/repo/project/README.md", {
+      announce: false,
+    });
+  });
+
+  it("shows a back button for navigating to parent directory", async () => {
+    mocked.isAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/home/user");
+    mocked.readdirMock.mockResolvedValue([{ name: "nested.txt", isDirectory: () => false }]);
+
+    const ctx = {
+      chat: { id: 123 },
+      from: { id: 42 },
+      match: "/repo/project/docs",
+      reply: vi.fn().mockResolvedValue({ message_id: 77 }),
+    } as unknown as Context;
+
+    await lsCommand(ctx as never);
+
+    const keyboard = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const flatButtons = keyboard.inline_keyboard.flat();
+    expect(
+      flatButtons.some(
+        (button: { callback_data?: string }) => button.callback_data === "ls:nav:/repo/project",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not show a back button at the project root", async () => {
+    mocked.readdirMock.mockResolvedValue([{ name: "README.md", isDirectory: () => false }]);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    const keyboard = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const flatButtons = keyboard.inline_keyboard.flat();
+
+    expect(flatButtons.some((button: { text?: string }) => button.text === t("open.back"))).toBe(false);
+  });
+
+  it("prefers the active project over a cached home directory", async () => {
+    mocked.getCurrentProjectMock.mockReturnValueOnce(undefined);
+
+    const firstCtx = createCommandContext();
+    await lsCommand(firstCtx as never);
+
+    mocked.getCurrentProjectMock.mockReturnValue({
+      id: "project-1",
+      worktree: "/repo/project",
+      name: "project",
+    });
+
+    const secondCtx = createCommandContext();
+    await lsCommand(secondCtx as never);
+
+    expect(mocked.readdirMock).toHaveBeenLastCalledWith("/repo/project", { withFileTypes: true });
+    expect(secondCtx.reply).toHaveBeenCalledWith(
+      expect.stringContaining("<code>/repo/project</code>"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+  });
+});

--- a/tests/bot/commands/ls.test.ts
+++ b/tests/bot/commands/ls.test.ts
@@ -134,6 +134,55 @@ describe("bot/commands/ls", () => {
     );
   });
 
+  it("blocks the command when foreground is busy", async () => {
+    mocked.isForegroundBusyMock.mockReturnValue(true);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    expect(mocked.replyBusyBlockedMock).toHaveBeenCalledWith(ctx);
+    expect(mocked.readdirMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an explicit path argument when provided", async () => {
+    const ctx = {
+      chat: { id: 123 },
+      from: { id: 42 },
+      match: "/repo/project/docs",
+      reply: vi.fn().mockResolvedValue({ message_id: 77 }),
+    } as unknown as Context;
+
+    await lsCommand(ctx as never);
+
+    expect(mocked.readdirMock).toHaveBeenCalledWith("/repo/project/docs", { withFileTypes: true });
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining("<code>/repo/project/docs</code>"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+  });
+
+  it("falls back to the first browser root when no project is selected", async () => {
+    mocked.getCurrentProjectMock.mockReturnValue(undefined);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    expect(mocked.readdirMock).toHaveBeenCalledWith("/home/user", { withFileTypes: true });
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining("<code>~</code>"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+  });
+
+  it("shows an error when the target directory cannot be listed", async () => {
+    mocked.readdirMock.mockRejectedValue(new Error("Permission denied"));
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(`❌ ${t("ls.scan_error")}: Permission denied`);
+  });
+
   it("lists directories before files", async () => {
     mocked.readdirMock.mockResolvedValue([
       { name: "z-last-dir", isDirectory: () => true },
@@ -183,6 +232,105 @@ describe("bot/commands/ls", () => {
     expect(mocked.sendDownloadedFileMock).toHaveBeenCalledWith(callbackCtx, "/repo/project/README.md", {
       announce: false,
     });
+  });
+
+  it("shows a next page button when directory contents exceed one page", async () => {
+    mocked.readdirMock.mockResolvedValue(
+      Array.from({ length: 9 }, (_, index) => ({
+        name: `dir-${index + 1}`,
+        isDirectory: () => true,
+      })),
+    );
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    const keyboard = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const flatButtons = keyboard.inline_keyboard.flat();
+
+    expect(flatButtons.some((button: { text?: string }) => button.text === t("open.next_page"))).toBe(true);
+  });
+
+  it("loads the next page when tapping the next button", async () => {
+    mocked.readdirMock.mockResolvedValue(
+      Array.from({ length: 9 }, (_, index) => ({
+        name: `dir-${index + 1}`,
+        isDirectory: () => true,
+      })),
+    );
+
+    const commandCtx = createCommandContext();
+    await lsCommand(commandCtx as never);
+
+    const keyboard = (commandCtx.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.reply_markup;
+    const flatButtons = keyboard.inline_keyboard.flat();
+    const nextButton = flatButtons.find((button: { text?: string }) => button.text === t("open.next_page"));
+
+    expect(nextButton?.callback_data).toBeDefined();
+
+    const callbackCtx = createCallbackContext(nextButton?.callback_data as string);
+    const handled = await handleLsCallback(callbackCtx);
+
+    expect(handled).toBe(true);
+    expect(callbackCtx.editMessageText).toHaveBeenCalledWith(
+      expect.stringContaining("(2/2)"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+  });
+
+  it("blocks callbacks when foreground is busy", async () => {
+    mocked.isForegroundBusyMock.mockReturnValue(true);
+
+    const ctx = createCallbackContext("ls:nav:/repo/project/docs");
+    const handled = await handleLsCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(mocked.replyBusyBlockedMock).toHaveBeenCalledWith(ctx);
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale callbacks when the inline menu is inactive", async () => {
+    mocked.ensureActiveInlineMenuMock.mockResolvedValue(false);
+
+    const ctx = createCallbackContext("ls:nav:/repo/project/docs");
+    const handled = await handleLsCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+    expect(mocked.sendDownloadedFileMock).not.toHaveBeenCalled();
+  });
+
+  it("denies navigation outside allowed roots", async () => {
+    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
+
+    const ctx = createCallbackContext("ls:nav:/etc");
+    const handled = await handleLsCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("ls.access_denied") });
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("denies pagination outside allowed roots", async () => {
+    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
+
+    const ctx = createCallbackContext("ls:pg:/etc|1");
+    const handled = await handleLsCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("ls.access_denied") });
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("denies file downloads outside allowed roots", async () => {
+    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
+
+    const ctx = createCallbackContext("ls:file:/etc/passwd");
+    const handled = await handleLsCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("ls.access_denied") });
+    expect(mocked.sendDownloadedFileMock).not.toHaveBeenCalled();
   });
 
   it("shows a back button for navigating to parent directory", async () => {

--- a/tests/bot/commands/ls.test.ts
+++ b/tests/bot/commands/ls.test.ts
@@ -4,14 +4,14 @@ import { t } from "../../../src/i18n/index.js";
 
 const mocked = vi.hoisted(() => ({
   readdirMock: vi.fn(),
+  statMock: vi.fn(),
   isForegroundBusyMock: vi.fn(),
   replyBusyBlockedMock: vi.fn(),
-  getBrowserRootsMock: vi.fn(),
-  isWithinAllowedRootMock: vi.fn(),
-  isAllowedRootMock: vi.fn(),
   getCurrentProjectMock: vi.fn(),
   ensureActiveInlineMenuMock: vi.fn(),
+  clearActiveInlineMenuMock: vi.fn(),
   interactionStartMock: vi.fn(),
+  interactionClearMock: vi.fn(),
   sendDownloadedFileMock: vi.fn(),
   loggerDebugMock: vi.fn(),
   loggerErrorMock: vi.fn(),
@@ -20,18 +20,13 @@ const mocked = vi.hoisted(() => ({
 vi.mock("node:fs", () => ({
   promises: {
     readdir: mocked.readdirMock,
+    stat: mocked.statMock,
   },
 }));
 
 vi.mock("../../../src/bot/utils/busy-guard.js", () => ({
   isForegroundBusy: mocked.isForegroundBusyMock,
   replyBusyBlocked: mocked.replyBusyBlockedMock,
-}));
-
-vi.mock("../../../src/bot/utils/browser-roots.js", () => ({
-  getBrowserRoots: mocked.getBrowserRootsMock,
-  isWithinAllowedRoot: mocked.isWithinAllowedRootMock,
-  isAllowedRoot: mocked.isAllowedRootMock,
 }));
 
 vi.mock("../../../src/settings/manager.js", () => ({
@@ -41,13 +36,14 @@ vi.mock("../../../src/settings/manager.js", () => ({
 vi.mock("../../../src/bot/handlers/inline-menu.js", () => ({
   appendInlineMenuCancelButton: vi.fn((kb: unknown) => kb),
   ensureActiveInlineMenu: mocked.ensureActiveInlineMenuMock,
+  clearActiveInlineMenu: mocked.clearActiveInlineMenuMock,
 }));
 
 vi.mock("../../../src/interaction/manager.js", () => ({
   interactionManager: {
     start: mocked.interactionStartMock,
     getSnapshot: vi.fn(() => null),
-    clear: vi.fn(),
+    clear: mocked.interactionClearMock,
   },
 }));
 
@@ -85,6 +81,7 @@ function createCallbackContext(data: string, messageId: number = 77): Context {
     } as Context["callbackQuery"],
     answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
     editMessageText: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
     reply: vi.fn().mockResolvedValue(undefined),
     api: {},
   } as unknown as Context;
@@ -98,18 +95,22 @@ describe("bot/commands/ls", () => {
       { name: "docs", isDirectory: () => true },
       { name: "README.md", isDirectory: () => false },
     ]);
+    mocked.statMock.mockReset().mockResolvedValue({
+      isFile: () => true,
+      size: 1234,
+      mtime: new Date("2024-01-02T00:00:00.000Z"),
+    });
     mocked.isForegroundBusyMock.mockReset().mockReturnValue(false);
     mocked.replyBusyBlockedMock.mockReset().mockResolvedValue(undefined);
-    mocked.getBrowserRootsMock.mockReset().mockReturnValue(["/home/user"]);
-    mocked.isWithinAllowedRootMock.mockReset().mockReturnValue(true);
-    mocked.isAllowedRootMock.mockReset().mockReturnValue(false);
     mocked.getCurrentProjectMock.mockReset().mockReturnValue({
       id: "project-1",
       worktree: "/repo/project",
       name: "project",
     });
     mocked.ensureActiveInlineMenuMock.mockReset().mockResolvedValue(true);
+    mocked.clearActiveInlineMenuMock.mockReset();
     mocked.interactionStartMock.mockReset();
+    mocked.interactionClearMock.mockReset();
     mocked.sendDownloadedFileMock.mockReset().mockResolvedValue(true);
     mocked.loggerDebugMock.mockReset();
     mocked.loggerErrorMock.mockReset();
@@ -132,6 +133,28 @@ describe("bot/commands/ls", () => {
         metadata: expect.objectContaining({ menuKind: "ls", messageId: 77 }),
       }),
     );
+  });
+
+  it("does not start an inline interaction for an empty project root", async () => {
+    mocked.readdirMock.mockResolvedValue([]);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining(t("ls.total", { count: 0 })), {
+      parse_mode: "HTML",
+    });
+    expect(mocked.interactionStartMock).not.toHaveBeenCalled();
+  });
+
+  it("requires an active project", async () => {
+    mocked.getCurrentProjectMock.mockReturnValue(undefined);
+
+    const ctx = createCommandContext();
+    await lsCommand(ctx as never);
+
+    expect(mocked.readdirMock).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith(t("bot.project_not_selected"));
   });
 
   it("blocks the command when foreground is busy", async () => {
@@ -161,17 +184,18 @@ describe("bot/commands/ls", () => {
     );
   });
 
-  it("falls back to the first browser root when no project is selected", async () => {
-    mocked.getCurrentProjectMock.mockReturnValue(undefined);
+  it("rejects an explicit path outside the current project", async () => {
+    const ctx = {
+      chat: { id: 123 },
+      from: { id: 42 },
+      match: "/etc",
+      reply: vi.fn().mockResolvedValue({ message_id: 77 }),
+    } as unknown as Context;
 
-    const ctx = createCommandContext();
     await lsCommand(ctx as never);
 
-    expect(mocked.readdirMock).toHaveBeenCalledWith("/home/user", { withFileTypes: true });
-    expect(ctx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("<code>~</code>"),
-      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
-    );
+    expect(mocked.readdirMock).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith(`❌ ${t("ls.access_denied")}`);
   });
 
   it("shows an error when the target directory cannot be listed", async () => {
@@ -217,7 +241,7 @@ describe("bot/commands/ls", () => {
     expect(callbackCtx.editMessageText).toHaveBeenCalled();
   });
 
-  it("downloads a file when tapping its button", async () => {
+  it("shows file details when tapping a file", async () => {
     const commandCtx = createCommandContext();
     await lsCommand(commandCtx as never);
 
@@ -228,10 +252,39 @@ describe("bot/commands/ls", () => {
     const handled = await handleLsCallback(callbackCtx);
 
     expect(handled).toBe(true);
+    expect(callbackCtx.editMessageText).toHaveBeenCalledWith(
+      expect.stringContaining(t("ls.file.header")),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+    expect(callbackCtx.editMessageText).toHaveBeenCalledWith(
+      expect.stringContaining("README.md"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
+    expect(mocked.sendDownloadedFileMock).not.toHaveBeenCalled();
+  });
+
+  it("downloads from file details view and ends the interaction", async () => {
+    const callbackCtx = createCallbackContext("ls:download:/repo/project/README.md");
+    const handled = await handleLsCallback(callbackCtx);
+
+    expect(handled).toBe(true);
     expect(callbackCtx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("commands.download.downloading") });
     expect(mocked.sendDownloadedFileMock).toHaveBeenCalledWith(callbackCtx, "/repo/project/README.md", {
       announce: false,
     });
+    expect(mocked.clearActiveInlineMenuMock).toHaveBeenCalledWith("ls_downloaded");
+    expect(callbackCtx.deleteMessage).toHaveBeenCalled();
+  });
+
+  it("returns to the file list from file details back button", async () => {
+    const callbackCtx = createCallbackContext("ls:back:/repo/project|0");
+    const handled = await handleLsCallback(callbackCtx);
+
+    expect(handled).toBe(true);
+    expect(callbackCtx.editMessageText).toHaveBeenCalledWith(
+      expect.stringContaining("<code>/repo/project</code>"),
+      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
+    );
   });
 
   it("shows a next page button when directory contents exceed one page", async () => {
@@ -300,9 +353,7 @@ describe("bot/commands/ls", () => {
     expect(mocked.sendDownloadedFileMock).not.toHaveBeenCalled();
   });
 
-  it("denies navigation outside allowed roots", async () => {
-    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
-
+  it("denies navigation outside the current project", async () => {
     const ctx = createCallbackContext("ls:nav:/etc");
     const handled = await handleLsCallback(ctx);
 
@@ -311,9 +362,7 @@ describe("bot/commands/ls", () => {
     expect(ctx.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("denies pagination outside allowed roots", async () => {
-    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
-
+  it("denies pagination outside the current project", async () => {
     const ctx = createCallbackContext("ls:pg:/etc|1");
     const handled = await handleLsCallback(ctx);
 
@@ -322,10 +371,17 @@ describe("bot/commands/ls", () => {
     expect(ctx.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("denies file downloads outside allowed roots", async () => {
-    mocked.isWithinAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/repo/project");
+  it("denies file details outside the current project", async () => {
+    const ctx = createCallbackContext("ls:file:/etc/passwd|0");
+    const handled = await handleLsCallback(ctx);
 
-    const ctx = createCallbackContext("ls:file:/etc/passwd");
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("ls.access_denied") });
+    expect(mocked.sendDownloadedFileMock).not.toHaveBeenCalled();
+  });
+
+  it("denies download outside the current project", async () => {
+    const ctx = createCallbackContext("ls:download:/etc/passwd");
     const handled = await handleLsCallback(ctx);
 
     expect(handled).toBe(true);
@@ -334,7 +390,6 @@ describe("bot/commands/ls", () => {
   });
 
   it("shows a back button for navigating to parent directory", async () => {
-    mocked.isAllowedRootMock.mockImplementation((targetPath: string) => targetPath === "/home/user");
     mocked.readdirMock.mockResolvedValue([{ name: "nested.txt", isDirectory: () => false }]);
 
     const ctx = {
@@ -367,7 +422,23 @@ describe("bot/commands/ls", () => {
     expect(flatButtons.some((button: { text?: string }) => button.text === t("open.back"))).toBe(false);
   });
 
-  it("prefers the active project over a cached home directory", async () => {
+  it("reuses a cached directory only when it is inside the current project", async () => {
+    const firstCtx = {
+      chat: { id: 123 },
+      from: { id: 42 },
+      match: "/repo/project/docs",
+      reply: vi.fn().mockResolvedValue({ message_id: 77 }),
+    } as unknown as Context;
+
+    await lsCommand(firstCtx as never);
+
+    const secondCtx = createCommandContext();
+    await lsCommand(secondCtx as never);
+
+    expect(mocked.readdirMock).toHaveBeenLastCalledWith("/repo/project/docs", { withFileTypes: true });
+  });
+
+  it("falls back to the project root when cached directory is outside the current project", async () => {
     mocked.getCurrentProjectMock.mockReturnValueOnce(undefined);
 
     const firstCtx = createCommandContext();
@@ -383,9 +454,5 @@ describe("bot/commands/ls", () => {
     await lsCommand(secondCtx as never);
 
     expect(mocked.readdirMock).toHaveBeenLastCalledWith("/repo/project", { withFileTypes: true });
-    expect(secondCtx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("<code>/repo/project</code>"),
-      expect.objectContaining({ parse_mode: "HTML", reply_markup: expect.anything() }),
-    );
   });
 });


### PR DESCRIPTION
This pull request adds a new `/ls` command to the bot, allowing users to interactively browse and download files from allowed directories. The implementation includes a paginated, inline menu for navigating directories, robust access control, and internationalized messages. Supporting utilities and i18n keys are also introduced or updated.

**New `/ls` command and interactive directory browser:**

- Implements the `/ls` command with a full-featured, paginated inline menu for browsing allowed directories and downloading files. It includes access checks, session state, and safe handling of long paths and large directories. (`src/bot/commands/ls.ts`)
- Registers the new command in the bot, command definitions, and inline menu handlers, ensuring it is available and properly integrated into the callback handling flow. (`src/bot/index.ts`, `src/bot/commands/definitions.ts`, `src/bot/handlers/inline-menu.ts`) [[1]](diffhunk://#diff-11a6466c79d20c725ed0d95df9bc87c5c78dfd3ed6d59684173f4d877a74b952R25) [[2]](diffhunk://#diff-11a6466c79d20c725ed0d95df9bc87c5c78dfd3ed6d59684173f4d877a74b952R1080) [[3]](diffhunk://#diff-11a6466c79d20c725ed0d95df9bc87c5c78dfd3ed6d59684173f4d877a74b952R1107-R1113) [[4]](diffhunk://#diff-11a6466c79d20c725ed0d95df9bc87c5c78dfd3ed6d59684173f4d877a74b952L1124-R1128) [[5]](diffhunk://#diff-11a6466c79d20c725ed0d95df9bc87c5c78dfd3ed6d59684173f4d877a74b952R1137) [[6]](diffhunk://#diff-e48ecdf84e07e84da9ca0f582df61c214fafeb2b80421a40e0913f990be54b98R40) [[7]](diffhunk://#diff-6dbbe49f7334f359d5b353f8101492c67254fa958622434fc8bed6afc9745c4eR18)

**File download support:**

- Adds a utility to securely send files to users, enforcing file size limits, access checks, and proper error handling. (`src/bot/utils/send-downloaded-file.ts`)

**Internationalization:**

- Adds and updates i18n keys for the new command, directory browsing, and file download features in English, German, and Spanish. (`src/i18n/en.ts`, `src/i18n/de.ts`, `src/i18n/es.ts`) [[1]](diffhunk://#diff-94b6e2a310026e68049f5163c5dc063f6a4965f8da5d9f1d9aade76e06097362R16) [[2]](diffhunk://#diff-94b6e2a310026e68049f5163c5dc063f6a4965f8da5d9f1d9aade76e06097362R455-R462) [[3]](diffhunk://#diff-94b6e2a310026e68049f5163c5dc063f6a4965f8da5d9f1d9aade76e06097362R548-R551) [[4]](diffhunk://#diff-7f4537822f2fbc2aa4d2b221d20356acff349acfb5c257506f8014c360dc6131R18) [[5]](diffhunk://#diff-7f4537822f2fbc2aa4d2b221d20356acff349acfb5c257506f8014c360dc6131R473-R480) [[6]](diffhunk://#diff-7f4537822f2fbc2aa4d2b221d20356acff349acfb5c257506f8014c360dc6131R570-R573) [[7]](diffhunk://#diff-8f1b9fcd04f8c3b250d284ddccf3906bdf401867a696ebecd20c5080a5831085R18)