### PR TITLE
fix(permission): forward permission requests from subagent sessions (#129)

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -756,7 +756,9 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     }
 
     const currentSession = getCurrentSession();
-    if (!currentSession || currentSession.id !== request.sessionID) {
+    const isCurrent = currentSession?.id === request.sessionID;
+    const isSubagent = summaryAggregator.isSubagentSession(request.sessionID);
+    if (!currentSession || (!isCurrent && !isSubagent)) {
       return;
     }
 
@@ -766,7 +768,7 @@ async function ensureEventSubscription(directory: string): Promise<void> {
     ]);
 
     logger.info(
-      `[Bot] Received permission request from agent: type=${request.permission}, requestID=${request.id}`,
+      `[Bot] Received permission request from agent: type=${request.permission}, requestID=${request.id}, subagent=${isSubagent}`,
     );
     await showPermissionRequest(botInstance.api, chatIdInstance, request);
   });

--- a/src/summary/aggregator.ts
+++ b/src/summary/aggregator.ts
@@ -482,6 +482,13 @@ class SummaryAggregator {
     return this.trackedSessionParents.has(sessionId) && sessionId !== this.currentSessionId;
   }
 
+  /**
+   * Public check: is this session a tracked subagent (child) of the current root session?
+   */
+  isSubagentSession(sessionId: string): boolean {
+    return this.isTrackedChildSession(sessionId);
+  }
+
   private getQueue(map: Map<string, string[]>, parentSessionId: string): string[] {
     const existing = map.get(parentSessionId);
     if (existing) {
@@ -1833,7 +1840,10 @@ class SummaryAggregator {
   ): void {
     const request = event.properties;
 
-    if (request.sessionID !== this.currentSessionId) {
+    const isCurrent = request.sessionID === this.currentSessionId;
+    const isTrackedChild = this.isTrackedChildSession(request.sessionID);
+
+    if (!isCurrent && !isTrackedChild) {
       logger.debug(
         `[Aggregator] Ignoring permission.asked for different session: ${request.sessionID} (current: ${this.currentSessionId})`,
       );
@@ -1841,7 +1851,7 @@ class SummaryAggregator {
     }
 
     logger.info(
-      `[Aggregator] Permission asked: requestID=${request.id}, type=${request.permission}, patterns=${request.patterns.length}`,
+      `[Aggregator] Permission asked: requestID=${request.id}, type=${request.permission}, patterns=${request.patterns.length}, subagent=${isTrackedChild}`,
     );
 
     if (this.onPermissionCallback) {

--- a/tests/summary/aggregator.test.ts
+++ b/tests/summary/aggregator.test.ts
@@ -1520,4 +1520,90 @@ describe("summary/aggregator", () => {
 
     expect(onTokens).not.toHaveBeenCalled();
   });
+
+  it("forwards permission.asked events from tracked subagent (child) sessions", async () => {
+    const onPermission = vi.fn();
+    summaryAggregator.setOnPermission(onPermission);
+    summaryAggregator.setSession("root-session");
+
+    // Register a tracked child session via the task tool flow.
+    summaryAggregator.processEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "subtask-1",
+          sessionID: "root-session",
+          messageID: "root-message",
+          type: "subtask",
+          prompt: "Edit file",
+          description: "Edit file",
+          agent: "general",
+        },
+      },
+    } as unknown as Event);
+
+    summaryAggregator.processEvent({
+      type: "session.created",
+      properties: {
+        info: {
+          id: "child-session-1",
+          parentID: "root-session",
+          title: "Edit file (@general subagent)",
+          slug: "child",
+          directory: "D:/repo",
+          projectID: "p1",
+          version: "1",
+          time: { created: Date.now(), updated: Date.now() },
+        },
+      },
+    } as unknown as Event);
+
+    // permission.asked from the child (subagent) session must reach the callback.
+    summaryAggregator.processEvent({
+      type: "permission.asked",
+      properties: {
+        id: "req-child-1",
+        sessionID: "child-session-1",
+        permission: "write",
+        patterns: ["src/foo.ts"],
+        metadata: {},
+        always: [],
+      },
+    } as unknown as Event);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onPermission).toHaveBeenCalledTimes(1);
+    expect(onPermission.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        id: "req-child-1",
+        sessionID: "child-session-1",
+        permission: "write",
+      }),
+    );
+    expect(summaryAggregator.isSubagentSession("child-session-1")).toBe(true);
+  });
+
+  it("ignores permission.asked events from unrelated sessions", async () => {
+    const onPermission = vi.fn();
+    summaryAggregator.setOnPermission(onPermission);
+    summaryAggregator.setSession("root-session");
+
+    summaryAggregator.processEvent({
+      type: "permission.asked",
+      properties: {
+        id: "req-other",
+        sessionID: "some-other-session",
+        permission: "write",
+        patterns: ["src/foo.ts"],
+        metadata: {},
+        always: [],
+      },
+    } as unknown as Event);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onPermission).not.toHaveBeenCalled();
+    expect(summaryAggregator.isSubagentSession("some-other-session")).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #129.

## Problem
When a sub-agent (Task tool / ULW delegation) requests permission for a
write/edit/bash call, the bot never showed the approval prompt and the
sub-agent hung until OpenCode timed it out.

## Root cause
Two `sessionID !== currentSessionId` filters dropped the event:
1. `summary/aggregator.ts` — `handlePermissionAsked` ignored all events
   whose `sessionID` wasn't the current root session.
2. `bot/index.ts` — the `setOnPermission` callback re-applied the same
   strict check before showing the Telegram message.

A sub-agent runs in its own child session (`session.created` with
`parentID = root`), so its `sessionID` never matched.

## Fix
- `aggregator`: `handlePermissionAsked` now also accepts events from
  tracked child sessions (the pattern already used by
  `handleSessionIdle` / `handleSessionError`). Adds public
  `isSubagentSession(id)` for consumers.
- `bot`: `setOnPermission` callback accepts the current session or any
  tracked sub-agent session.
- Reply path was already session-agnostic (uses `requestID` +
  directory), no change needed there.

## Tests
Two new regression tests in `tests/summary/aggregator.test.ts`:
- forwards `permission.asked` from a tracked subagent child session
- still ignores `permission.asked` from unrelated sessions

Full suite: 916/916 passing. `tsc --noEmit` clean.