### PR TITLE
feat(bot): add /messages command and support for fork and revert for ecah message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ OPENCODE_MODEL_ID=big-pickle
 # Maximum number of sessions shown in /sessions (default: 10)
 # SESSIONS_LIST_LIMIT=10
 
+# Maximum number of user messages shown per page in /messages (default: 10)
+# MESSAGES_LIST_LIMIT=10
+
 # Maximum number of projects shown in /projects (default: 10)
 # PROJECTS_LIST_LIMIT=10
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -102,6 +102,7 @@ Current command set:
 - `/abort` - stop the current task
 - `/detach` - detach the bot from the current session without stopping it
 - `/sessions` - show and switch recent sessions
+- `/messages` - browse user messages in the current session
 - `/projects` - show and switch projects
 - `/worktree` - show and switch existing git worktrees for the current repository
 - `/tts` - toggle global audio replies
@@ -121,7 +122,7 @@ Text messages (non-commands) are treated as prompts for OpenCode only when no bl
 
 Interaction routing rules:
 
-- Only one interactive flow can be active at a time (inline menu, permission, question, rename, commands, skills)
+- Only one interactive flow can be active at a time (inline menu, permission, question, rename, commands, skills, messages)
 - While an interaction is active, unrelated input is blocked with a contextual hint
 - Allowed utility commands during active interactions: `/help`, `/status`, `/abort`, `/detach`
 - Unknown slash commands return an explicit fallback message
@@ -166,12 +167,12 @@ Model picker behavior:
 - [x] `/mcps` command: browse available MCP servers
 - [x] Optional local OpenCode server monitoring with automatic restart
 - [x] Interactive project file browsing and file download from Telegram (`/ls`)
+- [x] `/messages` command: browse session messages with fork/revert placeholders
 
 ## Current Task List
 
 Open tasks for upcoming iterations:
 
-- [ ] `/messages` command: browse session messages with fork/revert actions
 - [ ] Model search in model switcher
 - [ ] Docker runtime support and deployment guide
 - [ ] Add a bot settings command with in-chat UI

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -167,7 +167,7 @@ Model picker behavior:
 - [x] `/mcps` command: browse available MCP servers
 - [x] Optional local OpenCode server monitoring with automatic restart
 - [x] Interactive project file browsing and file download from Telegram (`/ls`)
-- [x] `/messages` command: browse session messages with fork/revert placeholders
+- [x] `/messages` command: browse session messages with revert and fork functionality
 
 ## Current Task List
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ opencode-telegram config
 | `/abort`          | Abort the current task                                  |
 | `/detach`         | Detach from the current session without stopping it     |
 | `/sessions`       | Browse and switch between recent sessions               |
+| `/messages`       | Browse user messages in the current session             |
 | `/projects`       | Switch between OpenCode projects                        |
 | `/worktree`       | Switch between existing git worktrees                   |
 | `/open`           | Add a project by browsing directories                   |
@@ -210,6 +211,7 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `OPENCODE_MODEL_ID`                        | Default model ID                                                                                                      |   Yes    | `big-pickle`             |
 | `BOT_LOCALE`                               | Bot UI language (supported locale code, e.g. `en`, `de`, `es`, `fr`, `ru`, `zh`)                                      |    No    | `en`                     |
 | `SESSIONS_LIST_LIMIT`                      | Sessions per page in `/sessions`                                                                                      |    No    | `10`                     |
+| `MESSAGES_LIST_LIMIT`                      | User messages per page in `/messages`                                                                                 |    No    | `10`                     |
 | `PROJECTS_LIST_LIMIT`                      | Projects per page in `/projects`                                                                                      |    No    | `10`                     |
 | `OPEN_BROWSER_ROOTS`                       | Comma-separated paths `/open` is allowed to browse (supports `~`)                                                     |    No    | `~` (home directory)     |
 | `COMMANDS_LIST_LIMIT`                      | Items per page in `/commands` and `/skills`                                                                           |    No    | `10`                     |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ opencode-telegram config
 | `/abort`          | Abort the current task                                  |
 | `/detach`         | Detach from the current session without stopping it     |
 | `/sessions`       | Browse and switch between recent sessions               |
-| `/messages`       | Browse user messages in the current session             |
+| `/messages`       | Browse user messages and revert to a previous state     |
 | `/projects`       | Switch between OpenCode projects                        |
 | `/worktree`       | Switch between existing git worktrees                   |
 | `/open`           | Add a project by browsing directories                   |
@@ -153,6 +153,12 @@ opencode-telegram config
 Any regular text message is sent as a prompt to the coding agent only when no blocking interaction is active. Voice/audio messages are transcribed and then sent as prompts when STT is configured.
 
 When the current project is a git repository, `/worktree` shows the existing worktrees for that repository. Status and pinned updates display the main project path with the active branch, and show a separate `Worktree` line when a linked worktree is selected.
+
+## Message History and Revert
+
+The `/messages` command displays all user messages in the current session, sorted by time (newest first). Select a message to view its full text and access the **Revert** action.
+
+**Revert** rolls back the session state to the selected message, discarding all subsequent messages and agent responses. This is useful when you want to retry a different approach from a specific point in the conversation.
 
 ## Scheduled Tasks
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ opencode-telegram config
 | `/abort`          | Abort the current task                                  |
 | `/detach`         | Detach from the current session without stopping it     |
 | `/sessions`       | Browse and switch between recent sessions               |
-| `/messages`       | Browse user messages and revert to a previous state     |
+| `/messages`       | Browse user messages, revert or fork from a previous state     |
 | `/projects`       | Switch between OpenCode projects                        |
 | `/worktree`       | Switch between existing git worktrees                   |
 | `/open`           | Add a project by browsing directories                   |
@@ -154,11 +154,13 @@ Any regular text message is sent as a prompt to the coding agent only when no bl
 
 When the current project is a git repository, `/worktree` shows the existing worktrees for that repository. Status and pinned updates display the main project path with the active branch, and show a separate `Worktree` line when a linked worktree is selected.
 
-## Message History and Revert
+## Message History, Revert, and Fork
 
-The `/messages` command displays all user messages in the current session, sorted by time (newest first). Select a message to view its full text and access the **Revert** action.
+The `/messages` command displays all user messages in the current session, sorted by time (newest first). Select a message to view its full text and access the **Revert** and **Fork** actions.
 
 **Revert** rolls back the session state to the selected message, discarding all subsequent messages and agent responses. This is useful when you want to retry a different approach from a specific point in the conversation.
+
+**Fork** creates a new session that branches from the selected message. The original session remains unchanged, and you can continue working in the new forked session. This is useful when you want to explore an alternative approach without losing the original conversation history.
 
 ## Scheduled Tasks
 

