### PR TITLE
fix(abort): prevent stale busy state after interruption

### DIFF
--- a/src/bot/commands/abort.ts
+++ b/src/bot/commands/abort.ts
@@ -6,6 +6,9 @@ import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import { foregroundSessionState } from "../../scheduled-task/foreground-state.js";
 import { assistantRunState } from "../assistant-run-state.js";
+import { markAttachedSessionIdle } from "../../attach/service.js";
+import { clearPromptResponseMode } from "../handlers/prompt.js";
+import { markUserAbortRequested } from "../utils/abort-error-suppression.js";
 
 type SessionState = "idle" | "busy" | "not-found";
 
@@ -17,6 +20,13 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 
 function abortLocalStreaming(): void {
   clearAllInteractionState("abort_command");
+}
+
+async function releaseAbortBusyState(sessionId: string, reason: string): Promise<void> {
+  foregroundSessionState.markIdle(sessionId);
+  assistantRunState.clearRun(sessionId, reason);
+  await markAttachedSessionIdle(sessionId);
+  clearPromptResponseMode(sessionId);
 }
 
 async function pollSessionStatus(
@@ -92,6 +102,7 @@ export async function abortCurrentOperation(
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
+    markUserAbortRequested(currentSession.id);
 
     try {
       const { data: abortResult, error: abortError } = await opencodeClient.session.abort(
@@ -106,6 +117,7 @@ export async function abortCurrentOperation(
 
       if (abortError) {
         logger.warn("[Abort] Abort request failed:", abortError);
+        await releaseAbortBusyState(currentSession.id, "abort_unconfirmed");
         if (notifyUser && chatId !== null && waitingMessageId !== null) {
           await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_unconfirmed"));
         }
@@ -113,6 +125,7 @@ export async function abortCurrentOperation(
       }
 
       if (abortResult !== true) {
+        await releaseAbortBusyState(currentSession.id, "abort_maybe_finished");
         if (notifyUser && chatId !== null && waitingMessageId !== null) {
           await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.warn_maybe_finished"));
         }
@@ -126,8 +139,7 @@ export async function abortCurrentOperation(
       );
 
       if (finalStatus === "idle" || finalStatus === "not-found") {
-        foregroundSessionState.markIdle(currentSession.id);
-        assistantRunState.clearRun(currentSession.id, "abort_confirmed");
+        await releaseAbortBusyState(currentSession.id, "abort_confirmed");
         if (notifyUser && chatId !== null && waitingMessageId !== null) {
           await ctx.api.editMessageText(chatId, waitingMessageId, t("stop.success"));
         }
@@ -138,6 +150,7 @@ export async function abortCurrentOperation(
       }
     } catch (error) {
       clearTimeout(timeoutId);
+      await releaseAbortBusyState(currentSession.id, "abort_error");
 
       if (error instanceof Error && error.name === "AbortError") {
         if (notifyUser && chatId !== null && waitingMessageId !== null) {

--- a/src/bot/commands/opencode-start.ts
+++ b/src/bot/commands/opencode-start.ts
@@ -7,6 +7,50 @@ import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import { editBotText } from "../utils/telegram-text.js";
 
+const SERVER_READY_TIMEOUT_MS = 10_000;
+const SERVER_READY_POLL_INTERVAL_MS = 500;
+const HEALTH_CHECK_TIMEOUT_MS = 3_000;
+const HEALTH_CHECK_TIMED_OUT = Symbol("health-check-timed-out");
+
+type HealthCheckResult = Awaited<ReturnType<typeof opencodeClient.global.health>>;
+
+async function healthWithTimeout(
+  timeoutMs: number = HEALTH_CHECK_TIMEOUT_MS,
+): Promise<HealthCheckResult | typeof HEALTH_CHECK_TIMED_OUT> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      opencodeClient.global.health({ signal: controller.signal }),
+      new Promise<typeof HEALTH_CHECK_TIMED_OUT>((resolve) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          resolve(HEALTH_CHECK_TIMED_OUT);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function getHealthIfAvailable(): Promise<HealthCheckResult | null> {
+  try {
+    const result = await healthWithTimeout();
+    if (result === HEALTH_CHECK_TIMED_OUT) {
+      logger.warn(`[Bot] OpenCode health check timed out after ${HEALTH_CHECK_TIMEOUT_MS}ms`);
+      return null;
+    }
+
+    return result;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Wait for OpenCode server to become ready by polling health endpoint
  * @param maxWaitMs Maximum time to wait in milliseconds
@@ -14,20 +58,14 @@ import { editBotText } from "../utils/telegram-text.js";
  */
 async function waitForServerReady(maxWaitMs: number = 10000): Promise<boolean> {
   const startTime = Date.now();
-  const pollInterval = 500;
 
   while (Date.now() - startTime < maxWaitMs) {
-    try {
-      const { data, error } = await opencodeClient.global.health();
-
-      if (!error && data?.healthy) {
-        return true;
-      }
-    } catch {
-      // Server not ready yet
+    const health = await getHealthIfAvailable();
+    if (health?.data?.healthy) {
+      return true;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    await new Promise((resolve) => setTimeout(resolve, SERVER_READY_POLL_INTERVAL_MS));
   }
 
   return false;
@@ -47,9 +85,10 @@ export async function opencodeStartCommand(ctx: CommandContext<Context>) {
 
     // Check if server is already accessible.
     try {
-      const { data, error } = await opencodeClient.global.health();
+      const health = await getHealthIfAvailable();
+      const data = health?.data;
 
-      if (!error && data?.healthy) {
+      if (data?.healthy) {
         await ctx.reply(
           t("opencode_start.already_running", { version: data.version || t("common.unknown") }),
         );
@@ -82,7 +121,7 @@ export async function opencodeStartCommand(ctx: CommandContext<Context>) {
     childProcess.unref();
 
     logger.info("[Bot] Waiting for OpenCode server to become ready...");
-    const ready = await waitForServerReady(10000);
+    const ready = await waitForServerReady(SERVER_READY_TIMEOUT_MS);
 
     if (!ready) {
       await editBotText({
@@ -96,7 +135,7 @@ export async function opencodeStartCommand(ctx: CommandContext<Context>) {
       return;
     }
 
-    const { data: health } = await opencodeClient.global.health();
+    const health = (await getHealthIfAvailable())?.data;
     await editBotText({
       api: ctx.api,
       chatId: ctx.chat.id,

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -83,6 +83,7 @@ import { reconcileBusyState } from "./utils/busy-reconciliation.js";
 import { finalizeAssistantResponse } from "./utils/finalize-assistant-response.js";
 import { sendTtsResponseForSession } from "./utils/send-tts-response.js";
 import { deliverThinkingMessage } from "./utils/thinking-message.js";
+import { shouldSuppressUserAbortSessionError } from "./utils/abort-error-suppression.js";
 import {
   editRenderedBotPart,
   getTelegramRenderedPartSignature,
@@ -940,6 +941,13 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     ]);
 
     const normalizedMessage = message.trim() || t("common.unknown_error");
+    if (shouldSuppressUserAbortSessionError(sessionId, normalizedMessage)) {
+      logger.debug(`[Bot] Suppressed user-initiated abort error: session=${sessionId}`);
+      foregroundSessionState.markIdle(sessionId);
+      await scheduledTaskRuntime.flushDeferredDeliveries();
+      return;
+    }
+
     const truncatedMessage =
       normalizedMessage.length > 3500
         ? `${normalizedMessage.slice(0, 3497)}...`

--- a/src/bot/middleware/interaction-guard.ts
+++ b/src/bot/middleware/interaction-guard.ts
@@ -1,6 +1,7 @@
 import type { Context, NextFunction } from "grammy";
 import { resolveInteractionGuardDecision } from "../../interaction/guard.js";
 import type { BlockReason, InteractionKind } from "../../interaction/types.js";
+import { reconcileForegroundBusyState } from "../utils/busy-guard.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 
@@ -84,7 +85,12 @@ function getInteractionBlockedMessage(
 }
 
 export async function interactionGuardMiddleware(ctx: Context, next: NextFunction): Promise<void> {
-  const decision = resolveInteractionGuardDecision(ctx);
+  let decision = resolveInteractionGuardDecision(ctx);
+
+  if (!decision.allow && decision.busy) {
+    await reconcileForegroundBusyState();
+    decision = resolveInteractionGuardDecision(ctx);
+  }
 
   if (decision.allow) {
     await next();

--- a/src/bot/utils/abort-error-suppression.ts
+++ b/src/bot/utils/abort-error-suppression.ts
@@ -1,0 +1,25 @@
+const USER_ABORT_SUPPRESSION_WINDOW_MS = 30_000;
+
+const userAbortRequestedAtBySession = new Map<string, number>();
+
+export function markUserAbortRequested(sessionId: string): void {
+  userAbortRequestedAtBySession.set(sessionId, Date.now());
+}
+
+export function shouldSuppressUserAbortSessionError(sessionId: string, message: string): boolean {
+  if (message.trim().toLowerCase() !== "aborted") {
+    return false;
+  }
+
+  const requestedAt = userAbortRequestedAtBySession.get(sessionId);
+  if (requestedAt === undefined) {
+    return false;
+  }
+
+  userAbortRequestedAtBySession.delete(sessionId);
+  return Date.now() - requestedAt <= USER_ABORT_SUPPRESSION_WINDOW_MS;
+}
+
+export function __resetUserAbortErrorSuppressionForTests(): void {
+  userAbortRequestedAtBySession.clear();
+}

--- a/src/bot/utils/abort-error-suppression.ts
+++ b/src/bot/utils/abort-error-suppression.ts
@@ -1,9 +1,20 @@
-const USER_ABORT_SUPPRESSION_WINDOW_MS = 30_000;
+// Covers abort request timeout, post-abort status polling, and delayed SSE reconnect delivery.
+const USER_ABORT_SUPPRESSION_WINDOW_MS = 90_000;
 
 const userAbortRequestedAtBySession = new Map<string, number>();
 
+function deleteExpiredAbortRequests(now: number = Date.now()): void {
+  for (const [sessionId, requestedAt] of userAbortRequestedAtBySession) {
+    if (now - requestedAt > USER_ABORT_SUPPRESSION_WINDOW_MS) {
+      userAbortRequestedAtBySession.delete(sessionId);
+    }
+  }
+}
+
 export function markUserAbortRequested(sessionId: string): void {
-  userAbortRequestedAtBySession.set(sessionId, Date.now());
+  const now = Date.now();
+  deleteExpiredAbortRequests(now);
+  userAbortRequestedAtBySession.set(sessionId, now);
 }
 
 export function shouldSuppressUserAbortSessionError(sessionId: string, message: string): boolean {
@@ -22,4 +33,8 @@ export function shouldSuppressUserAbortSessionError(sessionId: string, message: 
 
 export function __resetUserAbortErrorSuppressionForTests(): void {
   userAbortRequestedAtBySession.clear();
+}
+
+export function __getUserAbortErrorSuppressionSizeForTests(): number {
+  return userAbortRequestedAtBySession.size;
 }

--- a/src/bot/utils/busy-guard.ts
+++ b/src/bot/utils/busy-guard.ts
@@ -1,10 +1,36 @@
 import type { Context } from "grammy";
 import { foregroundSessionState } from "../../scheduled-task/foreground-state.js";
 import { attachManager } from "../../attach/manager.js";
+import { reconcileBusyState } from "./busy-reconciliation.js";
 import { t } from "../../i18n/index.js";
 
 export function isForegroundBusy(): boolean {
   return foregroundSessionState.isBusy() || attachManager.isBusy();
+}
+
+function getBusyDirectories(): string[] {
+  const directories = new Set<string>();
+
+  for (const session of foregroundSessionState.getBusySessions()) {
+    directories.add(session.directory);
+  }
+
+  const attached = attachManager.getSnapshot();
+  if (attached?.busy) {
+    directories.add(attached.directory);
+  }
+
+  return [...directories];
+}
+
+export async function reconcileForegroundBusyState(): Promise<void> {
+  if (!isForegroundBusy()) {
+    return;
+  }
+
+  for (const directory of getBusyDirectories()) {
+    await reconcileBusyState(directory);
+  }
 }
 
 export async function replyBusyBlocked(ctx: Context): Promise<void> {

--- a/src/bot/utils/busy-guard.ts
+++ b/src/bot/utils/busy-guard.ts
@@ -1,8 +1,9 @@
 import type { Context } from "grammy";
 import { foregroundSessionState } from "../../scheduled-task/foreground-state.js";
 import { attachManager } from "../../attach/manager.js";
-import { reconcileBusyState } from "./busy-reconciliation.js";
+import { reconcileBusyStateNow } from "./busy-reconciliation.js";
 import { t } from "../../i18n/index.js";
+import { logger } from "../../utils/logger.js";
 
 export function isForegroundBusy(): boolean {
   return foregroundSessionState.isBusy() || attachManager.isBusy();
@@ -29,7 +30,11 @@ export async function reconcileForegroundBusyState(): Promise<void> {
   }
 
   for (const directory of getBusyDirectories()) {
-    await reconcileBusyState(directory);
+    try {
+      await reconcileBusyStateNow(directory);
+    } catch (error) {
+      logger.warn("[BusyGuard] Failed to reconcile foreground busy state", error);
+    }
   }
 }
 

--- a/src/opencode/events.ts
+++ b/src/opencode/events.ts
@@ -21,7 +21,9 @@ type OptionalGlobalEventClient = {
 
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 15000;
+let sseIdleTimeoutMs = 30_000;
 const FATAL_NO_STREAM_ERROR = "No stream returned from event subscription";
+const SSE_IDLE_TIMEOUT_ERROR = "SSE stream idle timeout";
 
 let eventStream: AsyncGenerator<unknown, unknown, unknown> | null = null;
 let eventCallback: EventCallback | null = null;
@@ -29,6 +31,12 @@ let isListening = false;
 let activeDirectory: string | null = null;
 let streamAbortController: AbortController | null = null;
 let listenerGeneration = 0;
+
+type StreamReadResult =
+  | { type: "next"; result: IteratorResult<unknown, unknown> }
+  | { type: "error"; error: unknown }
+  | { type: "aborted" }
+  | { type: "timeout" };
 
 function getReconnectDelayMs(attempt: number): number {
   const exponentialDelay = RECONNECT_BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1));
@@ -55,6 +63,64 @@ function waitWithAbort(ms: number, signal: AbortSignal): Promise<boolean> {
 
     signal.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function createAttemptAbortController(parentSignal: AbortSignal): {
+  controller: AbortController;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+
+  if (parentSignal.aborted) {
+    controller.abort();
+    return { controller, cleanup: () => {} };
+  }
+
+  const onAbort = () => controller.abort();
+  parentSignal.addEventListener("abort", onAbort, { once: true });
+
+  return {
+    controller,
+    cleanup: () => parentSignal.removeEventListener("abort", onAbort),
+  };
+}
+
+function readStreamWithIdleTimeout(
+  stream: AsyncGenerator<unknown, unknown, unknown>,
+  signal: AbortSignal,
+): Promise<StreamReadResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: StreamReadResult) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+
+    const onAbort = () => finish({ type: "aborted" });
+    const timeout = setTimeout(() => finish({ type: "timeout" }), sseIdleTimeoutMs);
+
+    if (signal.aborted) {
+      finish({ type: "aborted" });
+      return;
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    stream.next().then(
+      (result) => finish({ type: "next", result }),
+      (error) => finish({ type: "error", error }),
+    );
+  });
+}
+
+function isEventStreamIdleTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message === SSE_IDLE_TIMEOUT_ERROR;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -165,14 +231,16 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
     let useLegacyEventsOnce = false;
 
     while (isListening && activeDirectory === directory && !controller.signal.aborted) {
+      let attemptAbort: ReturnType<typeof createAttemptAbortController> | null = null;
       try {
         let subscription: EventStreamSubscription;
+        attemptAbort = createAttemptAbortController(controller.signal);
         if (useLegacyEventsOnce) {
           useLegacyEventsOnce = false;
-          subscription = await subscribeToLegacyEventStream(directory, controller.signal);
+          subscription = await subscribeToLegacyEventStream(directory, attemptAbort.controller.signal);
         } else {
           try {
-            subscription = await subscribeToGlobalEventStream(controller.signal);
+            subscription = await subscribeToGlobalEventStream(attemptAbort.controller.signal);
             logger.debug(`Using global OpenCode event stream for ${directory}`);
           } catch (error) {
             if (controller.signal.aborted || !isListening || activeDirectory !== directory) {
@@ -187,7 +255,7 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
               `Global event stream unavailable for ${directory}, falling back to project event stream`,
               error,
             );
-            subscription = await subscribeToLegacyEventStream(directory, controller.signal);
+            subscription = await subscribeToLegacyEventStream(directory, attemptAbort.controller.signal);
           }
         }
 
@@ -195,43 +263,69 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
         eventStream = subscription.stream;
         let usefulEventCount = 0;
 
-        for await (const event of eventStream) {
-          if (!isListening || activeDirectory !== directory || controller.signal.aborted) {
-            logger.debug(`Event listener stopped or changed directory, breaking loop`);
-            break;
+        try {
+          while (isListening && activeDirectory === directory && !controller.signal.aborted) {
+            const readResult = await readStreamWithIdleTimeout(
+              eventStream,
+              attemptAbort.controller.signal,
+            );
+
+            if (readResult.type === "aborted") {
+              logger.debug(`Event listener stopped or changed directory, breaking loop`);
+              break;
+            }
+
+            if (readResult.type === "timeout") {
+              attemptAbort.controller.abort();
+              const closeStream = eventStream.return?.(undefined);
+              void closeStream?.catch(() => undefined);
+              throw new Error(SSE_IDLE_TIMEOUT_ERROR);
+            }
+
+            if (readResult.type === "error") {
+              throw readResult.error;
+            }
+
+            if (readResult.result.done) {
+              break;
+            }
+
+            const event = readResult.result.value;
+
+            // CRITICAL: Explicitly yield to the event loop BEFORE processing the event
+            // This allows grammY to handle getUpdates between SSE events
+            await new Promise<void>((resolve) => setImmediate(resolve));
+
+            const normalizedEvent = normalizeEvent(event, subscription.source, directory);
+            if (!normalizedEvent) {
+              continue;
+            }
+
+            if (normalizedEvent.type !== "server.connected") {
+              usefulEventCount++;
+            }
+
+            if (eventCallback) {
+              // Use setImmediate to avoid blocking the event loop
+              // and let grammY process incoming Telegram updates
+              const callbackSnapshot = eventCallback;
+              setImmediate(() => {
+                if (
+                  streamAbortController !== controller ||
+                  controller.signal.aborted ||
+                  !isListening ||
+                  activeDirectory !== directory ||
+                  listenerGeneration !== generation
+                ) {
+                  return;
+                }
+
+                callbackSnapshot(normalizedEvent);
+              });
+            }
           }
-
-          // CRITICAL: Explicitly yield to the event loop BEFORE processing the event
-          // This allows grammY to handle getUpdates between SSE events
-          await new Promise<void>((resolve) => setImmediate(resolve));
-
-          const normalizedEvent = normalizeEvent(event, subscription.source, directory);
-          if (!normalizedEvent) {
-            continue;
-          }
-
-          if (normalizedEvent.type !== "server.connected") {
-            usefulEventCount++;
-          }
-
-          if (eventCallback) {
-            // Use setImmediate to avoid blocking the event loop
-            // and let grammY process incoming Telegram updates
-            const callbackSnapshot = eventCallback;
-            setImmediate(() => {
-              if (
-                streamAbortController !== controller ||
-                controller.signal.aborted ||
-                !isListening ||
-                activeDirectory !== directory ||
-                listenerGeneration !== generation
-              ) {
-                return;
-              }
-
-              callbackSnapshot(normalizedEvent);
-            });
-          }
+        } finally {
+          attemptAbort.cleanup();
         }
 
         eventStream = null;
@@ -259,6 +353,7 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
           break;
         }
       } catch (error) {
+        attemptAbort?.cleanup();
         eventStream = null;
 
         if (controller.signal.aborted || !isListening || activeDirectory !== directory) {
@@ -273,7 +368,11 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
 
         reconnectAttempt++;
         const reconnectDelay = getReconnectDelayMs(reconnectAttempt);
-        if (isExpectedOpencodeUnavailableError(error)) {
+        if (isEventStreamIdleTimeoutError(error)) {
+          logger.warn(
+            `Event stream idle timeout for ${directory}, reconnecting in ${reconnectDelay}ms (attempt=${reconnectAttempt})`,
+          );
+        } else if (isExpectedOpencodeUnavailableError(error)) {
           logger.warn(
             `Event stream unavailable for ${directory}, reconnecting in ${reconnectDelay}ms (attempt=${reconnectAttempt})`,
           );
@@ -329,4 +428,8 @@ export function stopEventListening(): void {
   eventStream = null;
   activeDirectory = null;
   logger.info("Event listener stopped");
+}
+
+export function __setSseIdleTimeoutForTests(timeoutMs: number): void {
+  sseIdleTimeoutMs = timeoutMs;
 }

--- a/src/opencode/events.ts
+++ b/src/opencode/events.ts
@@ -320,7 +320,11 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
                   return;
                 }
 
-                callbackSnapshot(normalizedEvent);
+                try {
+                  callbackSnapshot(normalizedEvent);
+                } catch (error) {
+                  logger.error("[Events] Callback failed:", error);
+                }
               });
             }
           }

--- a/tests/bot/commands/abort.test.ts
+++ b/tests/bot/commands/abort.test.ts
@@ -6,14 +6,22 @@ import { questionManager } from "../../../src/question/manager.js";
 import { permissionManager } from "../../../src/permission/manager.js";
 import { renameManager } from "../../../src/rename/manager.js";
 import { interactionManager } from "../../../src/interaction/manager.js";
+import { foregroundSessionState } from "../../../src/scheduled-task/foreground-state.js";
 import type { Question } from "../../../src/question/types.js";
 import type { PermissionRequest } from "../../../src/permission/types.js";
 import { t } from "../../../src/i18n/index.js";
+import {
+  __resetUserAbortErrorSuppressionForTests,
+  shouldSuppressUserAbortSessionError,
+} from "../../../src/bot/utils/abort-error-suppression.js";
 
 const mocked = vi.hoisted(() => ({
   currentSession: null as { id: string; title: string; directory: string } | null,
   abortMock: vi.fn(),
   statusMock: vi.fn(),
+  clearRunMock: vi.fn(),
+  markAttachedSessionIdleMock: vi.fn(),
+  clearPromptResponseModeMock: vi.fn(),
 }));
 
 vi.mock("../../../src/session/manager.js", () => ({
@@ -27,6 +35,20 @@ vi.mock("../../../src/opencode/client.js", () => ({
       status: mocked.statusMock,
     },
   },
+}));
+
+vi.mock("../../../src/bot/assistant-run-state.js", () => ({
+  assistantRunState: {
+    clearRun: mocked.clearRunMock,
+  },
+}));
+
+vi.mock("../../../src/attach/service.js", () => ({
+  markAttachedSessionIdle: mocked.markAttachedSessionIdleMock,
+}));
+
+vi.mock("../../../src/bot/handlers/prompt.js", () => ({
+  clearPromptResponseMode: mocked.clearPromptResponseModeMock,
 }));
 
 const TEST_QUESTION: Question = {
@@ -61,10 +83,27 @@ function activateInteractionState(): void {
 describe("bot/commands/abort", () => {
   beforeEach(() => {
     clearAllInteractionState("test_setup");
+    foregroundSessionState.__resetForTests();
     mocked.currentSession = null;
     mocked.abortMock.mockReset();
     mocked.statusMock.mockReset();
+    mocked.clearRunMock.mockReset();
+    mocked.markAttachedSessionIdleMock.mockReset();
+    mocked.markAttachedSessionIdleMock.mockResolvedValue(undefined);
+    mocked.clearPromptResponseModeMock.mockReset();
+    __resetUserAbortErrorSuppressionForTests();
   });
+
+  function markSessionBusy(): void {
+    foregroundSessionState.markBusy("session-1", "D:/repo");
+  }
+
+  function expectAbortStateReleased(reason: string): void {
+    expect(foregroundSessionState.isBusy()).toBe(false);
+    expect(mocked.clearRunMock).toHaveBeenCalledWith("session-1", reason);
+    expect(mocked.markAttachedSessionIdleMock).toHaveBeenCalledWith("session-1");
+    expect(mocked.clearPromptResponseModeMock).toHaveBeenCalledWith("session-1");
+  }
 
   it("clears interaction state even when there is no active session", async () => {
     activateInteractionState();
@@ -92,6 +131,7 @@ describe("bot/commands/abort", () => {
       title: "Session",
       directory: "D:/repo",
     };
+    markSessionBusy();
 
     mocked.abortMock.mockResolvedValue({ data: true, error: null });
     mocked.statusMock.mockResolvedValue({
@@ -122,6 +162,39 @@ describe("bot/commands/abort", () => {
     expect(permissionManager.isActive()).toBe(false);
     expect(renameManager.isWaitingForName()).toBe(false);
     expect(interactionManager.getSnapshot()).toBeNull();
+    expectAbortStateReleased("abort_confirmed");
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(true);
+  });
+
+  it("marks only Aborted session errors for suppression after user abort", async () => {
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+    markSessionBusy();
+
+    mocked.abortMock.mockResolvedValue({ data: true, error: null });
+    mocked.statusMock.mockResolvedValue({
+      data: {
+        "session-1": { type: "idle" },
+      },
+      error: null,
+    });
+
+    const ctx = {
+      chat: { id: 777 },
+      reply: vi.fn().mockResolvedValue({ message_id: 88 }),
+      api: {
+        editMessageText: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as Context;
+
+    await abortCommand(ctx as never);
+
+    expect(shouldSuppressUserAbortSessionError("session-1", "Model not found")).toBe(false);
+    expect(shouldSuppressUserAbortSessionError("session-1", " Aborted ")).toBe(true);
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(false);
   });
 
   it("can abort silently without progress messages", async () => {
@@ -132,6 +205,7 @@ describe("bot/commands/abort", () => {
       title: "Session",
       directory: "D:/repo",
     };
+    markSessionBusy();
 
     mocked.abortMock.mockResolvedValue({ data: true, error: null });
     mocked.statusMock.mockResolvedValue({
@@ -162,5 +236,108 @@ describe("bot/commands/abort", () => {
     expect(permissionManager.isActive()).toBe(false);
     expect(renameManager.isWaitingForName()).toBe(false);
     expect(interactionManager.getSnapshot()).toBeNull();
+    expectAbortStateReleased("abort_confirmed");
+  });
+
+  it("releases local busy state when abort request returns an API error", async () => {
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+    markSessionBusy();
+
+    mocked.abortMock.mockResolvedValue({ data: null, error: new Error("abort failed") });
+
+    const editMessageTextMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 777 },
+      reply: vi.fn().mockResolvedValue({ message_id: 88 }),
+      api: {
+        editMessageText: editMessageTextMock,
+      },
+    } as unknown as Context;
+
+    await abortCommand(ctx as never);
+
+    expect(editMessageTextMock).toHaveBeenCalledWith(777, 88, t("stop.warn_unconfirmed"));
+    expectAbortStateReleased("abort_unconfirmed");
+  });
+
+  it("releases local busy state when abort result is not confirmed", async () => {
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+    markSessionBusy();
+
+    mocked.abortMock.mockResolvedValue({ data: false, error: null });
+
+    const editMessageTextMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 777 },
+      reply: vi.fn().mockResolvedValue({ message_id: 88 }),
+      api: {
+        editMessageText: editMessageTextMock,
+      },
+    } as unknown as Context;
+
+    await abortCommand(ctx as never);
+
+    expect(editMessageTextMock).toHaveBeenCalledWith(777, 88, t("stop.warn_maybe_finished"));
+    expectAbortStateReleased("abort_maybe_finished");
+  });
+
+  it("releases local busy state when abort request times out", async () => {
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+    markSessionBusy();
+
+    const abortError = new Error("timeout");
+    abortError.name = "AbortError";
+    mocked.abortMock.mockRejectedValue(abortError);
+
+    const editMessageTextMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 777 },
+      reply: vi.fn().mockResolvedValue({ message_id: 88 }),
+      api: {
+        editMessageText: editMessageTextMock,
+      },
+    } as unknown as Context;
+
+    await abortCommand(ctx as never);
+
+    expect(editMessageTextMock).toHaveBeenCalledWith(777, 88, t("stop.warn_timeout"));
+    expectAbortStateReleased("abort_error");
+  });
+
+  it("releases local busy state when abort request fails locally", async () => {
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:/repo",
+    };
+    markSessionBusy();
+
+    mocked.abortMock.mockRejectedValue(new Error("network failed"));
+
+    const editMessageTextMock = vi.fn().mockResolvedValue(undefined);
+    const ctx = {
+      chat: { id: 777 },
+      reply: vi.fn().mockResolvedValue({ message_id: 88 }),
+      api: {
+        editMessageText: editMessageTextMock,
+      },
+    } as unknown as Context;
+
+    await abortCommand(ctx as never);
+
+    expect(editMessageTextMock).toHaveBeenCalledWith(777, 88, t("stop.warn_local_only"));
+    expectAbortStateReleased("abort_error");
   });
 });

--- a/tests/bot/commands/opencode-start.test.ts
+++ b/tests/bot/commands/opencode-start.test.ts
@@ -181,4 +181,30 @@ describe("bot/commands/opencode-start", () => {
     );
     expect(mocked.notifyReadyMock).not.toHaveBeenCalled();
   });
+
+  it("does not hang indefinitely when health checks never resolve", async () => {
+    vi.useFakeTimers();
+
+    const ctx = createContext();
+    const childProcess = createChildProcess(456);
+    mocked.startLocalOpencodeServerMock.mockReturnValue(childProcess);
+    mocked.healthMock.mockReturnValue(new Promise(() => {}));
+
+    const commandPromise = opencodeStartCommand(ctx as never);
+    await vi.advanceTimersByTimeAsync(20_000);
+    await commandPromise;
+
+    expect(mocked.startLocalOpencodeServerMock).toHaveBeenCalledWith({
+      host: "localhost",
+      port: 4096,
+    });
+    expect(mocked.editBotTextMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        text: t("opencode_start.started_not_ready", { pid: 456 }),
+      }),
+    );
+    expect(mocked.loggerWarnMock).toHaveBeenCalledWith(
+      "[Bot] OpenCode health check timed out after 3000ms",
+    );
+  });
 });

--- a/tests/bot/middleware/interaction-guard.test.ts
+++ b/tests/bot/middleware/interaction-guard.test.ts
@@ -5,6 +5,14 @@ import { interactionManager } from "../../../src/interaction/manager.js";
 import { foregroundSessionState } from "../../../src/scheduled-task/foreground-state.js";
 import { t } from "../../../src/i18n/index.js";
 
+const mocked = vi.hoisted(() => ({
+  reconcileForegroundBusyStateMock: vi.fn(),
+}));
+
+vi.mock("../../../src/bot/utils/busy-guard.js", () => ({
+  reconcileForegroundBusyState: mocked.reconcileForegroundBusyStateMock,
+}));
+
 function createTextContext(text: string): Context {
   return {
     chat: { id: 1 },
@@ -35,6 +43,8 @@ describe("interactionGuardMiddleware", () => {
   beforeEach(() => {
     interactionManager.clear("test_setup");
     foregroundSessionState.__resetForTests();
+    mocked.reconcileForegroundBusyStateMock.mockReset();
+    mocked.reconcileForegroundBusyStateMock.mockResolvedValue(undefined);
   });
 
   it("passes through when there is no active interaction", async () => {
@@ -272,6 +282,35 @@ describe("interactionGuardMiddleware", () => {
 
     await interactionGuardMiddleware(ctx, next);
 
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith(t("bot.session_busy"));
+  });
+
+  it("passes through after on-demand reconciliation clears stale busy state", async () => {
+    foregroundSessionState.markBusy("session-1", "D:\\Projects\\Repo");
+    mocked.reconcileForegroundBusyStateMock.mockImplementationOnce(async () => {
+      foregroundSessionState.markIdle("session-1");
+    });
+
+    const ctx = createTextContext("hello");
+    const next: NextFunction = vi.fn().mockResolvedValue(undefined);
+
+    await interactionGuardMiddleware(ctx, next);
+
+    expect(mocked.reconcileForegroundBusyStateMock).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it("keeps blocking after on-demand reconciliation leaves state busy", async () => {
+    foregroundSessionState.markBusy("session-1", "D:\\Projects\\Repo");
+
+    const ctx = createTextContext("hello");
+    const next: NextFunction = vi.fn().mockResolvedValue(undefined);
+
+    await interactionGuardMiddleware(ctx, next);
+
+    expect(mocked.reconcileForegroundBusyStateMock).toHaveBeenCalledTimes(1);
     expect(next).not.toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith(t("bot.session_busy"));
   });

--- a/tests/bot/utils/abort-error-suppression.test.ts
+++ b/tests/bot/utils/abort-error-suppression.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetUserAbortErrorSuppressionForTests,
+  markUserAbortRequested,
+  shouldSuppressUserAbortSessionError,
+} from "../../../src/bot/utils/abort-error-suppression.js";
+
+describe("bot/utils/abort-error-suppression", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-16T10:00:00Z"));
+    __resetUserAbortErrorSuppressionForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetUserAbortErrorSuppressionForTests();
+  });
+
+  it("suppresses one Aborted error after a user abort request", () => {
+    markUserAbortRequested("session-1");
+
+    expect(shouldSuppressUserAbortSessionError("session-1", " Aborted ")).toBe(true);
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(false);
+  });
+
+  it("does not suppress unrelated errors after a user abort request", () => {
+    markUserAbortRequested("session-1");
+
+    expect(shouldSuppressUserAbortSessionError("session-1", "Model not found")).toBe(false);
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(true);
+  });
+
+  it("does not suppress stale abort errors", () => {
+    markUserAbortRequested("session-1");
+    vi.advanceTimersByTime(30_001);
+
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(false);
+  });
+});

--- a/tests/bot/utils/abort-error-suppression.test.ts
+++ b/tests/bot/utils/abort-error-suppression.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __getUserAbortErrorSuppressionSizeForTests,
   __resetUserAbortErrorSuppressionForTests,
   markUserAbortRequested,
   shouldSuppressUserAbortSessionError,
@@ -33,8 +34,26 @@ describe("bot/utils/abort-error-suppression", () => {
 
   it("does not suppress stale abort errors", () => {
     markUserAbortRequested("session-1");
-    vi.advanceTimersByTime(30_001);
+    vi.advanceTimersByTime(90_001);
 
     expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(false);
+  });
+
+  it("keeps abort markers active within the suppression window", () => {
+    markUserAbortRequested("session-1");
+    vi.advanceTimersByTime(89_999);
+
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(true);
+  });
+
+  it("removes expired markers when a new abort request is marked", () => {
+    markUserAbortRequested("session-1");
+    vi.advanceTimersByTime(90_001);
+
+    markUserAbortRequested("session-2");
+
+    expect(__getUserAbortErrorSuppressionSizeForTests()).toBe(1);
+    expect(shouldSuppressUserAbortSessionError("session-1", "Aborted")).toBe(false);
+    expect(shouldSuppressUserAbortSessionError("session-2", "Aborted")).toBe(true);
   });
 });

--- a/tests/bot/utils/busy-guard.test.ts
+++ b/tests/bot/utils/busy-guard.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  reconcileBusyStateNowMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock("../../../src/bot/utils/busy-reconciliation.js", () => ({
+  reconcileBusyStateNow: mocked.reconcileBusyStateNowMock,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mocked.loggerWarnMock,
+    error: vi.fn(),
+  },
+}));
+
+import { attachManager } from "../../../src/attach/manager.js";
+import { foregroundSessionState } from "../../../src/scheduled-task/foreground-state.js";
+import { reconcileForegroundBusyState } from "../../../src/bot/utils/busy-guard.js";
+
+describe("bot/utils/busy-guard", () => {
+  beforeEach(() => {
+    foregroundSessionState.__resetForTests();
+    attachManager.__resetForTests();
+    mocked.reconcileBusyStateNowMock.mockReset();
+    mocked.reconcileBusyStateNowMock.mockResolvedValue(undefined);
+    mocked.loggerWarnMock.mockReset();
+  });
+
+  it("uses non-throttled reconciliation for foreground busy directories", async () => {
+    foregroundSessionState.markBusy("session-1", "D:/repo");
+
+    await reconcileForegroundBusyState();
+
+    expect(mocked.reconcileBusyStateNowMock).toHaveBeenCalledWith("D:/repo");
+    expect(mocked.reconcileBusyStateNowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues checking other directories when one on-demand reconciliation fails", async () => {
+    foregroundSessionState.markBusy("session-1", "D:/repo-a");
+    foregroundSessionState.markBusy("session-2", "D:/repo-b");
+    const error = new Error("status failed");
+    mocked.reconcileBusyStateNowMock.mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+
+    await reconcileForegroundBusyState();
+
+    expect(mocked.reconcileBusyStateNowMock).toHaveBeenCalledWith("D:/repo-a");
+    expect(mocked.reconcileBusyStateNowMock).toHaveBeenCalledWith("D:/repo-b");
+    expect(mocked.loggerWarnMock).toHaveBeenCalledWith(
+      "[BusyGuard] Failed to reconcile foreground busy state",
+      error,
+    );
+  });
+});

--- a/tests/opencode/events.test.ts
+++ b/tests/opencode/events.test.ts
@@ -19,7 +19,11 @@ vi.mock("../../src/opencode/client.js", () => ({
   },
 }));
 
-import { stopEventListening, subscribeToEvents } from "../../src/opencode/events.js";
+import {
+  __setSseIdleTimeoutForTests,
+  stopEventListening,
+  subscribeToEvents,
+} from "../../src/opencode/events.js";
 
 function createStream<T>(events: T[]): AsyncGenerator<T, void, unknown> {
   return (async function* () {
@@ -55,6 +59,21 @@ function createAbortableStream(signal: AbortSignal): AsyncGenerator<Event, void,
   })();
 }
 
+function createDelayedOpenStream<T>(
+  event: T,
+  signal: AbortSignal,
+  delayMs: number,
+): AsyncGenerator<T, void, unknown> {
+  return (async function* () {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    yield event;
+
+    while (!signal.aborted) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  })();
+}
+
 function flushImmediate(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -68,6 +87,8 @@ describe("opencode/events", () => {
 
   afterEach(() => {
     stopEventListening();
+    __setSseIdleTimeoutForTests(30_000);
+    vi.useRealTimers();
   });
 
   it("subscribes to stream and forwards events to callback", async () => {
@@ -326,6 +347,60 @@ describe("opencode/events", () => {
       },
       { timeout: 3000 },
     );
+
+    stopEventListening();
+    await subscription;
+  });
+
+  it("reconnects when an active stream stops delivering events", async () => {
+    vi.useFakeTimers();
+    __setSseIdleTimeoutForTests(10);
+
+    subscribeMock
+      .mockImplementationOnce(async (_params, options: { signal: AbortSignal }) => {
+        return { stream: createAbortableStream(options.signal) };
+      })
+      .mockImplementationOnce(async (_params, options: { signal: AbortSignal }) => {
+        return { stream: createAbortableStream(options.signal) };
+      });
+
+    const subscription = subscribeToEvents("D:/repo", vi.fn());
+
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(1_010);
+
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(2);
+    });
+
+    stopEventListening();
+    await subscription;
+  });
+
+  it("resets the idle timeout after receiving an event", async () => {
+    __setSseIdleTimeoutForTests(40);
+
+    const event = { type: "session.status", properties: { sessionID: "s1" } } as Event;
+    subscribeMock.mockImplementation(async (_params, options: { signal: AbortSignal }) => {
+      return { stream: createDelayedOpenStream(event, options.signal, 15) };
+    });
+
+    const callback = vi.fn();
+    const subscription = subscribeToEvents("D:/repo", callback);
+
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(event);
+    }, { timeout: 500 });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
 
     stopEventListening();
     await subscription;

--- a/tests/opencode/events.test.ts
+++ b/tests/opencode/events.test.ts
@@ -24,6 +24,7 @@ import {
   stopEventListening,
   subscribeToEvents,
 } from "../../src/opencode/events.js";
+import { logger } from "../../src/utils/logger.js";
 
 function createStream<T>(events: T[]): AsyncGenerator<T, void, unknown> {
   return (async function* () {
@@ -113,6 +114,32 @@ describe("opencode/events", () => {
     expect(callback).toHaveBeenCalledTimes(2);
     expect(callback.mock.calls[0][0]).toEqual(eventA);
     expect(callback.mock.calls[1][0]).toEqual(eventB);
+  });
+
+  it("logs callback errors without failing event delivery", async () => {
+    const eventA = { type: "session.status", properties: { sessionID: "s1" } } as Event;
+    const eventB = { type: "session.idle", properties: { sessionID: "s1" } } as Event;
+    subscribeMock.mockResolvedValueOnce({ stream: createStream([eventA, eventB]) });
+    const callbackError = new Error("callback failed");
+    const loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+    const callback = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw callbackError;
+      })
+      .mockImplementationOnce(() => undefined);
+
+    const subscription = subscribeToEvents("D:/repo", callback);
+
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith("[Events] Callback failed:", callbackError);
+
+    stopEventListening();
+    await subscription;
+    loggerErrorSpy.mockRestore();
   });
 
   it("unwraps global event payloads before forwarding them", async () => {


### PR DESCRIPTION
## Description of changes

prevent stale busy state after interruption

## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [x] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described
