### PR TITLE
feat: react to incoming user messages with a random emoji ack

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -13,6 +13,7 @@ import { safeBackgroundTask } from "../utils/safe-background-task.js";
 import { withTelegramRateLimitRetry } from "../utils/telegram-rate-limit-retry.js";
 import { registerCallbackRouter } from "./callbacks/callback-router.js";
 import { authMiddleware } from "./middleware/auth.js";
+import { reactionMiddleware } from "./middleware/reaction.js";
 import { interactionGuardMiddleware } from "./middleware/interaction-guard.js";
 import {
   ensureCommandsInitialized,
@@ -115,6 +116,7 @@ export function createBot(): Bot<Context> {
   });
 
   bot.use(authMiddleware);
+  bot.use(reactionMiddleware);
   bot.use(ensureCommandsInitialized);
   bot.use(interactionGuardMiddleware);
 

--- a/src/bot/middleware/reaction.ts
+++ b/src/bot/middleware/reaction.ts
@@ -1,0 +1,18 @@
+import { Context, NextFunction } from "grammy";
+import { pickReactionEmoji } from "../reactions.js";
+import { logger } from "../../utils/logger.js";
+
+export async function reactionMiddleware(ctx: Context, next: NextFunction): Promise<void> {
+  if (ctx.message && !ctx.message.from?.is_bot) {
+    const emoji = pickReactionEmoji();
+    ctx.api
+      .setMessageReaction(ctx.chat!.id, ctx.message.message_id, [
+        { type: "emoji", emoji },
+      ])
+      .catch((err) => {
+        logger.debug(`[Reaction] Failed to react to message ${ctx.message!.message_id}: ${err}`);
+      });
+  }
+
+  await next();
+}

--- a/src/bot/reactions.ts
+++ b/src/bot/reactions.ts
@@ -1,0 +1,5 @@
+const ACK_REACTIONS = ["👍", "❤", "🔥", "🎉", "😁", "🤩", "👏", "⚡", "🙏", "👌", "💯", "🏆", "❤‍🔥", "🕊", "🤓", "👀", "😇", "🤝", "✍", "🤗", "🫡", "🤪", "🆒", "🦄", "😎", "👾"] as const;
+
+export function pickReactionEmoji(): (typeof ACK_REACTIONS)[number] {
+  return ACK_REACTIONS[Math.floor(Math.random() * ACK_REACTIONS.length)];
+}

--- a/tests/bot/reactions.test.ts
+++ b/tests/bot/reactions.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest";
+import { pickReactionEmoji } from "../../src/bot/reactions.js";
+
+describe("bot/reactions", () => {
+  it("returns a valid emoji from the pool", () => {
+    const emoji = pickReactionEmoji();
+    const validEmojis = ["👍", "❤", "🔥", "🎉", "😁", "🤩", "👏", "⚡", "🙏", "👌", "💯", "🏆", "❤‍🔥", "🕊", "🤓", "👀", "😇", "🤝", "✍", "🤗", "🫡", "🤪", "🆒", "🦄", "😎", "👾"];
+    expect(validEmojis).toContain(emoji);
+  });
+
+  it("returns different emojis over multiple calls", () => {
+    const results = new Set(Array.from({ length: 100 }, () => pickReactionEmoji()));
+    expect(results.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Adds a middleware that reacts to every incoming user message with a random emoji from a curated pool of 26 Telegram-supported reaction emojis.

- Fire-and-forget — never blocks message processing
- Registered after auth, before interaction guard — user sees ack even when busy
- Existing rate-limit retry wrapper handles Telegram rate limits gracefully
- Includes unit tests for emoji selection