--- a/src/bot/commands/definitions.ts
+++ b/src/bot/commands/definitions.ts
@@ -26,6 +26,7 @@ const COMMAND_DEFINITIONS: BotCommandI18nDefinition[] = [
   { command: "abort", descriptionKey: "cmd.description.stop" },
   { command: "detach", descriptionKey: "cmd.description.detach" },
   { command: "sessions", descriptionKey: "cmd.description.sessions" },
+  { command: "messages", descriptionKey: "cmd.description.messages" },
   { command: "tts", descriptionKey: "cmd.description.tts" },
   { command: "projects", descriptionKey: "cmd.description.projects" },
   { command: "worktree", descriptionKey: "cmd.description.worktree" },

--- a/src/bot/commands/messages.ts
+++ b/src/bot/commands/messages.ts
@@ -1,0 +1,532 @@
+import { CommandContext, Context, InlineKeyboard } from "grammy";
+import { config } from "../../config.js";
+import type { InteractionState } from "../../interaction/types.js";
+import { interactionManager } from "../../interaction/manager.js";
+import { opencodeClient } from "../../opencode/client.js";
+import { getCurrentSession } from "../../session/manager.js";
+import { getCurrentProject } from "../../settings/manager.js";
+import { t } from "../../i18n/index.js";
+import { logger } from "../../utils/logger.js";
+
+const MESSAGES_CALLBACK_PREFIX = "messages:";
+const MESSAGES_CALLBACK_SELECT_PREFIX = `${MESSAGES_CALLBACK_PREFIX}select:`;
+const MESSAGES_CALLBACK_PAGE_PREFIX = `${MESSAGES_CALLBACK_PREFIX}page:`;
+const MESSAGES_CALLBACK_REVERT = `${MESSAGES_CALLBACK_PREFIX}revert`;
+const MESSAGES_CALLBACK_FORK = `${MESSAGES_CALLBACK_PREFIX}fork`;
+const MESSAGES_CALLBACK_BACK = `${MESSAGES_CALLBACK_PREFIX}back`;
+const MESSAGES_CALLBACK_CANCEL = `${MESSAGES_CALLBACK_PREFIX}cancel`;
+const MAX_INLINE_BUTTON_LABEL_LENGTH = 64;
+const TELEGRAM_MESSAGE_LIMIT = 4096;
+
+interface UserMessageItem {
+  id: string;
+  text: string;
+  created: number;
+}
+
+interface MessagesListMetadata {
+  flow: "messages";
+  stage: "list";
+  messageId: number;
+  projectDirectory: string;
+  sessionId: string;
+  messages: UserMessageItem[];
+  page: number;
+}
+
+interface MessagesDetailMetadata {
+  flow: "messages";
+  stage: "detail";
+  messageId: number;
+  projectDirectory: string;
+  sessionId: string;
+  messages: UserMessageItem[];
+  page: number;
+  selectedIndex: number;
+}
+
+type MessagesMetadata = MessagesListMetadata | MessagesDetailMetadata;
+
+type SessionMessageLike = {
+  info: {
+    id?: string;
+    role?: string;
+    time?: {
+      created?: number;
+    };
+  };
+  parts: Array<{ type: string; text?: string }>;
+};
+
+export interface MessagesPaginationRange {
+  page: number;
+  totalPages: number;
+  startIndex: number;
+  endIndex: number;
+}
+
+function getCallbackMessageId(ctx: Context): number | null {
+  const message = ctx.callbackQuery?.message;
+  if (!message || !("message_id" in message)) {
+    return null;
+  }
+
+  const messageId = (message as { message_id?: number }).message_id;
+  return typeof messageId === "number" ? messageId : null;
+}
+
+function extractTextParts(parts: Array<{ type: string; text?: string }>): string | null {
+  const text = parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text as string)
+    .join("")
+    .trim();
+
+  return text.length > 0 ? text : null;
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function normalizeButtonText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function formatMessageTime(created: number): string {
+  const date = new Date(created);
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+function formatMessageButtonLabel(message: UserMessageItem): string {
+  const prefix = `[${formatMessageTime(message.created)}] `;
+  const text = normalizeButtonText(message.text);
+  return `${prefix}${truncateText(text, MAX_INLINE_BUTTON_LABEL_LENGTH - prefix.length)}`;
+}
+
+function formatMessagesSelectText(page: number): string {
+  if (page === 0) {
+    return t("messages.select");
+  }
+
+  return t("messages.select_page", { page: page + 1 });
+}
+
+function formatMessageDetailText(message: UserMessageItem): string {
+  const prefix = `[${formatMessageTime(message.created)}]\n\n`;
+  return truncateText(`${prefix}${message.text}`, TELEGRAM_MESSAGE_LIMIT);
+}
+
+export function buildMessagePageCallback(page: number): string {
+  return `${MESSAGES_CALLBACK_PAGE_PREFIX}${page}`;
+}
+
+export function parseMessagePageCallback(data: string): number | null {
+  if (!data.startsWith(MESSAGES_CALLBACK_PAGE_PREFIX)) {
+    return null;
+  }
+
+  const rawPage = data.slice(MESSAGES_CALLBACK_PAGE_PREFIX.length);
+  const page = Number(rawPage);
+  if (!Number.isInteger(page) || page < 0) {
+    return null;
+  }
+
+  return page;
+}
+
+export function calculateMessagesPaginationRange(
+  totalMessages: number,
+  page: number,
+  pageSize: number,
+): MessagesPaginationRange {
+  const safePageSize = Math.max(1, pageSize);
+  const totalPages = Math.max(1, Math.ceil(totalMessages / safePageSize));
+  const normalizedPage = Math.min(Math.max(0, page), totalPages - 1);
+  const startIndex = normalizedPage * safePageSize;
+  const endIndex = Math.min(startIndex + safePageSize, totalMessages);
+
+  return {
+    page: normalizedPage,
+    totalPages,
+    startIndex,
+    endIndex,
+  };
+}
+
+function buildMessagesListKeyboard(
+  messages: UserMessageItem[],
+  page: number,
+  pageSize: number,
+): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  const {
+    page: normalizedPage,
+    totalPages,
+    startIndex,
+    endIndex,
+  } = calculateMessagesPaginationRange(messages.length, page, pageSize);
+
+  messages.slice(startIndex, endIndex).forEach((message, index) => {
+    const globalIndex = startIndex + index;
+    keyboard.text(formatMessageButtonLabel(message), `${MESSAGES_CALLBACK_SELECT_PREFIX}${globalIndex}`).row();
+  });
+
+  if (totalPages > 1) {
+    if (normalizedPage > 0) {
+      keyboard.text(t("messages.button.prev_page"), buildMessagePageCallback(normalizedPage - 1));
+    }
+
+    if (normalizedPage < totalPages - 1) {
+      keyboard.text(t("messages.button.next_page"), buildMessagePageCallback(normalizedPage + 1));
+    }
+
+    keyboard.row();
+  }
+
+  keyboard.text(t("messages.button.cancel"), MESSAGES_CALLBACK_CANCEL);
+  return keyboard;
+}
+
+function buildMessageDetailKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text(t("messages.button.revert"), MESSAGES_CALLBACK_REVERT)
+    .row()
+    .text(t("messages.button.fork"), MESSAGES_CALLBACK_FORK)
+    .row()
+    .text(t("messages.button.back"), MESSAGES_CALLBACK_BACK)
+    .text(t("messages.button.cancel"), MESSAGES_CALLBACK_CANCEL);
+}
+
+function parseMessages(value: unknown): UserMessageItem[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const messages: UserMessageItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      return null;
+    }
+
+    const id = (item as { id?: unknown }).id;
+    const text = (item as { text?: unknown }).text;
+    const created = (item as { created?: unknown }).created;
+
+    if (typeof id !== "string" || typeof text !== "string" || typeof created !== "number") {
+      return null;
+    }
+
+    messages.push({ id, text, created });
+  }
+
+  return messages;
+}
+
+function parseMessagesMetadata(state: InteractionState | null): MessagesMetadata | null {
+  if (!state || state.kind !== "custom") {
+    return null;
+  }
+
+  const flow = state.metadata.flow;
+  const stage = state.metadata.stage;
+  const messageId = state.metadata.messageId;
+  const projectDirectory = state.metadata.projectDirectory;
+  const sessionId = state.metadata.sessionId;
+  const messages = parseMessages(state.metadata.messages);
+  const page =
+    typeof state.metadata.page === "number" && Number.isInteger(state.metadata.page)
+      ? Math.max(0, state.metadata.page)
+      : 0;
+
+  if (
+    flow !== "messages" ||
+    typeof messageId !== "number" ||
+    typeof projectDirectory !== "string" ||
+    typeof sessionId !== "string" ||
+    !messages
+  ) {
+    return null;
+  }
+
+  if (stage === "list") {
+    return {
+      flow,
+      stage,
+      messageId,
+      projectDirectory,
+      sessionId,
+      messages,
+      page,
+    };
+  }
+
+  if (stage === "detail") {
+    const selectedIndex = state.metadata.selectedIndex;
+    if (typeof selectedIndex !== "number" || !Number.isInteger(selectedIndex) || selectedIndex < 0) {
+      return null;
+    }
+
+    return {
+      flow,
+      stage,
+      messageId,
+      projectDirectory,
+      sessionId,
+      messages,
+      page,
+      selectedIndex,
+    };
+  }
+
+  return null;
+}
+
+function clearMessagesInteraction(reason: string): void {
+  const metadata = parseMessagesMetadata(interactionManager.getSnapshot());
+  if (metadata) {
+    interactionManager.clear(reason);
+  }
+}
+
+async function loadUserMessages(sessionId: string, directory: string): Promise<UserMessageItem[]> {
+  const { data, error } = await opencodeClient.session.messages({
+    sessionID: sessionId,
+    directory,
+  });
+
+  if (error || !data) {
+    throw error || new Error("No message data received");
+  }
+
+  return (data as SessionMessageLike[])
+    .map((message) => {
+      if (message.info.role !== "user") {
+        return null;
+      }
+
+      const text = extractTextParts(message.parts);
+      if (!text) {
+        return null;
+      }
+
+      return {
+        id: message.info.id ?? `${message.info.time?.created ?? 0}`,
+        text,
+        created: message.info.time?.created ?? 0,
+      } satisfies UserMessageItem;
+    })
+    .filter((message): message is UserMessageItem => Boolean(message))
+    .sort((a, b) => b.created - a.created);
+}
+
+function parseSelectIndex(data: string): number | null {
+  if (!data.startsWith(MESSAGES_CALLBACK_SELECT_PREFIX)) {
+    return null;
+  }
+
+  const rawIndex = data.slice(MESSAGES_CALLBACK_SELECT_PREFIX.length);
+  const index = Number(rawIndex);
+
+  if (!Number.isInteger(index) || index < 0) {
+    return null;
+  }
+
+  return index;
+}
+
+export async function messagesCommand(ctx: CommandContext<Context>): Promise<void> {
+  try {
+    const currentProject = getCurrentProject();
+    if (!currentProject) {
+      await ctx.reply(t("messages.project_not_selected"));
+      return;
+    }
+
+    const currentSession = getCurrentSession();
+    if (!currentSession) {
+      await ctx.reply(t("messages.session_not_selected"));
+      return;
+    }
+
+    if (currentSession.directory !== currentProject.worktree) {
+      await ctx.reply(t("messages.session_project_mismatch"));
+      return;
+    }
+
+    const messages = await loadUserMessages(currentSession.id, currentSession.directory);
+    if (messages.length === 0) {
+      await ctx.reply(t("messages.empty"));
+      return;
+    }
+
+    const pageSize = config.bot.messagesListLimit;
+    const keyboard = buildMessagesListKeyboard(messages, 0, pageSize);
+    const message = await ctx.reply(formatMessagesSelectText(0), {
+      reply_markup: keyboard,
+    });
+
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: message.message_id,
+        projectDirectory: currentProject.worktree,
+        sessionId: currentSession.id,
+        messages,
+        page: 0,
+      },
+    });
+  } catch (error) {
+    logger.error("[Messages] Error fetching messages list:", error);
+    await ctx.reply(t("messages.fetch_error"));
+  }
+}
+
+export async function handleMessagesCallback(ctx: Context): Promise<boolean> {
+  const data = ctx.callbackQuery?.data;
+  if (!data || !data.startsWith(MESSAGES_CALLBACK_PREFIX)) {
+    return false;
+  }
+
+  const metadata = parseMessagesMetadata(interactionManager.getSnapshot());
+  const callbackMessageId = getCallbackMessageId(ctx);
+
+  if (!metadata || callbackMessageId === null || metadata.messageId !== callbackMessageId) {
+    await ctx.answerCallbackQuery({ text: t("messages.inactive_callback"), show_alert: true });
+    return true;
+  }
+
+  try {
+    if (data === MESSAGES_CALLBACK_REVERT || data === MESSAGES_CALLBACK_FORK) {
+      await ctx.answerCallbackQuery();
+      return true;
+    }
+
+    if (data === MESSAGES_CALLBACK_BACK) {
+      if (metadata.stage !== "detail") {
+        await ctx.answerCallbackQuery({ text: t("messages.inactive_callback"), show_alert: true });
+        return true;
+      }
+
+      const pageSize = config.bot.messagesListLimit;
+      const { page: normalizedPage } = calculateMessagesPaginationRange(
+        metadata.messages.length,
+        metadata.page,
+        pageSize,
+      );
+      await ctx.editMessageText(formatMessagesSelectText(normalizedPage), {
+        reply_markup: buildMessagesListKeyboard(metadata.messages, normalizedPage, pageSize),
+      });
+      await ctx.answerCallbackQuery();
+
+      interactionManager.transition({
+        expectedInput: "callback",
+        metadata: {
+          flow: "messages",
+          stage: "list",
+          messageId: metadata.messageId,
+          projectDirectory: metadata.projectDirectory,
+          sessionId: metadata.sessionId,
+          messages: metadata.messages,
+          page: normalizedPage,
+        },
+      });
+
+      return true;
+    }
+
+    if (data === MESSAGES_CALLBACK_CANCEL) {
+      clearMessagesInteraction("messages_cancelled");
+      await ctx.answerCallbackQuery({ text: t("messages.cancelled_callback") });
+      await ctx.deleteMessage().catch(() => {});
+      return true;
+    }
+
+    const page = parseMessagePageCallback(data);
+    if (page !== null) {
+      if (metadata.stage !== "list") {
+        await ctx.answerCallbackQuery({ text: t("callback.processing_error"), show_alert: true });
+        return true;
+      }
+
+      const pageSize = config.bot.messagesListLimit;
+      const { page: normalizedPage, totalPages } = calculateMessagesPaginationRange(
+        metadata.messages.length,
+        page,
+        pageSize,
+      );
+
+      if (page >= totalPages || page < 0) {
+        await ctx.answerCallbackQuery({ text: t("messages.page_empty_callback") });
+        return true;
+      }
+
+      await ctx.editMessageText(formatMessagesSelectText(normalizedPage), {
+        reply_markup: buildMessagesListKeyboard(metadata.messages, normalizedPage, pageSize),
+      });
+      await ctx.answerCallbackQuery();
+
+      interactionManager.transition({
+        expectedInput: "callback",
+        metadata: {
+          flow: "messages",
+          stage: "list",
+          messageId: metadata.messageId,
+          projectDirectory: metadata.projectDirectory,
+          sessionId: metadata.sessionId,
+          messages: metadata.messages,
+          page: normalizedPage,
+        },
+      });
+
+      return true;
+    }
+
+    const messageIndex = parseSelectIndex(data);
+    if (messageIndex === null || metadata.stage !== "list") {
+      await ctx.answerCallbackQuery({ text: t("callback.processing_error"), show_alert: true });
+      return true;
+    }
+
+    const selectedMessage = metadata.messages[messageIndex];
+    if (!selectedMessage) {
+      await ctx.answerCallbackQuery({ text: t("messages.inactive_callback"), show_alert: true });
+      return true;
+    }
+
+    await ctx.editMessageText(formatMessageDetailText(selectedMessage), {
+      reply_markup: buildMessageDetailKeyboard(),
+    });
+    await ctx.answerCallbackQuery();
+
+    interactionManager.transition({
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: metadata.messageId,
+        projectDirectory: metadata.projectDirectory,
+        sessionId: metadata.sessionId,
+        messages: metadata.messages,
+        page: metadata.page,
+        selectedIndex: messageIndex,
+      },
+    });
+
+    return true;
+  } catch (error) {
+    logger.error("[Messages] Error handling messages callback:", error);
+    clearMessagesInteraction("messages_callback_error");
+    await ctx.answerCallbackQuery({ text: t("callback.processing_error") }).catch(() => {});
+    return true;
+  }
+}

