### PR TITLE
Add ElevenLabs TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,7 +141,7 @@ OPENCODE_MODEL_ID=big-pickle
 
 # Text-to-Speech credentials (optional)
 # TTS reply behavior is controlled globally with /tts and persisted in settings.json.
-# Provider: "openai" (default) or "google".
+# Provider: "openai" (default), "elevenlabs", or "google".
 #
 # --- OpenAI-compatible (default) ---
 # Set TTS_API_URL and TTS_API_KEY to any OpenAI-compatible TTS endpoint.
@@ -149,6 +149,13 @@ OPENCODE_MODEL_ID=big-pickle
 # TTS_API_KEY=
 # TTS_MODEL=gpt-4o-mini-tts
 # TTS_VOICE=alloy
+#
+# --- ElevenLabs ---
+# TTS_PROVIDER=elevenlabs
+# TTS_API_URL=https://api.elevenlabs.io/v1
+# TTS_API_KEY=
+# TTS_MODEL=eleven_flash_v2_5
+# TTS_VOICE=21m00Tcm4TlvDq8ikWAM
 #
 # --- Google Cloud TTS ---
 # 1. Create a project at https://console.cloud.google.com

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -88,7 +88,7 @@ No public inbound ports are required for normal usage.
 - Configurable visibility for service messages (thinking/tool calls)
 - Configurable max code file size in KB (default: 100)
 - Optional STT settings for voice transcription (`STT_API_URL`, `STT_API_KEY`, `STT_MODEL`, `STT_LANGUAGE`)
-- Optional TTS settings for global audio replies (`TTS_API_URL`, `TTS_API_KEY`, `TTS_MODEL`, `TTS_VOICE`)
+- Optional TTS settings for global audio replies (`TTS_PROVIDER`, `TTS_API_URL`, `TTS_API_KEY`, `TTS_MODEL`, `TTS_VOICE`)
 - Optional IPv4-only mode for Telegram connectivity (`TELEGRAM_FORCE_IPV4`)
 
 ## Current Product Scope

--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `STT_MODEL`                                | STT model name passed to `/audio/transcriptions`                                                                      |    No    | `whisper-large-v3-turbo` |
 | `STT_LANGUAGE`                             | Optional language hint (empty = provider auto-detect)                                                                 |    No    | —                        |
 | `STT_NOTE_PROMPT`                          | Optional note prepended to the LLM prompt as `[Note: ...]` for voice transcriptions; empty / `false` / `0` disable it |    No    | —                        |
-| `TTS_PROVIDER`                             | TTS provider: `openai` for OpenAI-compatible APIs or `google` for Google Cloud TTS                                    |    No    | `openai`                 |
-| `TTS_API_URL`                              | OpenAI-compatible TTS API base URL                                                                                    |    No    | —                        |
-| `TTS_API_KEY`                              | OpenAI-compatible TTS API key                                                                                         |    No    | —                        |
-| `TTS_MODEL`                                | OpenAI-compatible TTS model name passed to `/audio/speech`                                                            |    No    | `gpt-4o-mini-tts`        |
-| `TTS_VOICE`                                | TTS voice name. Defaults to `alloy` for OpenAI-compatible APIs and `en-US-Studio-O` for Google Cloud TTS              |    No    | provider-specific        |
+| `TTS_PROVIDER`                             | TTS provider: `openai` for OpenAI-compatible APIs, `elevenlabs` for ElevenLabs, or `google` for Google Cloud TTS      |    No    | `openai`                 |
+| `TTS_API_URL`                              | TTS API base URL for OpenAI-compatible APIs or ElevenLabs                                                             |    No    | —                        |
+| `TTS_API_KEY`                              | TTS API key for OpenAI-compatible APIs or ElevenLabs                                                                  |    No    | —                        |
+| `TTS_MODEL`                                | TTS model name. Passed as `model` for OpenAI-compatible APIs and `model_id` for ElevenLabs                            |    No    | `gpt-4o-mini-tts`        |
+| `TTS_VOICE`                                | TTS voice name or ElevenLabs voice ID. Defaults to `alloy`, `21m00Tcm4TlvDq8ikWAM`, or `en-US-Studio-O` by provider   |    No    | provider-specific        |
 | `GOOGLE_APPLICATION_CREDENTIALS`           | Path to a Google Cloud service account JSON key file for `TTS_PROVIDER=google`                                        |    No    | —                        |
 | `LOG_LEVEL`                                | Log level (`debug`, `info`, `warn`, `error`)                                                                          |    No    | `info`                   |
 | `LOG_RETENTION`                            | Number of log files to keep: launch files in `sources`, daily files in `installed`                                    |    No    | `10`                     |
@@ -321,6 +321,16 @@ TTS_API_URL=https://api.openai.com/v1
 TTS_API_KEY=your-tts-api-key
 TTS_MODEL=gpt-4o-mini-tts
 TTS_VOICE=alloy
