### PR TITLE
fix(busy-state): release attachManager on /abort + periodic reconciliation

### DIFF
--- a/src/bot/commands/abort.ts
+++ b/src/bot/commands/abort.ts
@@ -6,6 +6,8 @@ import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import { foregroundSessionState } from "../../scheduled-task/foreground-state.js";
 import { assistantRunState } from "../assistant-run-state.js";
+import { markAttachedSessionIdle } from "../../attach/service.js";
+import { clearPromptResponseMode } from "../handlers/prompt.js";
 
 type SessionState = "idle" | "busy" | "not-found";
 
@@ -106,6 +108,11 @@ export async function abortCurrentOperation(
 
       if (abortError) {
         logger.warn("[Abort] Abort request failed:", abortError);
+        // Safety net: clear attach-manager busy + prompt-response mode even when the
+        // server did not confirm the abort, otherwise the bot can wedge in "busy"
+        // forever due to two parallel busy trackers (attachManager + foregroundState).
+        await markAttachedSessionIdle(currentSession.id);
+        clearPromptResponseMode(currentSession.id);
         if (notifyUser && chatId !== null && waitingMessageId !== null) {
           await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_unconfirmed"));
         }
@@ -128,6 +135,8 @@ export async function abortCurrentOperation(
       if (finalStatus === "idle" || finalStatus === "not-found") {
         foregroundSessionState.markIdle(currentSession.id);
         assistantRunState.clearRun(currentSession.id, "abort_confirmed");
+        await markAttachedSessionIdle(currentSession.id);
+        clearPromptResponseMode(currentSession.id);
         if (notifyUser && chatId !== null && waitingMessageId !== null) {
           await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.success"));
         }
@@ -138,6 +147,11 @@ export async function abortCurrentOperation(
       }
     } catch (error) {
       clearTimeout(timeoutId);
+
+      // Safety net for AbortError / generic errors: release attach-manager busy
+      // so a transient network failure does not permanently wedge the bot.
+      await markAttachedSessionIdle(currentSession.id);
+      clearPromptResponseMode(currentSession.id);
 
       if (error instanceof Error && error.name === "AbortError") {
         if (notifyUser && chatId !== null && waitingMessageId !== null) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -121,6 +121,7 @@ let botInstance: Bot<Context> | null = null;
 let chatIdInstance: number | null = null;
 let commandsInitialized = false;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let busyReconciliationTimer: ReturnType<typeof setInterval> | null = null;
 let unsubscribeReadyRestore: (() => void) | null = null;
 
 const TELEGRAM_DOCUMENT_CAPTION_MAX_LENGTH = 1024;
@@ -1055,6 +1056,11 @@ export function createBot(): Bot<Context> {
     heartbeatTimer = null;
   }
 
+  if (busyReconciliationTimer) {
+    clearInterval(busyReconciliationTimer);
+    busyReconciliationTimer = null;
+  }
+
   const botOptions = createTelegramBotOptions(config.telegram);
 
   const bot = new Bot(config.telegram.token, botOptions);
@@ -1093,6 +1099,20 @@ export function createBot(): Bot<Context> {
       logger.debug(`[Bot] Heartbeat #${heartbeatCounter} - event loop alive`);
     }
   }, 5000);
+
+  // Periodic busy-state reconciliation, independent of the SSE stream.
+  // reconcileBusyState() is normally triggered by server.heartbeat SSE events,
+  // but if the stream silently dies the bot can wedge in "busy" forever.
+  // The function has its own RECONCILE_MIN_INTERVAL_MS=10s throttle, so this
+  // 15s timer naturally respects it.
+  busyReconciliationTimer = setInterval(() => {
+    const currentProject = getCurrentProject();
+    const directory = currentProject?.worktree;
+    if (!directory) {
+      return;
+    }
+    void reconcileBusyState(directory);
+  }, 15_000);
 
   // Log all API calls for diagnostics
   let lastGetUpdatesTime = Date.now();
@@ -1507,6 +1527,11 @@ export function cleanupBotRuntime(reason: string): void {
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;
+  }
+
+  if (busyReconciliationTimer) {
+    clearInterval(busyReconciliationTimer);
+    busyReconciliationTimer = null;
   }
 
   botInstance = null;


### PR DESCRIPTION
## Problem

Two independent busy trackers — `attachManager` and `foregroundSessionState` — were being released asymmetrically. `session.idle` and `/detach` both call `markAttachedSessionIdle` + `clearPromptResponseMode`, but `/abort` cleared only `foregroundSessionState`. Since `busy-guard` ORs both trackers, the bot would then wedge on the next prompt with «agent is busy» until a process restart.

## Pattern table

| Call | `session.idle` | `/detach` | `/abort` (before) |
|---|---|---|---|
| `markAttachedSessionIdle()` | ✅ | ✅ | ❌ |
| `clearPromptResponseMode()` | ✅ | ✅ | ❌ |
| `foregroundSessionState.markIdle()` | ✅ | ✅ | ✅ |
| `assistantRunState.clearRun()` | ✅ | ✅ | ✅ |

## Changes

**`src/bot/commands/abort.ts`** — call `markAttachedSessionIdle` + `clearPromptResponseMode`:
- in the success path (after the server confirms idle), matching the pattern from `session.idle` and `/detach`;
- as a safety net in the error / `abortError` / `AbortError` (timeout) paths — even when the server does not confirm the abort, a transient network failure should not permanently wedge the bot.

**`src/bot/index.ts`** — add a 15-second `busyReconciliationTimer`. `reconcileBusyState()` already exists and is correct (it polls `session.status()` and resets stale busy), but it was only invoked from the `server.heartbeat` SSE event. If the SSE stream silently dies, reconciliation dies with it. The timer runs independently of SSE and naturally respects the function's own `RECONCILE_MIN_INTERVAL_MS=10s` throttle.

## Test plan

- [ ] `npm run build` clean (verified locally)
- [ ] Start bot → send prompt → `/abort` → send next prompt → should accept (not «agent busy»)
- [ ] Start bot → send prompt mid-stream → kill `opencode serve` → restart it → bot should recover via the new timer without manual intervention