--- a/src/bot/commands/messages.ts
+++ b/src/bot/commands/messages.ts
@@ -1,12 +1,19 @@
+import type { Bot } from "grammy";
 import { CommandContext, Context, InlineKeyboard } from "grammy";
 import { config } from "../../config.js";
 import type { InteractionState } from "../../interaction/types.js";
 import { interactionManager } from "../../interaction/manager.js";
 import { opencodeClient } from "../../opencode/client.js";
-import { getCurrentSession } from "../../session/manager.js";
+import { getCurrentSession, setCurrentSession, SessionInfo } from "../../session/manager.js";
 import { getCurrentProject } from "../../settings/manager.js";
+import { clearAllInteractionState } from "../../interaction/cleanup.js";
+import { attachToSession } from "../../attach/service.js";
+import { ingestSessionInfoForCache } from "../../session/cache-manager.js";
 import { t } from "../../i18n/index.js";
 import { logger } from "../../utils/logger.js";
+import { safeBackgroundTask } from "../../utils/safe-background-task.js";
+import { renderAssistantFinalPartsSafe } from "../utils/assistant-rendering.js";
+import { sendRenderedBotPart } from "../utils/telegram-text.js";
 
 const MESSAGES_CALLBACK_PREFIX = "messages:";
 const MESSAGES_CALLBACK_SELECT_PREFIX = `${MESSAGES_CALLBACK_PREFIX}select:`;
@@ -17,6 +24,12 @@ const MESSAGES_CALLBACK_BACK = `${MESSAGES_CALLBACK_PREFIX}back`;
 const MESSAGES_CALLBACK_CANCEL = `${MESSAGES_CALLBACK_PREFIX}cancel`;
 const MAX_INLINE_BUTTON_LABEL_LENGTH = 64;
 const TELEGRAM_MESSAGE_LIMIT = 4096;
+const LATEST_ASSISTANT_RESPONSE_MESSAGES_LIMIT = 20;
+
+export interface MessagesCallbackDeps {
+  bot: Bot<Context>;
+  ensureEventSubscription: (directory: string) => Promise<void>;
+}
 
 interface UserMessageItem {
   id: string;
@@ -345,6 +358,76 @@ async function loadUserMessages(sessionId: string, directory: string): Promise<U
   return messages;
 }
 
+async function loadLatestAssistantResponse(
+  sessionId: string,
+  directory: string,
+): Promise<string | null> {
+  try {
+    const { data: messages, error } = await opencodeClient.session.messages({
+      sessionID: sessionId,
+      directory,
+      limit: LATEST_ASSISTANT_RESPONSE_MESSAGES_LIMIT,
+    });
+
+    if (error || !messages) {
+      logger.warn("[Messages] Failed to fetch latest assistant response:", error);
+      return null;
+    }
+
+    const latestResponse = (messages as SessionMessageLike[]).reduce<{
+      text: string;
+      created: number;
+    } | null>((latest, message) => {
+      if (message.info.role !== "assistant") {
+        return latest;
+      }
+
+      const assistantInfo = message.info as { summary?: boolean };
+      if (assistantInfo.summary) {
+        return latest;
+      }
+
+      const text = extractTextParts(message.parts);
+      if (!text) {
+        return latest;
+      }
+
+      const created = message.info.time?.created ?? 0;
+      if (!latest || created >= latest.created) {
+        return { text, created };
+      }
+
+      return latest;
+    }, null);
+
+    return latestResponse?.text ?? null;
+  } catch (err) {
+    logger.error("[Messages] Error loading latest assistant response:", err);
+    return null;
+  }
+}
+
+async function sendLatestAssistantResponse(
+  api: Context["api"],
+  chatId: number,
+  sessionId: string,
+  directory: string,
+): Promise<void> {
+  const responseText = await loadLatestAssistantResponse(sessionId, directory);
+  if (!responseText) {
+    return;
+  }
+
+  const parts = renderAssistantFinalPartsSafe(responseText, TELEGRAM_MESSAGE_LIMIT);
+  for (const part of parts) {
+    await sendRenderedBotPart({
+      api,
+      chatId,
+      part,
+    });
+  }
+}
+
 function parseSelectIndex(data: string): number | null {
   if (!data.startsWith(MESSAGES_CALLBACK_SELECT_PREFIX)) {
     return null;
@@ -410,7 +493,10 @@ export async function messagesCommand(ctx: CommandContext<Context>): Promise<voi
   }
 }
 
