### PR TITLE
feat(vision): add auxiliary vision model for image description fallback

### DIFF
--- a/src/app/services/session-service.ts
+++ b/src/app/services/session-service.ts
@@ -3,6 +3,7 @@ import {
   setCurrentSession as setSettingsSession,
   clearSession as clearSettingsSession,
 } from "../stores/settings-store.js";
+import { clearImageCounter } from "./vision-model-service.js";
 import type { SessionInfo } from "../types/session.js";
 
 export type { SessionInfo };
@@ -16,5 +17,9 @@ export function getCurrentSession(): SessionInfo | null {
 }
 
 export function clearSession(): void {
+  const currentSession = getCurrentSession();
+  if (currentSession) {
+    clearImageCounter(currentSession.id);
+  }
   clearSettingsSession();
 }

--- a/src/app/services/vision-model-service.ts
+++ b/src/app/services/vision-model-service.ts
@@ -8,6 +8,8 @@ import {
 } from "../stores/settings-store.js";
 import { logger } from "../../utils/logger.js";
 
+const sessionImageCounter = new Map<string, number>();
+
 export function getStoredVisionModel(): ModelInfo | null {
   const model = getCurrentVisionModel();
   return model && model.providerID && model.modelID ? model : null;
@@ -25,6 +27,10 @@ export function clearVisionModel(): void {
   clearCurrentVisionModel();
 }
 
+export function clearImageCounter(sessionKey: string): void {
+  sessionImageCounter.delete(sessionKey);
+}
+
 export async function describeImage(
   imageFilePart: FilePartInput,
   userPrompt: string,
@@ -36,9 +42,13 @@ export async function describeImage(
     throw new Error("Vision model is not configured");
   }
 
+  const counterKey = parentSessionId ?? directory;
+  const count = (sessionImageCounter.get(counterKey) ?? 0) + 1;
+  sessionImageCounter.set(counterKey, count);
+
   const createResult = await opencodeClient.session.create({
     directory,
-    title: "vision-image-description",
+    title: `vision-image-description-${count}`,
     ...(parentSessionId ? { parentID: parentSessionId } : {}),
   });
 

--- a/src/app/services/vision-model-service.ts
+++ b/src/app/services/vision-model-service.ts
@@ -1,0 +1,93 @@
+import type { FilePartInput, TextPart } from "@opencode-ai/sdk/v2";
+import { opencodeClient } from "../../opencode/client.js";
+import type { ModelInfo } from "../types/model.js";
+import {
+  clearCurrentVisionModel,
+  getCurrentVisionModel,
+  setCurrentVisionModel,
+} from "../stores/settings-store.js";
+import { logger } from "../../utils/logger.js";
+
+export function getStoredVisionModel(): ModelInfo | null {
+  const model = getCurrentVisionModel();
+  return model && model.providerID && model.modelID ? model : null;
+}
+
+export function isVisionModelConfigured(): boolean {
+  return getStoredVisionModel() !== null;
+}
+
+export function setVisionModel(modelInfo: ModelInfo): void {
+  setCurrentVisionModel(modelInfo);
+}
+
+export function clearVisionModel(): void {
+  clearCurrentVisionModel();
+}
+
+export async function describeImage(
+  imageFilePart: FilePartInput,
+  userPrompt: string,
+  directory: string,
+  parentSessionId?: string,
+): Promise<string> {
+  const visionModel = getStoredVisionModel();
+  if (!visionModel) {
+    throw new Error("Vision model is not configured");
+  }
+
+  const createResult = await opencodeClient.session.create({
+    directory,
+    title: "vision-image-description",
+    ...(parentSessionId ? { parentID: parentSessionId } : {}),
+  });
+
+  if (createResult.error || !createResult.data) {
+    throw new Error(
+      `Failed to create vision session: ${JSON.stringify(createResult.error ?? "no session returned")}`,
+    );
+  }
+
+  const sessionId = createResult.data.id;
+
+  try {
+    const descriptionPrompt = userPrompt.trim().length > 0
+      ? `The user asked: "${userPrompt}"\n\nPlease describe the uploaded image in detail, focusing on the aspects most relevant to answering the user's question.`
+      : "Please describe this image in detail.";
+
+    const promptResult = await opencodeClient.session.prompt({
+      sessionID: sessionId,
+      directory,
+      model: {
+        providerID: visionModel.providerID,
+        modelID: visionModel.modelID,
+      },
+      parts: [
+        { type: "text", text: descriptionPrompt },
+        imageFilePart,
+      ],
+    });
+
+    if (promptResult.error || !promptResult.data) {
+      throw new Error(
+        `Vision model prompt failed: ${JSON.stringify(promptResult.error ?? "no response")}`,
+      );
+    }
+
+    const text = promptResult.data.parts
+      .filter((p): p is TextPart => p.type === "text")
+      .map((p) => p.text)
+      .join("\n")
+      .trim();
+
+    if (!text) {
+      throw new Error("Vision model returned no text description");
+    }
+
+    return text;
+  } finally {
+    opencodeClient.session.delete({ sessionID: sessionId, directory }).catch((err) => {
+      logger.warn("[VisionModel] Failed to delete temporary session:", err);
+    });
+  }
+}

--- a/src/app/stores/settings-store.ts
+++ b/src/app/stores/settings-store.ts
@@ -122,6 +122,20 @@ export function clearCurrentModel(): void {
   void writeSettingsFile(currentSettings);
 }
 
+export function getCurrentVisionModel(): ModelInfo | undefined {
+  return currentSettings.currentVisionModel;
+}
+
+export function setCurrentVisionModel(modelInfo: ModelInfo): void {
+  currentSettings.currentVisionModel = modelInfo;
+  void writeSettingsFile(currentSettings);
+}
+
+export function clearCurrentVisionModel(): void {
+  currentSettings.currentVisionModel = undefined;
+  void writeSettingsFile(currentSettings);
+}
+
 export function getPinnedMessageId(): number | undefined {
   return currentSettings.pinnedMessageId;
 }

--- a/src/app/types/settings.ts
+++ b/src/app/types/settings.ts
@@ -13,6 +13,7 @@ export interface Settings {
   currentSession?: SessionInfo;
   currentAgent?: string;
   currentModel?: ModelInfo;
+  currentVisionModel?: ModelInfo;
   pinnedMessageId?: number;
   ttsEnabled?: boolean;
   sessionDirectoryCache?: SessionDirectoryCacheInfo;

--- a/src/bot/callbacks/callback-router.ts
+++ b/src/bot/callbacks/callback-router.ts
@@ -27,6 +27,7 @@ import {
   handleTaskCallback,
   handleTaskListCallback,
 } from "./scheduled-task-callback-handler.js";
+import { handleVisionModelSelect } from "./vision-model-callback-handler.js";
 import { handleVariantSelect } from "./variant-selection-callback-handler.js";
 import { handleWorktreeCallback } from "./worktree-callback-handler.js";
 import { clearLsPathIndex, clearOpenPathIndex } from "../menus/file-browser-menu.js";
@@ -75,6 +76,7 @@ export function registerCallbackRouter(bot: Bot<Context>, deps: CallbackRouterDe
       const handledModelSearch = await handleModelSearchCallback(ctx);
       const handledModelSearchResults = await handleModelSearchResults(ctx);
       const handledModel = await handleModelSelect(ctx);
+      const handledVisionModel = await handleVisionModelSelect(ctx);
       const handledVariant = await handleVariantSelect(ctx);
       const handledCompactConfirm = await handleCompactConfirm(ctx);
       const handledTask = await handleTaskCallback(ctx);
@@ -95,7 +97,7 @@ export function registerCallbackRouter(bot: Bot<Context>, deps: CallbackRouterDe
       const handledMcps = await handleMcpsCallback(ctx);
 
       logger.debug(
-        `[Bot] Callback handled: backgroundSession=${handledBackgroundSession}, inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, ls=${handledLs}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, modelSearch=${handledModelSearch}, modelSearchResults=${handledModelSearchResults}, model=${handledModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, messages=${handledMessages}, skills=${handledSkills}, mcps=${handledMcps}`,
+        `[Bot] Callback handled: backgroundSession=${handledBackgroundSession}, inlineCancel=${handledInlineCancel}, session=${handledSession}, project=${handledProject}, worktree=${handledWorktree}, open=${handledOpen}, ls=${handledLs}, question=${handledQuestion}, permission=${handledPermission}, agent=${handledAgent}, modelSearch=${handledModelSearch}, modelSearchResults=${handledModelSearchResults}, model=${handledModel}, visionModel=${handledVisionModel}, variant=${handledVariant}, compactConfirm=${handledCompactConfirm}, task=${handledTask}, taskList=${handledTaskList}, rename=${handledRenameCancel}, commands=${handledCommands}, messages=${handledMessages}, skills=${handledSkills}, mcps=${handledMcps}`,
       );
 
       if (
@@ -112,6 +114,7 @@ export function registerCallbackRouter(bot: Bot<Context>, deps: CallbackRouterDe
         !handledModelSearch &&
         !handledModelSearchResults &&
         !handledModel &&
+        !handledVisionModel &&
         !handledVariant &&
         !handledCompactConfirm &&
         !handledTask &&

--- a/src/bot/callbacks/vision-model-callback-handler.ts
+++ b/src/bot/callbacks/vision-model-callback-handler.ts
@@ -1,0 +1,84 @@
+import { Context } from "grammy";
+import { formatModelForDisplay } from "../../app/types/model.js";
+import type { ModelInfo } from "../../app/types/model.js";
+import {
+  setVisionModel,
+  clearVisionModel,
+} from "../../app/services/vision-model-service.js";
+import { t } from "../../i18n/index.js";
+import { logger } from "../../utils/logger.js";
+import { clearActiveInlineMenu } from "../menus/inline-menu.js";
+import {
+  VISION_MODEL_CLEAR,
+  VISION_MODEL_SELECT_PREFIX,
+  setvisionCommand,
+} from "../commands/setvision-command.js";
+
+export async function handleVisionModelSelect(ctx: Context): Promise<boolean> {
+  const data = ctx.callbackQuery?.data;
+  if (!data) {
+    return false;
+  }
+
+  if (data === VISION_MODEL_CLEAR) {
+    try {
+      clearVisionModel();
+      clearActiveInlineMenu("vision_cleared");
+      await ctx.answerCallbackQuery({ text: t("vision.cleared") });
+      await ctx.reply(t("vision.model_cleared"));
+      await ctx.deleteMessage().catch(() => {});
+    } catch (err) {
+      clearActiveInlineMenu("vision_clear_error");
+      logger.error("[VisionModel] Error clearing vision model:", err);
+      await ctx.answerCallbackQuery({ text: t("vision.error") });
+    }
+    return true;
+  }
+
+  if (data === `${VISION_MODEL_SELECT_PREFIX}change`) {
+    try {
+      clearVisionModel();
+      clearActiveInlineMenu("vision_change");
+      await ctx.deleteMessage().catch(() => {});
+      await setvisionCommand(ctx as never);
+    } catch (err) {
+      clearActiveInlineMenu("vision_change_error");
+      logger.error("[VisionModel] Error switching to change menu:", err);
+      await ctx.answerCallbackQuery({ text: t("vision.error") });
+    }
+    return true;
+  }
+
+  if (data.startsWith(VISION_MODEL_SELECT_PREFIX)) {
+    const idPart = data.slice(VISION_MODEL_SELECT_PREFIX.length);
+    const separatorIndex = idPart.indexOf(":");
+    if (separatorIndex === -1) {
+      return false;
+    }
+
+    const providerID = idPart.slice(0, separatorIndex);
+    const modelID = idPart.slice(separatorIndex + 1);
+
+    if (!providerID || !modelID) {
+      return false;
+    }
+
+    try {
+      const modelInfo: ModelInfo = { providerID, modelID };
+      setVisionModel(modelInfo);
+      clearActiveInlineMenu("vision_model_selected");
+
+      const displayName = formatModelForDisplay(providerID, modelID);
+      await ctx.answerCallbackQuery({ text: t("vision.model_set") });
+      await ctx.reply(t("vision.model_set_message", { name: displayName }));
+      await ctx.deleteMessage().catch(() => {});
+    } catch (err) {
+      clearActiveInlineMenu("vision_model_select_error");
+      logger.error("[VisionModel] Error setting vision model:", err);
+      await ctx.answerCallbackQuery({ text: t("vision.error") });
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/src/bot/commands/definitions.ts
+++ b/src/bot/commands/definitions.ts
@@ -28,6 +28,7 @@ const COMMAND_DEFINITIONS: BotCommandI18nDefinition[] = [
   { command: "sessions", descriptionKey: "cmd.description.sessions" },
   { command: "messages", descriptionKey: "cmd.description.messages" },
   { command: "tts", descriptionKey: "cmd.description.tts" },
+  { command: "setvision", descriptionKey: "cmd.description.setvision" },
   { command: "projects", descriptionKey: "cmd.description.projects" },
   { command: "worktree", descriptionKey: "cmd.description.worktree" },
   { command: "task", descriptionKey: "cmd.description.task" },

--- a/src/bot/commands/setvision-command.ts
+++ b/src/bot/commands/setvision-command.ts
@@ -1,0 +1,71 @@
+import { CommandContext, Context, InlineKeyboard } from "grammy";
+import { formatModelForDisplay } from "../../app/types/model.js";
+import {
+  getStoredVisionModel,
+} from "../../app/services/vision-model-service.js";
+import { getModelSelectionLists } from "../../app/services/model-selection-service.js";
+import { t } from "../../i18n/index.js";
+import { logger } from "../../utils/logger.js";
+import { replyWithInlineMenu } from "../menus/inline-menu.js";
+
+export const VISION_MODEL_SELECT_PREFIX = "vmodel:";
+export const VISION_MODEL_CLEAR = "vmodel:clear";
+
+export async function setvisionCommand(ctx: CommandContext<Context>): Promise<void> {
+  try {
+    const currentVision = getStoredVisionModel();
+
+    if (currentVision) {
+      const displayName = formatModelForDisplay(currentVision.providerID, currentVision.modelID);
+      const keyboard = new InlineKeyboard()
+        .text(t("vision.change"), `${VISION_MODEL_SELECT_PREFIX}change`)
+        .text(t("vision.clear"), VISION_MODEL_CLEAR);
+
+      await replyWithInlineMenu(ctx, {
+        menuKind: "vision",
+        text: t("vision.current", { name: displayName }),
+        keyboard,
+      });
+      return;
+    }
+
+    const modelLists = await getModelSelectionLists();
+    const favorites = modelLists.favorites;
+    const recent = modelLists.recent;
+
+    if (favorites.length === 0 && recent.length === 0) {
+      await ctx.reply(t("vision.no_models"));
+      return;
+    }
+
+    const keyboard = new InlineKeyboard();
+    const lines = [t("vision.select_prompt"), t("model.menu.favorites_title")];
+
+    if (favorites.length === 0) {
+      lines.push(t("model.menu.favorites_empty"));
+    }
+
+    lines.push(t("model.menu.recent_title"));
+
+    if (recent.length === 0) {
+      lines.push(t("model.menu.recent_empty"));
+    }
+
+    const addButton = (providerID: string, modelID: string, prefix: string): void => {
+      const label = `${prefix} ${providerID}/${modelID}`;
+      keyboard.text(label, `${VISION_MODEL_SELECT_PREFIX}${providerID}:${modelID}`).row();
+    };
+
+    favorites.forEach((model) => addButton(model.providerID, model.modelID, "⭐"));
+    recent.forEach((model) => addButton(model.providerID, model.modelID, "🕘"));
+
+    await replyWithInlineMenu(ctx, {
+      menuKind: "vision",
+      text: lines.join("\n"),
+      keyboard,
+    });
+  } catch (err) {
+    logger.error("[SetVision] Error showing vision model menu:", err);
+    await ctx.reply(t("vision.error"));
+  }
+}

--- a/src/bot/handlers/document-handler.ts
+++ b/src/bot/handlers/document-handler.ts
@@ -9,6 +9,8 @@ import {
 } from "../../app/services/file-download-service.js";
 import { getModelCapabilities, supportsInput } from "../../app/services/model-capabilities-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
+import { getStoredVisionModel, describeImage } from "../../app/services/vision-model-service.js";
+import { getCurrentProject, getCurrentSession } from "../../app/stores/settings-store.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import type { FilePartInput, Model } from "@opencode-ai/sdk/v2";
@@ -84,6 +86,36 @@ export async function handleDocumentMessage(
         logger.warn(
           `[Document] Model ${storedModel.providerID}/${storedModel.modelID} doesn't support image input`,
         );
+
+        const visionModel = getStoredVisionModel();
+        const project = getCurrentProject();
+
+        if (visionModel && project?.worktree) {
+          await ctx.reply(t("bot.vision_describing"));
+          const downloadedFile = await downloadFile(ctx.api, doc.file_id);
+          const filePart: FilePartInput = {
+            type: "file",
+            mime: mimeType,
+            filename: filename,
+            url: toDataUri(downloadedFile.buffer, mimeType),
+          };
+
+          try {
+            const description = await describeImage(filePart, caption, project.worktree, getCurrentSession()?.id);
+            const enriched = caption.trim().length > 0
+              ? `${caption}\n\n[Image description: ${description}]`
+              : `[Image description: ${description}]`;
+            await processPrompt(ctx, enriched, deps);
+          } catch (err) {
+            logger.error("[Document] Vision description failed:", err);
+            await ctx.reply(t("bot.vision_describe_error"));
+            if (caption.trim().length > 0) {
+              await processPrompt(ctx, caption, deps);
+            }
+          }
+          return;
+        }
+
         await ctx.reply(t("bot.photo_model_no_image"));
 
         if (caption.trim().length > 0) {

--- a/src/bot/handlers/media-group-handler.ts
+++ b/src/bot/handlers/media-group-handler.ts
@@ -4,6 +4,8 @@ import { config } from "../../config.js";
 import { t } from "../../i18n/index.js";
 import { getModelCapabilities, supportsInput } from "../../app/services/model-capabilities-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
+import { getStoredVisionModel, describeImage } from "../../app/services/vision-model-service.js";
+import { getCurrentProject, getCurrentSession } from "../../app/stores/settings-store.js";
 import { logger } from "../../utils/logger.js";
 import {
   downloadTelegramFile,
@@ -44,6 +46,7 @@ type ValidMediaGroupItem =
       fileId: string;
       mime: string;
       filename: string;
+      needsVisionDescription?: boolean;
     }
   | {
       kind: "text";
@@ -207,7 +210,13 @@ export class MediaGroupAttachmentHandler {
         return;
       }
 
-      await replyCtx.reply(t("bot.files_downloading"));
+      const needsVision = validationResult.items.some(
+        (item) => item.kind === "file" && item.needsVisionDescription,
+      );
+
+      await replyCtx.reply(
+        needsVision ? t("bot.vision_describing") : t("bot.files_downloading"),
+      );
 
       const { promptText, fileParts } = await this.preparePrompt(validationResult.items, items);
       const processPrompt = this.deps.processPrompt ?? processUserPrompt;
@@ -302,7 +311,19 @@ export class MediaGroupAttachmentHandler {
       const capabilities = await getCapabilities(storedModel.providerID, storedModel.modelID);
 
       if (needsImageSupport && !supportsInput(capabilities, "image")) {
-        return { reason: `model_no_image:${storedModel.providerID}/${storedModel.modelID}` };
+        const visionModel = getStoredVisionModel();
+        const project = getCurrentProject();
+
+        if (visionModel && project?.worktree) {
+          // Mark all image file items for vision description
+          for (const item of validItems) {
+            if (item.kind === "file" && item.mime.startsWith("image/")) {
+              item.needsVisionDescription = true;
+            }
+          }
+        } else {
+          return { reason: `model_no_image:${storedModel.providerID}/${storedModel.modelID}` };
+        }
       }
 
       if (needsPdfSupport && !supportsInput(capabilities, "pdf")) {
@@ -320,6 +341,8 @@ export class MediaGroupAttachmentHandler {
     const downloadFile = this.deps.downloadFile ?? downloadTelegramFile;
     const textSections: string[] = [];
     const fileParts: FilePartInput[] = [];
+    const project = getCurrentProject();
+    const visionModel = getStoredVisionModel();
 
     for (const item of validItems) {
       const downloadedFile = await downloadFile(item.ctx.api, item.fileId);
@@ -329,6 +352,26 @@ export class MediaGroupAttachmentHandler {
         textSections.push(
           `--- Content of ${item.filename} ---\n${textContent}\n--- End of file ---`,
         );
+        continue;
+      }
+
+      if (item.needsVisionDescription && visionModel && project?.worktree) {
+        const filePart: FilePartInput = {
+          type: "file",
+          mime: item.mime,
+          filename: item.filename,
+          url: toDataUri(downloadedFile.buffer, item.mime),
+        };
+
+        try {
+          const description = await describeImage(filePart, "", project.worktree, getCurrentSession()?.id);
+          textSections.push(
+            `[Image description for ${item.filename}: ${description}]`,
+          );
+        } catch (err) {
+          logger.error("[MediaGroup] Vision description failed for item:", err);
+          textSections.push(`[Image: ${item.filename} (description unavailable)]`);
+        }
         continue;
       }
 

--- a/src/bot/handlers/photo-handler.ts
+++ b/src/bot/handlers/photo-handler.ts
@@ -3,6 +3,8 @@ import type { FilePartInput, Model } from "@opencode-ai/sdk/v2";
 import { downloadTelegramFile, toDataUri } from "../../app/services/file-download-service.js";
 import { getModelCapabilities, supportsInput } from "../../app/services/model-capabilities-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
+import { getStoredVisionModel, describeImage } from "../../app/services/vision-model-service.js";
+import { getCurrentProject, getCurrentSession } from "../../app/stores/settings-store.js";
 import { t } from "../../i18n/index.js";
 import { logger } from "../../utils/logger.js";
 import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
@@ -46,6 +48,36 @@ export async function handlePhotoMessage(ctx: Context, deps: PhotoHandlerDeps): 
       logger.warn(
         `[Bot] Model ${storedModel.providerID}/${storedModel.modelID} doesn't support image input`,
       );
+
+      const visionModel = getStoredVisionModel();
+      const project = getCurrentProject();
+
+      if (visionModel && project?.worktree) {
+        await ctx.reply(t("bot.vision_describing"));
+        const downloadedFile = await downloadFile(ctx.api, largestPhoto.file_id);
+        const filePart: FilePartInput = {
+          type: "file",
+          mime: "image/jpeg",
+          filename: "photo.jpg",
+          url: toDataUri(downloadedFile.buffer, "image/jpeg"),
+        };
+
+        try {
+          const description = await describeImage(filePart, caption, project.worktree, getCurrentSession()?.id);
+          const enriched = caption.trim().length > 0
+            ? `${caption}\n\n[Image description: ${description}]`
+            : `[Image description: ${description}]`;
+          await processPrompt(ctx, enriched, deps);
+        } catch (err) {
+          logger.error("[Bot] Vision description failed:", err);
+          await ctx.reply(t("bot.vision_describe_error"));
+          if (caption.trim().length > 0) {
+            await processPrompt(ctx, caption, deps);
+          }
+        }
+        return;
+      }
+
       await ctx.reply(t("bot.photo_model_no_image"));
 
       if (caption.trim().length > 0) {

--- a/src/bot/menus/inline-menu.ts
+++ b/src/bot/menus/inline-menu.ts
@@ -17,6 +17,7 @@ const INLINE_MENU_KINDS = [
   "open",
   "ls",
   "worktree",
+  "vision",
 ] as const;
 
 export type InlineMenuKind = (typeof INLINE_MENU_KINDS)[number];

--- a/src/bot/routers/command-router.ts
+++ b/src/bot/routers/command-router.ts
@@ -1,6 +1,7 @@
 import type { Bot, Context, NextFunction } from "grammy";
 import { config } from "../../config.js";
 import { ttsCommand } from "../commands/tts-command.js";
+import { setvisionCommand } from "../commands/setvision-command.js";
 import { opencodeStartCommand } from "../commands/opencode-start-command.js";
 import { opencodeStopCommand } from "../commands/opencode-stop-command.js";
 import { projectsCommand } from "../commands/projects-command.js";
@@ -64,6 +65,7 @@ export function registerCommandRouter(bot: Bot<Context>, deps: CommandRouterDeps
   bot.command("help", helpCommand);
   bot.command("status", statusCommand);
   bot.command("tts", ttsCommand);
+  bot.command("setvision", setvisionCommand);
   bot.command("opencode_start", opencodeStartCommand);
   bot.command("opencode_stop", opencodeStopCommand);
   bot.command("projects", projectsCommand);

--- a/src/i18n/ar.ts
+++ b/src/i18n/ar.ts
@@ -15,6 +15,7 @@ export const ar: I18nDictionary = {
   "cmd.description.sessions": "عرض الجلسات السابقة",
   "cmd.description.messages": "استعراض رسائل الجلسة",
   "cmd.description.tts": "تشغيل أو إيقاف الردود الصوتية",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "عرض المشاريع",
   "cmd.description.worktree": "التبديل بين نسخ العمل في Git",
   "cmd.description.task": "إنشاء مهمة مجدولة",
@@ -88,6 +89,20 @@ export const ar: I18nDictionary = {
   "bot.media_group_not_processed": "⚠️ تعذر معالجة ملف أو أكثر في هذه المجموعة. لم يتم إرسال أي ملف إلى OpenCode.",
   "bot.media_group_download_error": "🔴 تعذر تنزيل أحد الملفات. لم يتم إرسال أي ملف إلى OpenCode.",
   "bot.model_no_pdf": "⚠️ النموذج الحالي لا يدعم ملفات PDF. سيتم إرسال النص فقط.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ حجم الملف النصي أكبر من الحد المسموح ({maxSizeKb}KB)",
 
   "status.header_running": "🟢 خادم OpenCode يعمل",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -8,6 +8,7 @@ export const de: I18nDictionary = {
   "cmd.description.sessions": "Sitzungen auflisten",
   "cmd.description.messages": "Sitzungsnachrichten durchsuchen",
   "cmd.description.tts": "Audioantworten umschalten",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "Projekte auflisten",
   "cmd.description.worktree": "Git-Worktrees wechseln",
   "cmd.description.task": "Geplante Aufgabe erstellen",
@@ -105,6 +106,20 @@ export const de: I18nDictionary = {
   "bot.media_group_download_error":
     "🔴 Eine der Dateien konnte nicht heruntergeladen werden. Es wurde nichts an OpenCode gesendet.",
   "bot.model_no_pdf": "⚠️ Das aktuelle Modell unterstützt keine PDF-Eingabe. Sende nur Text.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ Textdatei ist zu groß (max. {maxSizeKb}KB)",
 
   "status.header_running": "🟢 OpenCode-Server läuft",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,6 +6,7 @@ export const en = {
   "cmd.description.sessions": "List sessions",
   "cmd.description.messages": "Browse session messages",
   "cmd.description.tts": "Toggle audio replies",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "List projects",
   "cmd.description.worktree": "Switch git worktrees",
   "cmd.description.task": "Create a scheduled task",
@@ -98,6 +99,20 @@ export const en = {
   "bot.media_group_download_error":
     "🔴 Failed to download one of the files. Nothing was sent to OpenCode.",
   "bot.model_no_pdf": "⚠️ Current model doesn't support PDF input. Sending text only.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ Text file is too large (max {maxSizeKb}KB)",
 
   "status.header_running": "🟢 OpenCode Server is running",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -8,6 +8,7 @@ export const es: I18nDictionary = {
   "cmd.description.sessions": "Listar sesiones",
   "cmd.description.messages": "Ver mensajes de la sesión",
   "cmd.description.tts": "Alternar respuestas de audio",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "Listar proyectos",
   "cmd.description.worktree": "Cambiar worktrees de git",
   "cmd.description.task": "Crear tarea programada",
@@ -105,6 +106,20 @@ export const es: I18nDictionary = {
   "bot.media_group_download_error":
     "🔴 No se pudo descargar uno de los archivos. No se envió nada a OpenCode.",
   "bot.model_no_pdf": "⚠️ El modelo actual no admite entrada PDF. Enviaré solo texto.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ El archivo de texto es demasiado grande (max {maxSizeKb}KB)",
 
   "status.header_running": "🟢 OpenCode Server está en ejecución",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -8,6 +8,7 @@ export const fr: I18nDictionary = {
   "cmd.description.sessions": "Lister les sessions",
   "cmd.description.messages": "Parcourir les messages de session",
   "cmd.description.tts": "Basculer les réponses audio",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "Lister les projets",
   "cmd.description.worktree": "Changer de worktree git",
   "cmd.description.task": "Créer une tâche planifiée",
@@ -107,6 +108,20 @@ export const fr: I18nDictionary = {
     "🔴 Impossible de télécharger l'un des fichiers. Rien n'a été envoyé à OpenCode.",
   "bot.model_no_pdf":
     "⚠️ Le modèle actuel ne prend pas en charge les PDF. Envoi du texte uniquement.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ Le fichier texte est trop volumineux (max {maxSizeKb}KB)",
 
   "status.header_running": "🟢 Le serveur OpenCode est en cours d'exécution",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -8,6 +8,7 @@ export const ru: I18nDictionary = {
   "cmd.description.sessions": "Список сессий",
   "cmd.description.messages": "Сообщения текущей сессии",
   "cmd.description.tts": "Переключить аудиоответы",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "Список проектов",
   "cmd.description.worktree": "Переключить git worktree",
   "cmd.description.task": "Создать задачу по расписанию",
@@ -98,6 +99,20 @@ export const ru: I18nDictionary = {
   "bot.media_group_download_error":
     "🔴 Не удалось скачать один из файлов. В OpenCode ничего не отправлено.",
   "bot.model_no_pdf": "⚠️ Текущая модель не поддерживает PDF. Отправляю только текст.",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ Текстовый файл слишком большой (макс. {maxSizeKb}КБ)",
 
   "status.header_running": "🟢 OpenCode Server запущен",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -8,6 +8,7 @@ export const zh: I18nDictionary = {
   "cmd.description.sessions": "列出会话",
   "cmd.description.messages": "浏览会话消息",
   "cmd.description.tts": "切换语音回复",
+  "cmd.description.setvision": "Set vision model for image description",
   "cmd.description.projects": "列出项目",
   "cmd.description.worktree": "切换 git worktree",
   "cmd.description.task": "创建定时任务",
@@ -86,6 +87,20 @@ export const zh: I18nDictionary = {
   "bot.media_group_not_processed": "⚠️ 此相册中有一个或多个文件无法处理。未向 OpenCode 发送任何内容。",
   "bot.media_group_download_error": "🔴 无法下载其中一个文件。未向 OpenCode 发送任何内容。",
   "bot.model_no_pdf": "⚠️ 当前模型不支持PDF输入。将仅发送文本。",
+
+  "bot.vision_describing": "🔍 Analyzing image with vision model...",
+  "bot.vision_describe_error": "⚠️ Failed to describe image. Sending text only.",
+
+  "vision.select_prompt": "Select a model for image description:",
+  "vision.current": "Current vision model: {name}",
+  "vision.model_set": "Vision model set",
+  "vision.model_set_message": "✅ Vision model: {name}",
+  "vision.model_cleared": "Vision model cleared",
+  "vision.cleared": "Cleared",
+  "vision.change": "🔄 Change",
+  "vision.clear": "❌ Clear",
+  "vision.no_models": "No models available. Configure models in OpenCode first.",
+  "vision.error": "Failed to update vision model.",
   "bot.text_file_too_large": "⚠️ 文本文件过大（最大 {maxSizeKb}KB）",
 
   "status.header_running": "🟢 OpenCode 服务器正在运行",

--- a/tests/bot/routers/command-router.test.ts
+++ b/tests/bot/routers/command-router.test.ts
@@ -18,6 +18,7 @@ describe("bot/routers/command-router", () => {
       "help",
       "status",
       "tts",
+      "setvision",
       "opencode_start",
       "opencode_stop",
       "projects",


### PR DESCRIPTION
## What

Adds an auxiliary vision model fallback. When the user sends an image to a model that **does not** support image input, the bot:

1. Automatically detects the current model lacks vision capability
2. Sends the image to a vision model **configured by the user** (via `/setvision`)
3. The vision model describes the image (with dynamic prompt: if a caption is provided, describes in context of the user question)
4. The textual description is forwarded to the main model, which continues processing

Everything is automatic — no user confirmation required. If no vision model is configured, the bot behaves exactly as before (error message + text-only fallback).

Closes #151

## Commands

- `/setvision` — shows a menu to select a vision model. If already set, shows the current model with "Change" and "Clear" options
- The vision model selection persists in `settings.json` across restarts

## Technical changes

**3 new files:**
- `src/app/services/vision-model-service.ts` — service: `describeImage()` creates a temporary session, calls `session.prompt()` synchronously with the vision model, extracts the text description, deletes the session
- `src/bot/commands/setvision-command.ts` — `/setvision` command handler
- `src/bot/callbacks/vision-model-callback-handler.ts` — inline menu callback for vision model selection

**17 modified files:**
- `src/app/types/settings.ts` / `src/app/stores/settings-store.ts` — new `currentVisionModel` field
- `src/bot/handlers/photo-handler.ts` — vision fallback in `!supportsImage` branch
- `src/bot/handlers/document-handler.ts` — fallback for image documents
- `src/bot/handlers/media-group-handler.ts` — fallback for media groups with images
- `src/bot/routers/command-router.ts` / `callback-router.ts` — command and callback registration
- `src/bot/menus/inline-menu.ts` — added `"vision"` menu kind
- `src/bot/commands/definitions.ts` — command list registration
- `src/i18n/*.ts` — 11 new i18n keys across 7 languages

## Notes

- The temporary vision session is created as a **child** of the foreground session to suppress background session notifications
- The vision model call uses `session.prompt()` (synchronous) rather than `promptAsync()`, since the full response is needed to continue the flow
- The image description prompt is dynamic: if the user wrote a caption, the prompt is _"The user asked: [caption]. Please describe the image focusing on the most relevant aspects."_ — otherwise _"Please describe this image in detail."_