+```
+
+ElevenLabs TTS configuration example:
+
+```env
+TTS_PROVIDER=elevenlabs
+TTS_API_URL=https://api.elevenlabs.io/v1
+TTS_API_KEY=your-elevenlabs-api-key
+TTS_MODEL=eleven_flash_v2_5
+TTS_VOICE=21m00Tcm4TlvDq8ikWAM
 ```
 
 Google Cloud TTS configuration example:

--- a/src/app/services/tts-service.ts
+++ b/src/app/services/tts-service.ts
@@ -157,12 +157,62 @@ async function synthesizeWithOpenAi(text: string): Promise<TtsResult> {
   }
 }
 
+async function synthesizeWithElevenLabs(text: string): Promise<TtsResult> {
+  const apiUrl = config.tts.apiUrl.replace(/\/+$/, "");
+  const voiceId = config.tts.voice || "21m00Tcm4TlvDq8ikWAM";
+  const url = `${apiUrl}/text-to-speech/${encodeURIComponent(voiceId)}`;
+
+  logger.debug(
+    `[TTS] ElevenLabs: url=${url}, model=${config.tts.model}, voice=${voiceId}, chars=${text.length}`,
+  );
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TTS_REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "xi-api-key": config.tts.apiKey,
+        "Content-Type": "application/json",
+        Accept: "audio/mpeg",
+      },
+      body: JSON.stringify({
+        text,
+        model_id: config.tts.model || "eleven_flash_v2_5",
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(
+        `TTS API returned HTTP ${response.status}: ${errorBody || response.statusText}`,
+      );
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.length === 0) {
+      throw new Error("ElevenLabs TTS API returned an empty audio response");
+    }
+
+    logger.debug(`[TTS] Generated ElevenLabs speech audio: ${buffer.length} bytes`);
+    return { buffer, filename: "assistant-reply.mp3", mimeType: "audio/mpeg" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 // --- Public API ---
 
 function getNotConfiguredMessage(): string {
-  return config.tts.provider === "google"
-    ? "TTS is not configured: set GOOGLE_APPLICATION_CREDENTIALS for Google Cloud TTS"
-    : "TTS is not configured: set TTS_API_URL and TTS_API_KEY";
+  if (config.tts.provider === "google") {
+    return "TTS is not configured: set GOOGLE_APPLICATION_CREDENTIALS for Google Cloud TTS";
+  }
+  if (config.tts.provider === "elevenlabs") {
+    return "TTS is not configured: set TTS_API_URL and TTS_API_KEY for ElevenLabs";
+  }
+  return "TTS is not configured: set TTS_API_URL and TTS_API_KEY";
 }
 
 export async function synthesizeSpeech(text: string): Promise<TtsResult> {
@@ -180,6 +230,9 @@ export async function synthesizeSpeech(text: string): Promise<TtsResult> {
   try {
     if (config.tts.provider === "google") {
       return await synthesizeWithGoogle(input);
+    }
+    if (config.tts.provider === "elevenlabs") {
+      return await synthesizeWithElevenLabs(input);
     }
     return await synthesizeWithOpenAi(input);
   } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: runtimePaths.envFilePath, quiet: true });
 
 export type MessageFormatMode = "raw" | "markdown";
 export type StreamingMode = "edit" | "draft";
-export type TtsProvider = "openai" | "google";
+export type TtsProvider = "openai" | "google" | "elevenlabs";
 
 function getEnvVar(key: string, required: boolean = true): string {
   const value = process.env[key];
@@ -95,7 +95,7 @@ function getOptionalMessageFormatModeEnvVar(
   return defaultValue;
 }
 
-const VALID_TTS_PROVIDERS: TtsProvider[] = ["openai", "google"];
+const VALID_TTS_PROVIDERS: TtsProvider[] = ["openai", "google", "elevenlabs"];
 
 function getOptionalTtsProviderEnvVar(key: string, defaultValue: TtsProvider): TtsProvider {
   const value = getEnvVar(key, false);
@@ -202,7 +202,12 @@ export const config = {
   },
   tts: (() => {
     const provider = getOptionalTtsProviderEnvVar("TTS_PROVIDER", "openai");
-    const defaultVoice = provider === "google" ? "en-US-Studio-O" : "alloy";
+    const defaultVoice =
+      provider === "google"
+        ? "en-US-Studio-O"
+        : provider === "elevenlabs"
+          ? "21m00Tcm4TlvDq8ikWAM"
+          : "alloy";
     return {
       apiUrl: getEnvVar("TTS_API_URL", false),
       apiKey: getEnvVar("TTS_API_KEY", false),

--- a/tests/app/services/tts-service.test.ts
+++ b/tests/app/services/tts-service.test.ts
@@ -105,6 +105,13 @@ describe("isTtsConfigured", () => {
     expect(isTtsConfigured()).toBe(true);
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
   });
+
+  it("returns true when ElevenLabs credentials are set", () => {
+    mockTts.provider = "elevenlabs";
+    mockTts.apiUrl = "https://api.elevenlabs.io/v1";
+    mockTts.apiKey = "xi-test-key";
+    expect(isTtsConfigured()).toBe(true);
+  });
 });
 
 describe("stripMarkdownForSpeech", () => {
@@ -337,5 +344,80 @@ describe("synthesizeSpeech (Google)", () => {
 
     const callArgs = mockSynthesizeSpeech.mock.calls[0];
     expect(callArgs[0].input).toEqual({ text: "Hello bold and code" });
+  });
+});
+
+describe("synthesizeSpeech (ElevenLabs)", () => {
+  beforeEach(() => {
+    mockTts.apiUrl = "https://api.elevenlabs.io/v1";
+    mockTts.apiKey = "xi-test-key";
+    mockTts.provider = "elevenlabs";
+    mockTts.model = "eleven_flash_v2_5";
+    mockTts.voice = "nPczCjzI2devNBz1zQrb";
+    vi.restoreAllMocks();
+  });
+
+  it("throws with provider-specific message when not configured", async () => {
+    mockTts.apiKey = "";
+
+    await expect(synthesizeSpeech("hello")).rejects.toThrow(
+      "TTS_API_URL and TTS_API_KEY for ElevenLabs",
+    );
+  });
+
+  it("sends correct request and returns audio bytes", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(Uint8Array.from([7, 8, 9]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+    );
+
+    const result = await synthesizeSpeech("Hello **bold** world");
+
+    expect(result.filename).toBe("assistant-reply.mp3");
+    expect(result.mimeType).toBe("audio/mpeg");
+    expect(result.buffer).toEqual(Buffer.from([7, 8, 9]));
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.elevenlabs.io/v1/text-to-speech/nPczCjzI2devNBz1zQrb");
+    expect(options?.method).toBe("POST");
+    expect((options?.headers as Record<string, string>)["xi-api-key"]).toBe("xi-test-key");
+    expect((options?.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect((options?.headers as Record<string, string>)["Accept"]).toBe("audio/mpeg");
+    expect(JSON.parse(String(options?.body))).toEqual({
+      text: "Hello bold world",
+      model_id: "eleven_flash_v2_5",
+    });
+  });
+
+  it("trims trailing slashes from the API URL", async () => {
+    mockTts.apiUrl = "https://api.elevenlabs.io/v1/";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(Uint8Array.from([1]), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+    );
+
+    await synthesizeSpeech("Hello world");
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://api.elevenlabs.io/v1/text-to-speech/nPczCjzI2devNBz1zQrb",
+    );
+  });
+
+  it("throws on non-OK HTTP response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Voice not found", {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+
+    await expect(synthesizeSpeech("Hello world")).rejects.toThrow(
+      "TTS API returned HTTP 404: Voice not found",
+    );
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -290,6 +290,31 @@ describe("config boolean env parsing", () => {
     expect(config.tts.model).toBe("gpt-4o-mini-tts");
     expect(config.tts.voice).toBe("alloy");
   });
+
+  it("accepts ElevenLabs as a TTS provider", async () => {
+    vi.stubEnv("TTS_PROVIDER", "elevenlabs");
+    vi.stubEnv("TTS_API_URL", "https://api.elevenlabs.io/v1");
+    vi.stubEnv("TTS_API_KEY", "xi-test-key");
+    vi.stubEnv("TTS_MODEL", "eleven_flash_v2_5");
+    vi.stubEnv("TTS_VOICE", "nPczCjzI2devNBz1zQrb");
+
+    const config = await loadConfig();
+
+    expect(config.tts.provider).toBe("elevenlabs");
+    expect(config.tts.apiUrl).toBe("https://api.elevenlabs.io/v1");
+    expect(config.tts.apiKey).toBe("xi-test-key");
+    expect(config.tts.model).toBe("eleven_flash_v2_5");
+    expect(config.tts.voice).toBe("nPczCjzI2devNBz1zQrb");
+  });
+
+  it("uses an ElevenLabs voice ID default for ElevenLabs TTS", async () => {
+    vi.stubEnv("TTS_PROVIDER", "elevenlabs");
+    vi.stubEnv("TTS_VOICE", "");
+
+    const config = await loadConfig();
+
+    expect(config.tts.voice).toBe("21m00Tcm4TlvDq8ikWAM");
+  });
 });
 
 describe("config telegram reverse-proxy", () => {


### PR DESCRIPTION
## Summary
- add elevenlabs as a supported TTS_PROVIDER
- call the ElevenLabs text-to-speech endpoint with xi-api-key auth
- document ElevenLabs configuration and add tests for request shape/config parsing

## Validation
- npm run build
- npm run lint
- npm test