-export async function handleMessagesCallback(ctx: Context): Promise<boolean> {
+export async function handleMessagesCallback(
+  ctx: Context,
+  deps: MessagesCallbackDeps,
+): Promise<boolean> {
   const data = ctx.callbackQuery?.data;
   if (!data || !data.startsWith(MESSAGES_CALLBACK_PREFIX)) {
     return false;
@@ -461,7 +547,73 @@ export async function handleMessagesCallback(ctx: Context): Promise<boolean> {
     }
 
     if (data === MESSAGES_CALLBACK_FORK) {
+      if (metadata.stage !== "detail") {
+        await ctx.answerCallbackQuery({ text: t("messages.inactive_callback"), show_alert: true });
+        return true;
+      }
+
+      const selectedMessage = metadata.messages[metadata.selectedIndex];
+      if (!selectedMessage) {
+        await ctx.answerCallbackQuery({ text: t("messages.fetch_error"), show_alert: true });
+        return true;
+      }
+
       await ctx.answerCallbackQuery();
+
+      try {
+        const { data: forkedSession, error: forkError } = await opencodeClient.session.fork({
+          sessionID: metadata.sessionId,
+          messageID: selectedMessage.id,
+          directory: metadata.projectDirectory,
+        });
+
+        if (forkError || !forkedSession) {
+          throw forkError || new Error("No session data received from fork");
+        }
+
+        logger.info(
+          `[Messages] Forked session: id=${forkedSession.id}, title="${forkedSession.title}", from message=${selectedMessage.id}`,
+        );
+
+        const sessionInfo: SessionInfo = {
+          id: forkedSession.id,
+          title: forkedSession.title,
+          directory: metadata.projectDirectory,
+        };
+
+        setCurrentSession(sessionInfo);
+        clearAllInteractionState("session_forked");
+        await ingestSessionInfoForCache(forkedSession);
+
+        await attachToSession({
+          bot: deps.bot,
+          chatId: ctx.chat!.id,
+          session: sessionInfo,
+          ensureEventSubscription: deps.ensureEventSubscription,
+        });
+
+        const successText = t("messages.fork_success", { text: selectedMessage.text });
+        await ctx.editMessageText(truncateText(successText, TELEGRAM_MESSAGE_LIMIT), {
+          reply_markup: undefined,
+        });
+        clearMessagesInteraction("messages_fork_success");
+
+        safeBackgroundTask({
+          taskName: "messages.sendLatestAssistantResponse",
+          task: () =>
+            sendLatestAssistantResponse(
+              ctx.api,
+              ctx.chat!.id,
+              forkedSession.id,
+              metadata.projectDirectory,
+            ),
+        });
+      } catch (error) {
+        logger.error("[Messages] Error forking session:", error);
+        await ctx.editMessageText(t("messages.fork_error"), { reply_markup: undefined });
+        clearMessagesInteraction("messages_fork_error");
+      }
+
       return true;
     }
 

--- a/src/bot/commands/messages.ts
+++ b/src/bot/commands/messages.ts
@@ -305,7 +305,15 @@ async function loadUserMessages(sessionId: string, directory: string): Promise<U
     throw error || new Error("No message data received");
   }
 
-  return (data as SessionMessageLike[])
+  // Get session info to check for revert
+  const { data: sessionData } = await opencodeClient.session.get({
+    sessionID: sessionId,
+    directory,
+  });
+
+  const revertMessageID = sessionData?.revert?.messageID;
+
+  const messages = (data as SessionMessageLike[])
     .map((message) => {
       if (message.info.role !== "user") {
         return null;
@@ -324,6 +332,17 @@ async function loadUserMessages(sessionId: string, directory: string): Promise<U
     })
     .filter((message): message is UserMessageItem => Boolean(message))
     .sort((a, b) => b.created - a.created);
+
+  // If there's a revert, filter messages to only include those before the revert point
+  // Messages are sorted newest first, so we need to skip the revert message and everything after it
+  if (revertMessageID) {
+    const revertIndex = messages.findIndex((msg) => msg.id === revertMessageID);
+    if (revertIndex !== -1) {
+      return messages.slice(revertIndex + 1);
+    }
+  }
+
+  return messages;
 }
 
 function parseSelectIndex(data: string): number | null {
@@ -406,7 +425,42 @@ export async function handleMessagesCallback(ctx: Context): Promise<boolean> {
   }
 
   try {
-    if (data === MESSAGES_CALLBACK_REVERT || data === MESSAGES_CALLBACK_FORK) {
+    if (data === MESSAGES_CALLBACK_REVERT) {
+      if (metadata.stage !== "detail") {
+        await ctx.answerCallbackQuery({ text: t("messages.inactive_callback"), show_alert: true });
+        return true;
+      }
+
+      const selectedMessage = metadata.messages[metadata.selectedIndex];
+      if (!selectedMessage) {
+        await ctx.answerCallbackQuery({ text: t("messages.fetch_error"), show_alert: true });
+        return true;
+      }
+
+      await ctx.answerCallbackQuery();
+
+      try {
+        await opencodeClient.session.revert({
+          sessionID: metadata.sessionId,
+          directory: metadata.projectDirectory,
+          messageID: selectedMessage.id,
+        });
+
+        const successText = t("messages.revert_success", { text: selectedMessage.text });
+        await ctx.editMessageText(truncateText(successText, TELEGRAM_MESSAGE_LIMIT), {
+          reply_markup: undefined,
+        });
+        clearMessagesInteraction("messages_revert_success");
+      } catch (error) {
+        logger.error("[Messages] Error reverting message:", error);
+        await ctx.editMessageText(t("messages.revert_error"), { reply_markup: undefined });
+        clearMessagesInteraction("messages_revert_error");
+      }
+
+      return true;
+    }
+
+    if (data === MESSAGES_CALLBACK_FORK) {
       await ctx.answerCallbackQuery();
       return true;
     }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -38,6 +38,7 @@ import {
   handleCommandsCallback,
   handleCommandTextArguments,
 } from "./commands/commands.js";
+import { handleMessagesCallback, messagesCommand } from "./commands/messages.js";
 import {
   skillsCommand,
   handleSkillsCallback,
@@ -1177,6 +1178,7 @@ export function createBot(): Bot<Context> {
   bot.command("open", openCommand);
   bot.command("ls", lsCommand);
   bot.command("sessions", sessionsCommand);
+  bot.command("messages", messagesCommand);
   bot.command("new", (ctx) => newCommand(ctx, { bot, ensureEventSubscription }));
   bot.command("abort", abortCommand);
   bot.command("detach", detachCommand);
@@ -1226,11 +1228,12 @@ export function createBot(): Bot<Context> {
       const handledTaskList = await handleTaskListCallback(ctx);
       const handledRenameCancel = await handleRenameCancel(ctx);
       const handledCommands = await handleCommandsCallback(ctx, { bot, ensureEventSubscription });
+      const handledMessages = await handleMessagesCallback(ctx);
       const handledSkills = await handleSkillsCallback(ctx, { bot, ensureEventSubscription });
       const handledMcps = await handleMcpsCallback(ctx);
 
       logger.debug(
-        `[Bot] Callback handled: backgroundSession=${handledBackgroundSession}, inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, ls=${handledLs}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, modelSearch=${handledModelSearch}, modelSearchResults=${handledModelSearchResults}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, skills=${handledSkills}, mcps=${handledMcps}`,
+        `[Bot] Callback handled: backgroundSession=${handledBackgroundSession}, inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, ls=${handledLs}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, modelSearch=${handledModelSearch}, modelSearchResults=${handledModelSearchResults}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, messages=${handledMessages}, skills=${handledSkills}, mcps=${handledMcps}`,
       );
 
       if (
@@ -1253,6 +1256,7 @@ export function createBot(): Bot<Context> {
         !handledTaskList &&
         !handledRenameCancel &&
         !handledCommands &&
+        !handledMessages &&
         !handledSkills &&
         !handledMcps
       ) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1228,7 +1228,7 @@ export function createBot(): Bot<Context> {
       const handledTaskList = await handleTaskListCallback(ctx);
       const handledRenameCancel = await handleRenameCancel(ctx);
       const handledCommands = await handleCommandsCallback(ctx, { bot, ensureEventSubscription });
-      const handledMessages = await handleMessagesCallback(ctx);
+      const handledMessages = await handleMessagesCallback(ctx, { bot, ensureEventSubscription });
       const handledSkills = await handleSkillsCallback(ctx, { bot, ensureEventSubscription });
       const handledMcps = await handleMcpsCallback(ctx);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -150,6 +150,7 @@ export const config = {
   },
   bot: {
     sessionsListLimit: getOptionalPositiveIntEnvVar("SESSIONS_LIST_LIMIT", 10),
+    messagesListLimit: getOptionalPositiveIntEnvVar("MESSAGES_LIST_LIMIT", 10),
     projectsListLimit: getOptionalPositiveIntEnvVar("PROJECTS_LIST_LIMIT", 10),
     commandsListLimit: getOptionalPositiveIntEnvVar("COMMANDS_LIST_LIMIT", 10),
     taskLimit: getOptionalPositiveIntEnvVar("TASK_LIMIT", 10),

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,6 +6,7 @@ export const de: I18nDictionary = {
   "cmd.description.stop": "Aktuelle Aktion stoppen",
   "cmd.description.detach": "Von aktueller Sitzung trennen",
   "cmd.description.sessions": "Sitzungen auflisten",
+  "cmd.description.messages": "Sitzungsnachrichten durchsuchen",
   "cmd.description.tts": "Audioantworten umschalten",
   "cmd.description.projects": "Projekte auflisten",
   "cmd.description.worktree": "Git-Worktrees wechseln",
@@ -171,6 +172,27 @@ export const de: I18nDictionary = {
   "sessions.preview.title": "Letzte Nachrichten:",
   "sessions.preview.you": "Du:",
   "sessions.preview.agent": "Agent:",
+
+  "messages.project_not_selected":
+    "🏗 Kein Projekt ausgewählt.\n\nWähle zuerst ein Projekt mit /projects.",
+  "messages.session_not_selected":
+    "💬 Keine Sitzung ausgewählt.\n\nWähle zuerst eine Sitzung mit /sessions oder erstelle eine mit /new.",
+  "messages.session_project_mismatch":
+    "⚠️ Die ausgewählte Sitzung passt nicht zum aktuellen Projekt. Wähle die Sitzung erneut über /sessions.",
+  "messages.empty": "📭 Keine Benutzernachrichten in der aktuellen Sitzung.",
+  "messages.select": "Wähle eine Nachricht:",
+  "messages.select_page": "Wähle eine Nachricht (Seite {page}):",
+  "messages.fetch_error":
+    "🔴 OpenCode Server ist nicht erreichbar oder beim Laden der Nachrichten ist ein Fehler aufgetreten.",
+  "messages.inactive_callback": "Dieses Nachrichtenmenü ist nicht mehr aktiv",
+  "messages.cancelled_callback": "Abgebrochen",
+  "messages.page_empty_callback": "Keine Nachrichten auf dieser Seite",
+  "messages.button.prev_page": "⬅️ Zurück",
+  "messages.button.next_page": "Weiter ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ Zurück",
+  "messages.button.cancel": "❌ Abbrechen",
 
   "attach.project_not_selected":
     "🏗 Projekt ist nicht ausgewählt.\n\nWähle zuerst ein Projekt mit /projects.",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -193,6 +193,8 @@ export const de: I18nDictionary = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ Zurück",
   "messages.button.cancel": "❌ Abbrechen",
+  "messages.revert_success": "✅ Zurück zur Nachricht:\n\n{text}",
+  "messages.revert_error": "❌ Nachricht konnte nicht zurückgesetzt werden. Bitte versuche es erneut.",
 
   "attach.project_not_selected":
     "🏗 Projekt ist nicht ausgewählt.\n\nWähle zuerst ein Projekt mit /projects.",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -195,6 +195,8 @@ export const de: I18nDictionary = {
   "messages.button.cancel": "❌ Abbrechen",
   "messages.revert_success": "✅ Zurück zur Nachricht:\n\n{text}",
   "messages.revert_error": "❌ Nachricht konnte nicht zurückgesetzt werden. Bitte versuche es erneut.",
+  "messages.fork_success": "🔀 Fork erstellt von Nachricht:\n\n{text}",
+  "messages.fork_error": "❌ Fork konnte nicht erstellt werden. Bitte versuche es erneut.",
 
   "attach.project_not_selected":
     "🏗 Projekt ist nicht ausgewählt.\n\nWähle zuerst ein Projekt mit /projects.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,6 +4,7 @@ export const en = {
   "cmd.description.stop": "Stop current action",
   "cmd.description.detach": "Detach from current session",
   "cmd.description.sessions": "List sessions",
+  "cmd.description.messages": "Browse session messages",
   "cmd.description.tts": "Toggle audio replies",
   "cmd.description.projects": "List projects",
   "cmd.description.worktree": "Switch git worktrees",
@@ -163,6 +164,27 @@ export const en = {
   "sessions.preview.title": "Recent messages:",
   "sessions.preview.you": "You:",
   "sessions.preview.agent": "Agent:",
+
+  "messages.project_not_selected":
+    "🏗 Project is not selected.\n\nFirst select a project with /projects.",
+  "messages.session_not_selected":
+    "💬 Session is not selected.\n\nFirst choose a session with /sessions or create one with /new.",
+  "messages.session_project_mismatch":
+    "⚠️ The selected session does not match the current project. Choose the session again via /sessions.",
+  "messages.empty": "📭 No user messages in the current session.",
+  "messages.select": "Choose a message:",
+  "messages.select_page": "Choose a message (page {page}):",
+  "messages.fetch_error":
+    "🔴 OpenCode Server is unavailable or an error occurred while loading messages.",
+  "messages.inactive_callback": "This messages menu is inactive",
+  "messages.cancelled_callback": "Cancelled",
+  "messages.page_empty_callback": "No messages on this page",
+  "messages.button.prev_page": "⬅️ Prev",
+  "messages.button.next_page": "Next ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ Back",
+  "messages.button.cancel": "❌ Cancel",
 
   "attach.project_not_selected":
     "🏗 Project is not selected.\n\nFirst select a project with /projects.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -185,6 +185,8 @@ export const en = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ Back",
   "messages.button.cancel": "❌ Cancel",
+  "messages.revert_success": "✅ Reverted to message:\n\n{text}",
+  "messages.revert_error": "❌ Failed to revert message. Please try again.",
 
   "attach.project_not_selected":
     "🏗 Project is not selected.\n\nFirst select a project with /projects.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -187,6 +187,8 @@ export const en = {
   "messages.button.cancel": "❌ Cancel",
   "messages.revert_success": "✅ Reverted to message:\n\n{text}",
   "messages.revert_error": "❌ Failed to revert message. Please try again.",
+  "messages.fork_success": "🔀 Fork created from message:\n\n{text}",
+  "messages.fork_error": "❌ Failed to create fork. Please try again.",
 
   "attach.project_not_selected":
     "🏗 Project is not selected.\n\nFirst select a project with /projects.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -6,6 +6,7 @@ export const es: I18nDictionary = {
   "cmd.description.stop": "Detener la acción actual",
   "cmd.description.detach": "Desconectar de la sesión actual",
   "cmd.description.sessions": "Listar sesiones",
+  "cmd.description.messages": "Ver mensajes de la sesión",
   "cmd.description.tts": "Alternar respuestas de audio",
   "cmd.description.projects": "Listar proyectos",
   "cmd.description.worktree": "Cambiar worktrees de git",
@@ -170,6 +171,27 @@ export const es: I18nDictionary = {
   "sessions.preview.title": "Mensajes recientes:",
   "sessions.preview.you": "Tú:",
   "sessions.preview.agent": "Agente:",
+
+  "messages.project_not_selected":
+    "🏗 No hay ningún proyecto seleccionado.\n\nPrimero selecciona un proyecto con /projects.",
+  "messages.session_not_selected":
+    "💬 No hay ninguna sesión seleccionada.\n\nPrimero elige una sesión con /sessions o crea una con /new.",
+  "messages.session_project_mismatch":
+    "⚠️ La sesión seleccionada no coincide con el proyecto actual. Vuelve a elegir la sesión con /sessions.",
+  "messages.empty": "📭 No hay mensajes de usuario en la sesión actual.",
+  "messages.select": "Elige un mensaje:",
+  "messages.select_page": "Elige un mensaje (página {page}):",
+  "messages.fetch_error":
+    "🔴 OpenCode Server no está disponible o se produjo un error al cargar los mensajes.",
+  "messages.inactive_callback": "Este menú de mensajes ya no está activo",
+  "messages.cancelled_callback": "Cancelado",
+  "messages.page_empty_callback": "No hay mensajes en esta página",
+  "messages.button.prev_page": "⬅️ Anterior",
+  "messages.button.next_page": "Siguiente ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ Volver",
+  "messages.button.cancel": "❌ Cancelar",
 
   "attach.project_not_selected":
     "🏗 No hay un proyecto seleccionado.\n\nPrimero selecciona un proyecto con /projects.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -192,6 +192,8 @@ export const es: I18nDictionary = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ Volver",
   "messages.button.cancel": "❌ Cancelar",
+  "messages.revert_success": "✅ Revertido al mensaje:\n\n{text}",
+  "messages.revert_error": "❌ No se pudo revertir el mensaje. Inténtalo de nuevo.",
 
   "attach.project_not_selected":
     "🏗 No hay un proyecto seleccionado.\n\nPrimero selecciona un proyecto con /projects.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -194,6 +194,8 @@ export const es: I18nDictionary = {
   "messages.button.cancel": "❌ Cancelar",
   "messages.revert_success": "✅ Revertido al mensaje:\n\n{text}",
   "messages.revert_error": "❌ No se pudo revertir el mensaje. Inténtalo de nuevo.",
+  "messages.fork_success": "🔀 Fork creado desde el mensaje:\n\n{text}",
+  "messages.fork_error": "❌ No se pudo crear el fork. Inténtalo de nuevo.",
 
   "attach.project_not_selected":
     "🏗 No hay un proyecto seleccionado.\n\nPrimero selecciona un proyecto con /projects.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -6,6 +6,7 @@ export const fr: I18nDictionary = {
   "cmd.description.stop": "Arrêter l'action en cours",
   "cmd.description.detach": "Se détacher de la session actuelle",
   "cmd.description.sessions": "Lister les sessions",
+  "cmd.description.messages": "Parcourir les messages de session",
   "cmd.description.tts": "Basculer les réponses audio",
   "cmd.description.projects": "Lister les projets",
   "cmd.description.worktree": "Changer de worktree git",
@@ -172,6 +173,27 @@ export const fr: I18nDictionary = {
   "sessions.preview.title": "Messages récents :",
   "sessions.preview.you": "Vous :",
   "sessions.preview.agent": "Agent :",
+
+  "messages.project_not_selected":
+    "🏗 Aucun projet sélectionné.\n\nSélectionnez d'abord un projet avec /projects.",
+  "messages.session_not_selected":
+    "💬 Aucune session sélectionnée.\n\nChoisissez d'abord une session avec /sessions ou créez-en une avec /new.",
+  "messages.session_project_mismatch":
+    "⚠️ La session sélectionnée ne correspond pas au projet actuel. Choisissez à nouveau la session via /sessions.",
+  "messages.empty": "📭 Aucun message utilisateur dans la session actuelle.",
+  "messages.select": "Choisissez un message :",
+  "messages.select_page": "Choisissez un message (page {page}) :",
+  "messages.fetch_error":
+    "🔴 OpenCode Server est indisponible ou une erreur est survenue pendant le chargement des messages.",
+  "messages.inactive_callback": "Ce menu de messages est inactif",
+  "messages.cancelled_callback": "Annulé",
+  "messages.page_empty_callback": "Aucun message sur cette page",
+  "messages.button.prev_page": "⬅️ Précédent",
+  "messages.button.next_page": "Suivant ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ Retour",
+  "messages.button.cancel": "❌ Annuler",
 
   "attach.project_not_selected":
     "🏗 Aucun projet sélectionné.\n\nSélectionnez d'abord un projet avec /projects.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -194,6 +194,8 @@ export const fr: I18nDictionary = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ Retour",
   "messages.button.cancel": "❌ Annuler",
+  "messages.revert_success": "✅ Retour au message :\n\n{text}",
+  "messages.revert_error": "❌ Impossible de revenir au message. Veuillez réessayer.",
 
   "attach.project_not_selected":
     "🏗 Aucun projet sélectionné.\n\nSélectionnez d'abord un projet avec /projects.",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -196,6 +196,8 @@ export const fr: I18nDictionary = {
   "messages.button.cancel": "❌ Annuler",
   "messages.revert_success": "✅ Retour au message :\n\n{text}",
   "messages.revert_error": "❌ Impossible de revenir au message. Veuillez réessayer.",
+  "messages.fork_success": "🔀 Fork créé à partir du message :\n\n{text}",
+  "messages.fork_error": "❌ Échec de la création du fork. Veuillez réessayer.",
 
   "attach.project_not_selected":
     "🏗 Aucun projet sélectionné.\n\nSélectionnez d'abord un projet avec /projects.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -6,6 +6,7 @@ export const ru: I18nDictionary = {
   "cmd.description.stop": "Прервать текущее действие",
   "cmd.description.detach": "Отсоединиться от текущей сессии",
   "cmd.description.sessions": "Список сессий",
+  "cmd.description.messages": "Сообщения текущей сессии",
   "cmd.description.tts": "Переключить аудиоответы",
   "cmd.description.projects": "Список проектов",
   "cmd.description.worktree": "Переключить git worktree",
@@ -163,6 +164,27 @@ export const ru: I18nDictionary = {
   "sessions.preview.title": "Последние сообщения:",
   "sessions.preview.you": "Вы:",
   "sessions.preview.agent": "Агент:",
+
+  "messages.project_not_selected":
+    "🏗 Проект не выбран.\n\nСначала выберите проект командой /projects.",
+  "messages.session_not_selected":
+    "💬 Сессия не выбрана.\n\nСначала выберите сессию через /sessions или создайте новую через /new.",
+  "messages.session_project_mismatch":
+    "⚠️ Выбранная сессия не соответствует текущему проекту. Повторно выберите сессию через /sessions.",
+  "messages.empty": "📭 В текущей сессии нет сообщений пользователя.",
+  "messages.select": "Выберите сообщение:",
+  "messages.select_page": "Выберите сообщение (страница {page}):",
+  "messages.fetch_error":
+    "🔴 OpenCode Server недоступен или произошла ошибка при получении списка сообщений.",
+  "messages.inactive_callback": "Это меню сообщений уже неактивно",
+  "messages.cancelled_callback": "Отменено",
+  "messages.page_empty_callback": "На этой странице нет сообщений",
+  "messages.button.prev_page": "⬅️ Назад",
+  "messages.button.next_page": "Вперёд ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ Назад",
+  "messages.button.cancel": "❌ Отмена",
 
   "attach.project_not_selected":
     "🏗 Проект не выбран.\n\nСначала выберите проект командой /projects.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -185,6 +185,8 @@ export const ru: I18nDictionary = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ Назад",
   "messages.button.cancel": "❌ Отмена",
+  "messages.revert_success": "✅ Откатили до сообщения:\n\n{text}",
+  "messages.revert_error": "❌ Не удалось откатить сообщение. Попробуйте ещё раз.",
 
   "attach.project_not_selected":
     "🏗 Проект не выбран.\n\nСначала выберите проект командой /projects.",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -187,6 +187,8 @@ export const ru: I18nDictionary = {
   "messages.button.cancel": "❌ Отмена",
   "messages.revert_success": "✅ Откатили до сообщения:\n\n{text}",
   "messages.revert_error": "❌ Не удалось откатить сообщение. Попробуйте ещё раз.",
+  "messages.fork_success": "🔀 Создан форк от сообщения:\n\n{text}",
+  "messages.fork_error": "❌ Не удалось создать форк. Попробуйте ещё раз.",
 
   "attach.project_not_selected":
     "🏗 Проект не выбран.\n\nСначала выберите проект командой /projects.",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -6,6 +6,7 @@ export const zh: I18nDictionary = {
   "cmd.description.stop": "停止当前操作",
   "cmd.description.detach": "从当前会话分离",
   "cmd.description.sessions": "列出会话",
+  "cmd.description.messages": "浏览会话消息",
   "cmd.description.tts": "切换语音回复",
   "cmd.description.projects": "列出项目",
   "cmd.description.worktree": "切换 git worktree",
@@ -146,6 +147,25 @@ export const zh: I18nDictionary = {
   "sessions.preview.title": "最近消息：",
   "sessions.preview.you": "你：",
   "sessions.preview.agent": "代理：",
+
+  "messages.project_not_selected": "🏗 未选择项目。\n\n请先使用 /projects 选择项目。",
+  "messages.session_not_selected":
+    "💬 未选择会话。\n\n请先使用 /sessions 选择会话，或使用 /new 创建会话。",
+  "messages.session_project_mismatch":
+    "⚠️ 所选会话与当前项目不匹配。请通过 /sessions 重新选择会话。",
+  "messages.empty": "📭 当前会话中没有用户消息。",
+  "messages.select": "选择一条消息：",
+  "messages.select_page": "选择一条消息（第 {page} 页）：",
+  "messages.fetch_error": "🔴 OpenCode Server 不可用，或加载消息时发生错误。",
+  "messages.inactive_callback": "此消息菜单已失效",
+  "messages.cancelled_callback": "已取消",
+  "messages.page_empty_callback": "此页面没有消息",
+  "messages.button.prev_page": "⬅️ 上一页",
+  "messages.button.next_page": "下一页 ➡️",
+  "messages.button.revert": "↩️ Revert",
+  "messages.button.fork": "🔀 Fork",
+  "messages.button.back": "⬅️ 返回",
+  "messages.button.cancel": "❌ 取消",
 
   "attach.project_not_selected": "🏗 未选择项目。\n\n请先使用 /projects 选择一个项目。",
   "attach.session_not_selected": "💬 未选择会话。\n\n请先使用 /sessions 选择一个会话。",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -168,6 +168,8 @@ export const zh: I18nDictionary = {
   "messages.button.cancel": "❌ 取消",
   "messages.revert_success": "✅ 已恢复到消息：\n\n{text}",
   "messages.revert_error": "❌ 无法恢复消息。请重试。",
+  "messages.fork_success": "🔀 从消息创建分支：\n\n{text}",
+  "messages.fork_error": "❌ 创建分支失败。请重试。",
 
   "attach.project_not_selected": "🏗 未选择项目。\n\n请先使用 /projects 选择一个项目。",
   "attach.session_not_selected": "💬 未选择会话。\n\n请先使用 /sessions 选择一个会话。",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -166,6 +166,8 @@ export const zh: I18nDictionary = {
   "messages.button.fork": "🔀 Fork",
   "messages.button.back": "⬅️ 返回",
   "messages.button.cancel": "❌ 取消",
+  "messages.revert_success": "✅ 已恢复到消息：\n\n{text}",
+  "messages.revert_error": "❌ 无法恢复消息。请重试。",
 
   "attach.project_not_selected": "🏗 未选择项目。\n\n请先使用 /projects 选择一个项目。",
   "attach.session_not_selected": "💬 未选择会话。\n\n请先使用 /sessions 选择一个会话。",

--- a/tests/bot/commands/messages.test.ts
+++ b/tests/bot/commands/messages.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+import {
+  calculateMessagesPaginationRange,
+  handleMessagesCallback,
+  messagesCommand,
+  parseMessagePageCallback,
+} from "../../../src/bot/commands/messages.js";
+import { interactionManager } from "../../../src/interaction/manager.js";
+import { t } from "../../../src/i18n/index.js";
+
+const mocked = vi.hoisted(() => ({
+  currentProject: {
+    id: "project-1",
+    worktree: "D:\\Projects\\Repo",
+  } as { id: string; worktree: string } | null,
+  currentSession: {
+    id: "session-1",
+    title: "Session",
+    directory: "D:\\Projects\\Repo",
+  } as { id: string; title: string; directory: string } | null,
+  sessionMessagesMock: vi.fn(),
+}));
+
+vi.mock("../../../src/settings/manager.js", () => ({
+  getCurrentProject: vi.fn(() => mocked.currentProject),
+}));
+
+vi.mock("../../../src/session/manager.js", () => ({
+  getCurrentSession: vi.fn(() => mocked.currentSession),
+}));
+
+vi.mock("../../../src/opencode/client.js", () => ({
+  opencodeClient: {
+    session: {
+      messages: mocked.sessionMessagesMock,
+    },
+  },
+}));
+
+function createCommandContext(messageId: number): Context {
+  return {
+    chat: { id: 777 },
+    reply: vi.fn().mockResolvedValue({ message_id: messageId }),
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Context;
+}
+
+function createCallbackContext(data: string, messageId: number): Context {
+  return {
+    chat: { id: 777 },
+    callbackQuery: {
+      data,
+      message: {
+        message_id: messageId,
+      },
+    } as Context["callbackQuery"],
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Context;
+}
+
+function makeUserMessage(id: string, text: string, created: number) {
+  return {
+    info: {
+      id,
+      role: "user",
+      time: { created },
+    },
+    parts: [{ type: "text", text }],
+  };
+}
+
+describe("bot/commands/messages", () => {
+  beforeEach(() => {
+    interactionManager.clear("test_setup");
+
+    mocked.currentProject = {
+      id: "project-1",
+      worktree: "D:\\Projects\\Repo",
+    };
+    mocked.currentSession = {
+      id: "session-1",
+      title: "Session",
+      directory: "D:\\Projects\\Repo",
+    };
+    mocked.sessionMessagesMock.mockReset();
+  });
+
+  it("asks to select project when project is missing", async () => {
+    mocked.currentProject = null;
+
+    const ctx = createCommandContext(100);
+    await messagesCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(t("messages.project_not_selected"));
+    expect(mocked.sessionMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("asks to select session when session is missing", async () => {
+    mocked.currentSession = null;
+
+    const ctx = createCommandContext(101);
+    await messagesCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(t("messages.session_not_selected"));
+    expect(mocked.sessionMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("does not load messages when session belongs to another project", async () => {
+    mocked.currentSession = {
+      id: "session-2",
+      title: "Other",
+      directory: "D:\\Projects\\Other",
+    };
+
+    const ctx = createCommandContext(102);
+    await messagesCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(t("messages.session_project_mismatch"));
+    expect(mocked.sessionMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("shows user messages newest first and starts custom interaction", async () => {
+    const oldTime = new Date(2026, 4, 30, 10, 3).getTime();
+    const newTime = new Date(2026, 4, 30, 14, 5).getTime();
+    mocked.sessionMessagesMock.mockResolvedValue({
+      data: [
+        makeUserMessage("old", "older prompt", oldTime),
+        {
+          info: { id: "assistant-1", role: "assistant", time: { created: newTime + 1 } },
+          parts: [{ type: "text", text: "assistant reply" }],
+        },
+        makeUserMessage("empty", "", newTime + 2),
+        makeUserMessage("new", "newer prompt with\nline break", newTime),
+      ],
+      error: null,
+    });
+
+    const ctx = createCommandContext(200);
+    await messagesCommand(ctx as never);
+
+    expect(mocked.sessionMessagesMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      directory: "D:\\Projects\\Repo",
+    });
+
+    const [, options] = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string; text: string }>> } },
+    ];
+
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe("messages:select:0");
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.text).toContain("[14:05] newer prompt with line break");
+    expect(options.reply_markup.inline_keyboard[1]?.[0]?.callback_data).toBe("messages:select:1");
+    expect(options.reply_markup.inline_keyboard[1]?.[0]?.text).toContain("[10:03] older prompt");
+    expect(options.reply_markup.inline_keyboard[2]?.[0]?.callback_data).toBe("messages:cancel");
+
+    const state = interactionManager.getSnapshot();
+    expect(state?.kind).toBe("custom");
+    expect(state?.expectedInput).toBe("callback");
+    expect(state?.metadata.flow).toBe("messages");
+    expect(state?.metadata.stage).toBe("list");
+    expect(state?.metadata.messageId).toBe(200);
+    expect(state?.metadata.messages).toEqual([
+      { id: "new", text: "newer prompt with\nline break", created: newTime },
+      { id: "old", text: "older prompt", created: oldTime },
+    ]);
+  });
+
+  it("shows empty state when there are no user messages", async () => {
+    mocked.sessionMessagesMock.mockResolvedValue({
+      data: [
+        {
+          info: { id: "assistant-1", role: "assistant", time: { created: 1 } },
+          parts: [{ type: "text", text: "assistant reply" }],
+        },
+      ],
+      error: null,
+    });
+
+    const ctx = createCommandContext(201);
+    await messagesCommand(ctx as never);
+
+    expect(ctx.reply).toHaveBeenCalledWith(t("messages.empty"));
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("handles pagination callbacks", async () => {
+    const messages = Array.from({ length: 12 }, (_, index) => ({
+      id: `msg-${index + 1}`,
+      text: `message ${index + 1}`,
+      created: new Date(2026, 4, 30, 12, index).getTime(),
+    }));
+
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 300,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:page:1", 300);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    const [text, options] = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string; text: string }>> } },
+    ];
+    expect(text).toBe(t("messages.select_page", { page: 2 }));
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe("messages:select:10");
+    expect(options.reply_markup.inline_keyboard[2]?.[0]?.callback_data).toBe("messages:page:0");
+    expect(interactionManager.getSnapshot()?.metadata.page).toBe(1);
+  });
+
+  it("opens full message and provides placeholder actions", async () => {
+    const created = new Date(2026, 4, 30, 9, 8).getTime();
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 400,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages: [{ id: "msg-1", text: "full prompt text", created }],
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:select:0", 400);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    const [text, options] = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string; text: string }>> } },
+    ];
+    expect(text).toBe("[09:08]\n\nfull prompt text");
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe("messages:revert");
+    expect(options.reply_markup.inline_keyboard[1]?.[0]?.callback_data).toBe("messages:fork");
+    expect(options.reply_markup.inline_keyboard[2]?.[0]?.callback_data).toBe("messages:back");
+    expect(options.reply_markup.inline_keyboard[2]?.[1]?.callback_data).toBe("messages:cancel");
+    expect(interactionManager.getSnapshot()?.metadata.stage).toBe("detail");
+  });
+
+  it("returns to list from message detail on back", async () => {
+    const messages = [{ id: "msg-1", text: "full prompt text", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 500,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:back", 500);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.editMessageText).toHaveBeenCalledWith(
+      t("messages.select"),
+      expect.objectContaining({ reply_markup: expect.any(Object) }),
+    );
+    expect(interactionManager.getSnapshot()?.metadata.stage).toBe("list");
+  });
+
+  it("closes menu on cancel from detail", async () => {
+    const messages = [{ id: "msg-1", text: "full prompt text", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 500,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:cancel", 500);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+      text: t("messages.cancelled_callback"),
+    });
+    expect(ctx.deleteMessage).toHaveBeenCalledTimes(1);
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("closes menu on cancel from list", async () => {
+    const messages = [{ id: "msg-1", text: "full prompt text", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 501,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:cancel", 501);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+      text: t("messages.cancelled_callback"),
+    });
+    expect(ctx.deleteMessage).toHaveBeenCalledTimes(1);
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("keeps detail screen unchanged for revert and fork placeholders", async () => {
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages: [{ id: "msg-1", text: "text", created: 1000 }],
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:revert", 600);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+    expect(interactionManager.getSnapshot()?.metadata.stage).toBe("detail");
+  });
+
+  it("handles stale callback as inactive", async () => {
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 700,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages: [{ id: "msg-1", text: "text", created: 1000 }],
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:select:0", 999);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+      text: t("messages.inactive_callback"),
+      show_alert: true,
+    });
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+  });
+});
+
+describe("messages pagination helpers", () => {
+  it("parses valid page callbacks", () => {
+    expect(parseMessagePageCallback("messages:page:0")).toBe(0);
+    expect(parseMessagePageCallback("messages:page:12")).toBe(12);
+  });
+
+  it("returns null for non-page callbacks", () => {
+    expect(parseMessagePageCallback("messages:select:0")).toBeNull();
+    expect(parseMessagePageCallback("messages:page:-1")).toBeNull();
+    expect(parseMessagePageCallback("messages:page:abc")).toBeNull();
+  });
+
+  it("calculates pagination bounds", () => {
+    expect(calculateMessagesPaginationRange(25, 1, 10)).toEqual({
+      page: 1,
+      totalPages: 3,
+      startIndex: 10,
+      endIndex: 20,
+    });
+    expect(calculateMessagesPaginationRange(25, 99, 10)).toEqual({
+      page: 2,
+      totalPages: 3,
+      startIndex: 20,
+      endIndex: 25,
+    });
+  });
+});

--- a/tests/bot/commands/messages.test.ts
+++ b/tests/bot/commands/messages.test.ts
@@ -20,6 +20,8 @@ const mocked = vi.hoisted(() => ({
     directory: "D:\\Projects\\Repo",
   } as { id: string; title: string; directory: string } | null,
   sessionMessagesMock: vi.fn(),
+  sessionGetMock: vi.fn(),
+  sessionRevertMock: vi.fn(),
 }));
 
 vi.mock("../../../src/settings/manager.js", () => ({
@@ -34,6 +36,8 @@ vi.mock("../../../src/opencode/client.js", () => ({
   opencodeClient: {
     session: {
       messages: mocked.sessionMessagesMock,
+      get: mocked.sessionGetMock,
+      revert: mocked.sessionRevertMock,
     },
   },
 }));
@@ -87,6 +91,14 @@ describe("bot/commands/messages", () => {
       directory: "D:\\Projects\\Repo",
     };
     mocked.sessionMessagesMock.mockReset();
+    mocked.sessionGetMock.mockReset();
+    mocked.sessionRevertMock.mockReset();
+
+    // Default: session without revert
+    mocked.sessionGetMock.mockResolvedValue({
+      data: { id: "session-1", directory: "D:\\Projects\\Repo" },
+      error: null,
+    });
   });
 
   it("asks to select project when project is missing", async () => {
@@ -185,7 +197,50 @@ describe("bot/commands/messages", () => {
     await messagesCommand(ctx as never);
 
     expect(ctx.reply).toHaveBeenCalledWith(t("messages.empty"));
-    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("filters messages to show only those before revert point", async () => {
+    const time1 = new Date(2026, 4, 30, 10, 0).getTime();
+    const time2 = new Date(2026, 4, 30, 11, 0).getTime();
+    const time3 = new Date(2026, 4, 30, 12, 0).getTime();
+
+    mocked.sessionMessagesMock.mockResolvedValue({
+      data: [
+        makeUserMessage("msg-1", "first message", time1),
+        makeUserMessage("msg-2", "second message", time2),
+        makeUserMessage("msg-3", "third message", time3),
+      ],
+      error: null,
+    });
+
+    // Session has revert to msg-2, so only msg-1 should be shown
+    mocked.sessionGetMock.mockResolvedValue({
+      data: {
+        id: "session-1",
+        directory: "D:\\Projects\\Repo",
+        revert: { messageID: "msg-2" },
+      },
+      error: null,
+    });
+
+    const ctx = createCommandContext(202);
+    await messagesCommand(ctx as never);
+
+    const [, options] = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { reply_markup: { inline_keyboard: Array<Array<{ callback_data?: string; text: string }>> } },
+    ];
+
+    // Should only show msg-1 (before the revert point)
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.callback_data).toBe("messages:select:0");
+    expect(options.reply_markup.inline_keyboard[0]?.[0]?.text).toContain("first message");
+    // msg-2 and msg-3 should not be present
+    expect(options.reply_markup.inline_keyboard[1]?.[0]?.callback_data).toBe("messages:cancel");
+
+    const state = interactionManager.getSnapshot();
+    expect(state?.metadata.messages).toEqual([
+      { id: "msg-1", text: "first message", created: time1 },
+    ]);
   });
 
   it("handles pagination callbacks", async () => {
@@ -338,7 +393,106 @@ describe("bot/commands/messages", () => {
     expect(interactionManager.getSnapshot()).toBeNull();
   });
 
-  it("keeps detail screen unchanged for revert and fork placeholders", async () => {
+  it("reverts message successfully", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    mocked.sessionRevertMock.mockResolvedValue({});
+
+    const ctx = createCallbackContext("messages:revert", 600);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+    expect(mocked.sessionRevertMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      directory: "D:\\Projects\\Repo",
+      messageID: "msg-1",
+    });
+    expect(ctx.editMessageText).toHaveBeenCalledWith(
+      t("messages.revert_success", { text: "test prompt" }),
+      { reply_markup: undefined },
+    );
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("handles revert error", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    mocked.sessionRevertMock.mockRejectedValue(new Error("API error"));
+
+    const ctx = createCallbackContext("messages:revert", 600);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+    expect(mocked.sessionRevertMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      directory: "D:\\Projects\\Repo",
+      messageID: "msg-1",
+    });
+    expect(ctx.editMessageText).toHaveBeenCalledWith(t("messages.revert_error"), {
+      reply_markup: undefined,
+    });
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("rejects revert from list stage", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:revert", 600);
+    const handled = await handleMessagesCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+      text: t("messages.inactive_callback"),
+      show_alert: true,
+    });
+    expect(mocked.sessionRevertMock).not.toHaveBeenCalled();
+    expect(ctx.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("keeps detail screen unchanged for fork placeholder", async () => {
     interactionManager.start({
       kind: "custom",
       expectedInput: "callback",
@@ -354,7 +508,7 @@ describe("bot/commands/messages", () => {
       },
     });
 
-    const ctx = createCallbackContext("messages:revert", 600);
+    const ctx = createCallbackContext("messages:fork", 600);
     const handled = await handleMessagesCallback(ctx);
 
     expect(handled).toBe(true);

--- a/tests/bot/commands/messages.test.ts
+++ b/tests/bot/commands/messages.test.ts
@@ -22,6 +22,10 @@ const mocked = vi.hoisted(() => ({
   sessionMessagesMock: vi.fn(),
   sessionGetMock: vi.fn(),
   sessionRevertMock: vi.fn(),
+  sessionForkMock: vi.fn(),
+  attachToSessionMock: vi.fn(),
+  setCurrentSessionMock: vi.fn(),
+  ingestSessionInfoForCacheMock: vi.fn(),
 }));
 
 vi.mock("../../../src/settings/manager.js", () => ({
@@ -30,6 +34,16 @@ vi.mock("../../../src/settings/manager.js", () => ({
 
 vi.mock("../../../src/session/manager.js", () => ({
   getCurrentSession: vi.fn(() => mocked.currentSession),
+  setCurrentSession: mocked.setCurrentSessionMock,
+}));
+
+vi.mock("../../../src/attach/service.js", () => ({
+  attachToSession: mocked.attachToSessionMock,
+}));
+
+vi.mock("../../../src/session/cache-manager.js", () => ({
+  ingestSessionInfoForCache: mocked.ingestSessionInfoForCacheMock,
+  __resetSessionDirectoryCacheForTests: vi.fn(),
 }));
 
 vi.mock("../../../src/opencode/client.js", () => ({
@@ -38,6 +52,7 @@ vi.mock("../../../src/opencode/client.js", () => ({
       messages: mocked.sessionMessagesMock,
       get: mocked.sessionGetMock,
       revert: mocked.sessionRevertMock,
+      fork: mocked.sessionForkMock,
     },
   },
 }));
@@ -63,8 +78,20 @@ function createCallbackContext(data: string, messageId: number): Context {
     answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
     editMessageText: vi.fn().mockResolvedValue(undefined),
     deleteMessage: vi.fn().mockResolvedValue(undefined),
+    api: {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 999 }),
+    },
   } as unknown as Context;
 }
+
+const testDeps = {
+  bot: {
+    api: {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 999 }),
+    },
+  },
+  ensureEventSubscription: vi.fn().mockResolvedValue(undefined),
+};
 
 function makeUserMessage(id: string, text: string, created: number) {
   return {
@@ -93,6 +120,10 @@ describe("bot/commands/messages", () => {
     mocked.sessionMessagesMock.mockReset();
     mocked.sessionGetMock.mockReset();
     mocked.sessionRevertMock.mockReset();
+    mocked.sessionForkMock.mockReset();
+    mocked.attachToSessionMock.mockReset();
+    mocked.setCurrentSessionMock.mockReset();
+    mocked.ingestSessionInfoForCacheMock.mockReset();
 
     // Default: session without revert
     mocked.sessionGetMock.mockResolvedValue({
@@ -265,7 +296,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:page:1", 300);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     const [text, options] = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock.calls[0] as [
@@ -295,7 +326,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:select:0", 400);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     const [text, options] = (ctx.editMessageText as ReturnType<typeof vi.fn>).mock.calls[0] as [
@@ -328,7 +359,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:back", 500);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.editMessageText).toHaveBeenCalledWith(
@@ -356,7 +387,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:cancel", 500);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
@@ -383,7 +414,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:cancel", 501);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
@@ -413,7 +444,7 @@ describe("bot/commands/messages", () => {
     mocked.sessionRevertMock.mockResolvedValue({});
 
     const ctx = createCallbackContext("messages:revert", 600);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
@@ -449,7 +480,7 @@ describe("bot/commands/messages", () => {
     mocked.sessionRevertMock.mockRejectedValue(new Error("API error"));
 
     const ctx = createCallbackContext("messages:revert", 600);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
@@ -481,7 +512,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:revert", 600);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
@@ -492,7 +523,8 @@ describe("bot/commands/messages", () => {
     expect(ctx.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("keeps detail screen unchanged for fork placeholder", async () => {
+  it("handles successful fork", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
     interactionManager.start({
       kind: "custom",
       expectedInput: "callback",
@@ -502,19 +534,110 @@ describe("bot/commands/messages", () => {
         messageId: 600,
         projectDirectory: "D:\\Projects\\Repo",
         sessionId: "session-1",
-        messages: [{ id: "msg-1", text: "text", created: 1000 }],
+        messages,
         page: 0,
         selectedIndex: 0,
       },
     });
 
+    const forkedSession = {
+      id: "session-2",
+      title: "Forked Session",
+      directory: "D:\\Projects\\Repo",
+    };
+    mocked.sessionForkMock.mockResolvedValue({ data: forkedSession, error: null });
+    mocked.attachToSessionMock.mockResolvedValue({
+      busy: false,
+      alreadyAttached: false,
+      restoredQuestion: false,
+      restoredPermissions: 0,
+    });
+    mocked.ingestSessionInfoForCacheMock.mockResolvedValue(undefined);
+
     const ctx = createCallbackContext("messages:fork", 600);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+    expect(mocked.sessionForkMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      messageID: "msg-1",
+      directory: "D:\\Projects\\Repo",
+    });
+    expect(mocked.setCurrentSessionMock).toHaveBeenCalledWith({
+      id: "session-2",
+      title: "Forked Session",
+      directory: "D:\\Projects\\Repo",
+    });
+    expect(mocked.attachToSessionMock).toHaveBeenCalled();
+    expect(ctx.editMessageText).toHaveBeenCalledWith(
+      t("messages.fork_success", { text: "test prompt" }),
+      { reply_markup: undefined },
+    );
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("handles fork error", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "detail",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+        selectedIndex: 0,
+      },
+    });
+
+    mocked.sessionForkMock.mockRejectedValue(new Error("API error"));
+
+    const ctx = createCallbackContext("messages:fork", 600);
+    const handled = await handleMessagesCallback(ctx, testDeps);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith();
+    expect(mocked.sessionForkMock).toHaveBeenCalledWith({
+      sessionID: "session-1",
+      messageID: "msg-1",
+      directory: "D:\\Projects\\Repo",
+    });
+    expect(ctx.editMessageText).toHaveBeenCalledWith(t("messages.fork_error"), {
+      reply_markup: undefined,
+    });
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("rejects fork from list stage", async () => {
+    const messages = [{ id: "msg-1", text: "test prompt", created: 1000 }];
+    interactionManager.start({
+      kind: "custom",
+      expectedInput: "callback",
+      metadata: {
+        flow: "messages",
+        stage: "list",
+        messageId: 600,
+        projectDirectory: "D:\\Projects\\Repo",
+        sessionId: "session-1",
+        messages,
+        page: 0,
+      },
+    });
+
+    const ctx = createCallbackContext("messages:fork", 600);
+    const handled = await handleMessagesCallback(ctx, testDeps);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({
+      text: t("messages.inactive_callback"),
+      show_alert: true,
+    });
+    expect(mocked.sessionForkMock).not.toHaveBeenCalled();
     expect(ctx.editMessageText).not.toHaveBeenCalled();
-    expect(interactionManager.getSnapshot()?.metadata.stage).toBe("detail");
   });
 
   it("handles stale callback as inactive", async () => {
@@ -533,7 +656,7 @@ describe("bot/commands/messages", () => {
     });
 
     const ctx = createCallbackContext("messages:select:0", 999);
-    const handled = await handleMessagesCallback(ctx);
+    const handled = await handleMessagesCallback(ctx, testDeps);
 
     expect(handled).toBe(true);
     expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description of changes

add /messages command and support for fork and revert for ecah message

## Checklist

- [x] PR title follows Conventional Commits: `<type>(<scope>)?: <description>`
- [x] This PR contains one logically complete change
- [x] Branch is rebased on the latest `main`
- [x] I ran `npm run lint`, `npm run build`, and `npm test`
- [ ] If this PR is OS-sensitive, behavior/limitations for Linux/macOS/Windows are described
