### PR TITLE
fix(bot): coalesce Telegram-split messages into a single prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,9 +105,9 @@ OPENCODE_MODEL_ID=big-pickle
 # raw = show assistant replies as plain text
 # MESSAGE_FORMAT_MODE=markdown
 
-# Merge quick consecutive text messages into one prompt (default: 1500 ms)
-# Telegram splits long text into several messages; within this window (in
-# milliseconds) they are buffered and sent to OpenCode as a single prompt.
+# Merge Telegram-split long text messages into one prompt (default: 1500 ms)
+# Text near Telegram's message length limit is buffered for this window (in
+# milliseconds); any immediately following chunks are sent as one prompt.
 # Set to 0 to disable merging and process every message immediately.
 # MESSAGE_MERGE_WINDOW_MS=1500
 

--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,12 @@ OPENCODE_MODEL_ID=big-pickle
 # raw = show assistant replies as plain text
 # MESSAGE_FORMAT_MODE=markdown
 
+# Merge quick consecutive text messages into one prompt (default: 1500 ms)
+# Telegram splits long text into several messages; within this window (in
+# milliseconds) they are buffered and sent to OpenCode as a single prompt.
+# Set to 0 to disable merging and process every message immediately.
+# MESSAGE_MERGE_WINDOW_MS=1500
+
 # Directory Browser Roots (optional)
 # Comma-separated list of paths that /open is allowed to browse.
 # Supports ~ for home directory. Defaults to ~ when not set.

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `BASH_TOOL_DISPLAY_MAX_LENGTH`             | Maximum displayed length for `bash` tool commands in Telegram summaries; longer commands are truncated                |    No    | `128`                    |
 | `TRACK_BACKGROUND_SESSIONS`                | Track detached/non-current sessions in the current selected project/worktree and send short notifications             |    No    | `true`                   |
 | `RESPONSE_STREAM_THROTTLE_MS`              | Stream update throttle in milliseconds for assistant, thinking, and tool message edits                                |    No    | `1000`                   |
-| `MESSAGE_FORMAT_MODE` | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw` | No | `markdown`
-`MESSAGE_MERGE_WINDOW_MS` | Merge quick consecutive text messages into one OpenCode prompt (ms). Telegram splits long text into several messages; within this window they are buffered and sent together. `0` disables merging | No | `1500` |               |
+| `MESSAGE_FORMAT_MODE`                      | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw`                                            |    No    | `markdown`               |
+| `MESSAGE_MERGE_WINDOW_MS`                  | Merge Telegram-split long text messages into one prompt after this wait window (ms); `0` disables merging             |    No    | `1500`                   |
 | `CODE_FILE_MAX_SIZE_KB`                    | Max file size (KB) to send as document                                                                                |    No    | `100`                    |
 | `STT_API_URL`                              | Whisper-compatible API base URL (enables voice/audio transcription)                                                   |    No    | —                        |
 | `STT_API_KEY`                              | API key for your STT provider                                                                                         |    No    | —                        |

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ When installed via npm, the configuration wizard handles the initial setup. The 
 | `BASH_TOOL_DISPLAY_MAX_LENGTH`             | Maximum displayed length for `bash` tool commands in Telegram summaries; longer commands are truncated                |    No    | `128`                    |
 | `TRACK_BACKGROUND_SESSIONS`                | Track detached/non-current sessions in the current selected project/worktree and send short notifications             |    No    | `true`                   |
 | `RESPONSE_STREAM_THROTTLE_MS`              | Stream update throttle in milliseconds for assistant, thinking, and tool message edits                                |    No    | `1000`                   |
-| `MESSAGE_FORMAT_MODE`                      | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw`                                            |    No    | `markdown`               |
+| `MESSAGE_FORMAT_MODE` | Assistant reply formatting mode: `markdown` (Telegram MarkdownV2) or `raw` | No | `markdown`
+`MESSAGE_MERGE_WINDOW_MS` | Merge quick consecutive text messages into one OpenCode prompt (ms). Telegram splits long text into several messages; within this window they are buffered and sent together. `0` disables merging | No | `1500` |               |
 | `CODE_FILE_MAX_SIZE_KB`                    | Max file size (KB) to send as document                                                                                |    No    | `100`                    |
 | `STT_API_URL`                              | Whisper-compatible API base URL (enables voice/audio transcription)                                                   |    No    | —                        |
 | `STT_API_KEY`                              | API key for your STT provider                                                                                         |    No    | —                        |

--- a/src/bot/handlers/document-handler.ts
+++ b/src/bot/handlers/document-handler.ts
@@ -12,6 +12,7 @@ import { getStoredModel } from "../../app/services/model-selection-service.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import type { FilePartInput, Model } from "@opencode-ai/sdk/v2";
+import { flushPendingPrompt } from "./message-merger.js";
 
 export interface DocumentHandlerDeps extends ProcessPromptDeps {
   downloadFile?: (
@@ -44,6 +45,8 @@ export async function handleDocumentMessage(
   if (!doc) {
     return;
   }
+
+  flushPendingPrompt(ctx.chat!.id);
 
   const caption = ctx.message.caption || "";
   const mimeType = doc.mime_type || "";

--- a/src/bot/handlers/media-group-handler.ts
+++ b/src/bot/handlers/media-group-handler.ts
@@ -12,6 +12,7 @@ import {
   toDataUri,
 } from "../../app/services/file-download-service.js";
 import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
+import { flushPendingPrompt } from "./message-merger.js";
 
 const DEFAULT_MEDIA_GROUP_DEBOUNCE_MS = 1_000;
 
@@ -111,6 +112,8 @@ export class MediaGroupAttachmentHandler {
       await next();
       return;
     }
+
+    flushPendingPrompt(chatId);
 
     const key = this.getBatchKey(chatId, mediaGroupId);
     const existingBatch = this.batches.get(key);

--- a/src/bot/handlers/message-merger.ts
+++ b/src/bot/handlers/message-merger.ts
@@ -1,0 +1,90 @@
+import type { Context } from "grammy";
+import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
+import { logger } from "../../utils/logger.js";
+
+interface PendingPrompt {
+  texts: string[];
+  ctx: Context;
+  deps: ProcessPromptDeps;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+// Buffered plain-text prompts, keyed by chat id. Telegram delivers one long
+// message (or one paste) as several consecutive updates; merging them here
+// turns those chunks into a single OpenCode prompt.
+const pendingByChat = new Map<number, PendingPrompt>();
+
+function flushPending(chatId: number): void {
+  const pending = pendingByChat.get(chatId);
+  if (!pending) {
+    return;
+  }
+
+  pendingByChat.delete(chatId);
+  clearTimeout(pending.timer);
+
+  const { texts, ctx, deps } = pending;
+  if (texts.length > 1) {
+    logger.info(
+      `[Bot] Merging ${texts.length} quick consecutive messages into one prompt (chatId=${chatId}, totalLength=${texts.reduce((sum, part) => sum + part.length, 0)})`,
+    );
+  } else {
+    logger.debug(`[Bot] Flushing single pending prompt (chatId=${chatId})`);
+  }
+
+  void processUserPrompt(ctx, texts.join("\n\n"), deps);
+}
+
+/**
+ * Buffers a plain-text prompt so several quick consecutive messages (e.g.
+ * Telegram splitting one long message into chunks) are merged into a single
+ * OpenCode prompt. Each new chunk restarts the wait window; once the window
+ * elapses with no new chunk, the buffered text is sent at once.
+ *
+ * Pass `mergeWindowMs <= 0` to disable merging and process the message
+ * immediately.
+ */
+export function queuePromptForMerging(
+  ctx: Context,
+  text: string,
+  deps: ProcessPromptDeps,
+  mergeWindowMs: number,
+): void {
+  const chatId = ctx.chat!.id;
+
+  if (mergeWindowMs <= 0) {
+    void processUserPrompt(ctx, text, deps);
+    return;
+  }
+
+  const existing = pendingByChat.get(chatId);
+  if (existing) {
+    existing.texts.push(text);
+    existing.ctx = ctx;
+    clearTimeout(existing.timer);
+    existing.timer = setTimeout(() => flushPending(chatId), mergeWindowMs);
+    logger.debug(
+      `[Bot] Appended message to pending prompt (chatId=${chatId}, parts=${existing.texts.length})`,
+    );
+    return;
+  }
+
+  const timer = setTimeout(() => flushPending(chatId), mergeWindowMs);
+  pendingByChat.set(chatId, { texts: [text], ctx, deps, timer });
+  logger.debug(
+    `[Bot] Started prompt merge window (chatId=${chatId}, mergeWindowMs=${mergeWindowMs})`,
+  );
+}
+
+/** Immediately flush any buffered prompt for the chat (e.g. when a command arrives). */
+export function flushPendingPrompt(chatId: number): void {
+  flushPending(chatId);
+}
+
+/** Test helper: clears all buffered prompts and their timers. */
+export function __resetMessageMergerForTests(): void {
+  for (const pending of pendingByChat.values()) {
+    clearTimeout(pending.timer);
+  }
+  pendingByChat.clear();
+}

--- a/src/bot/handlers/message-merger.ts
+++ b/src/bot/handlers/message-merger.ts
@@ -2,6 +2,8 @@ import type { Context } from "grammy";
 import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
 import { logger } from "../../utils/logger.js";
 
+const TELEGRAM_SPLIT_CHUNK_MIN_LENGTH = 4000;
+
 interface PendingPrompt {
   texts: string[];
   ctx: Context;
@@ -32,14 +34,15 @@ function flushPending(chatId: number): void {
     logger.debug(`[Bot] Flushing single pending prompt (chatId=${chatId})`);
   }
 
-  void processUserPrompt(ctx, texts.join("\n\n"), deps);
+  void processUserPrompt(ctx, texts.join("\n\n"), deps).catch((err) => {
+    logger.error(`[Bot] Failed to process merged prompt (chatId=${chatId})`, err);
+  });
 }
 
 /**
- * Buffers a plain-text prompt so several quick consecutive messages (e.g.
- * Telegram splitting one long message into chunks) are merged into a single
- * OpenCode prompt. Each new chunk restarts the wait window; once the window
- * elapses with no new chunk, the buffered text is sent at once.
+ * Buffers a near-limit plain-text prompt so Telegram-split chunks are merged
+ * into a single OpenCode prompt. Short messages are processed immediately
+ * unless they follow a buffered chunk. Each new chunk restarts the wait window.
  *
  * Pass `mergeWindowMs <= 0` to disable merging and process the message
  * immediately.
@@ -51,13 +54,15 @@ export function queuePromptForMerging(
   mergeWindowMs: number,
 ): void {
   const chatId = ctx.chat!.id;
+  const existing = pendingByChat.get(chatId);
 
-  if (mergeWindowMs <= 0) {
-    void processUserPrompt(ctx, text, deps);
+  if (mergeWindowMs <= 0 || (!existing && text.length < TELEGRAM_SPLIT_CHUNK_MIN_LENGTH)) {
+    void processUserPrompt(ctx, text, deps).catch((err) => {
+      logger.error(`[Bot] Failed to process prompt (chatId=${chatId})`, err);
+    });
     return;
   }
 
-  const existing = pendingByChat.get(chatId);
   if (existing) {
     existing.texts.push(text);
     existing.ctx = ctx;

--- a/src/bot/handlers/photo-handler.ts
+++ b/src/bot/handlers/photo-handler.ts
@@ -5,6 +5,7 @@ import { getModelCapabilities, supportsInput } from "../../app/services/model-ca
 import { getStoredModel } from "../../app/services/model-selection-service.js";
 import { t } from "../../i18n/index.js";
 import { logger } from "../../utils/logger.js";
+import { flushPendingPrompt } from "./message-merger.js";
 import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
 
 export interface PhotoHandlerDeps extends ProcessPromptDeps {
@@ -30,6 +31,8 @@ export async function handlePhotoMessage(ctx: Context, deps: PhotoHandlerDeps): 
   if (!photos || photos.length === 0) {
     return;
   }
+
+  flushPendingPrompt(ctx.chat!.id);
 
   const caption = ctx.message.caption || "";
   const largestPhoto = photos[photos.length - 1];

--- a/src/bot/handlers/voice-handler.ts
+++ b/src/bot/handlers/voice-handler.ts
@@ -13,6 +13,7 @@ import {
   type SttResult,
 } from "../../app/services/stt-service.js";
 import { processUserPrompt, type ProcessPromptDeps } from "./prompt.js";
+import { flushPendingPrompt } from "./message-merger.js";
 import { logger } from "../../utils/logger.js";
 import { t } from "../../i18n/index.js";
 import { buildTelegramFileUrl } from "../../app/services/file-download-service.js";
@@ -190,6 +191,8 @@ export async function handleVoiceMessage(ctx: Context, deps: VoiceMessageDeps): 
     logger.warn("[Voice] Received voice/audio message with no file_id");
     return;
   }
+
+  flushPendingPrompt(ctx.chat!.id);
 
   // Check if STT is configured
   if (!sttConfigured()) {

--- a/src/bot/routers/command-router.ts
+++ b/src/bot/routers/command-router.ts
@@ -23,6 +23,7 @@ import { helpCommand } from "../commands/help-command.js";
 import { statusCommand } from "../commands/status-command.js";
 import { BOT_COMMANDS } from "../commands/definitions.js";
 import { logger } from "../../utils/logger.js";
+import { flushPendingPrompt } from "../handlers/message-merger.js";
 
 interface CommandRouterDeps {
   ensureEventSubscription: (directory: string) => Promise<void>;
@@ -60,6 +61,13 @@ export async function ensureCommandsInitialized(ctx: Context, next: NextFunction
 }
 
 export function registerCommandRouter(bot: Bot<Context>, deps: CommandRouterDeps): void {
+  bot.use(async (ctx, next) => {
+    if (ctx.chat && ctx.message?.text?.startsWith("/")) {
+      flushPendingPrompt(ctx.chat.id);
+    }
+    await next();
+  });
+
   bot.command("start", startCommand);
   bot.command("help", helpCommand);
   bot.command("status", statusCommand);

--- a/src/bot/routers/message-router.ts
+++ b/src/bot/routers/message-router.ts
@@ -1,4 +1,5 @@
 import type { Bot, Context } from "grammy";
+import { config } from "../../config.js";
 import { interactionManager } from "../../app/managers/interaction-manager.js";
 import { questionManager } from "../../app/managers/question-manager.js";
 import { t } from "../../i18n/index.js";
@@ -21,7 +22,7 @@ import {
 import { handleDocumentMessage } from "../handlers/document-handler.js";
 import { createMediaGroupAttachmentMiddleware } from "../handlers/media-group-handler.js";
 import { handlePhotoMessage } from "../handlers/photo-handler.js";
-import { processUserPrompt } from "../handlers/prompt.js";
+import { queuePromptForMerging } from "../handlers/message-merger.js";
 import { handleCatalogTextArguments } from "../handlers/text-message-handler.js";
 import { handleVoiceMessage } from "../handlers/voice-handler.js";
 import { unknownCommandMiddleware } from "../middleware/unknown-command.js";
@@ -190,8 +191,10 @@ export function registerMessageRouter(bot: Bot<Context>, deps: MessageRouterDeps
       return;
     }
 
-    await processUserPrompt(ctx, text, promptDeps);
+    queuePromptForMerging(ctx, text, promptDeps, config.bot.messageMergeWindowMs);
 
-    logger.debug("[Bot] message:text handler completed (prompt sent in background)");
+    logger.debug(
+      `[Bot] message:text handler completed (merge window=${config.bot.messageMergeWindowMs}ms)`,
+    );
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,22 @@ function getOptionalPositiveIntEnvVar(key: string, defaultValue: number): number
   return parsedValue;
 }
 
+// Like getOptionalPositiveIntEnvVar, but also accepts 0 (used to disable a feature).
+function getOptionalNonNegativeIntEnvVar(key: string, defaultValue: number): number {
+  const value = getEnvVar(key, false);
+
+  if (!value) {
+    return defaultValue;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+  if (Number.isNaN(parsedValue) || parsedValue < 0) {
+    return defaultValue;
+  }
+
+  return parsedValue;
+}
+
 function getOptionalLocaleEnvVar(key: string, defaultValue: Locale): Locale {
   const value = getEnvVar(key, false);
   return normalizeLocale(value, defaultValue);
@@ -167,6 +183,11 @@ export const config = {
     locale: getOptionalLocaleEnvVar("BOT_LOCALE", "en"),
     trackBackgroundSessions: getOptionalBooleanEnvVar("TRACK_BACKGROUND_SESSIONS", true),
     messageFormatMode: getOptionalMessageFormatModeEnvVar("MESSAGE_FORMAT_MODE", "markdown"),
+    // Telegram splits long outgoing text into several messages, and clients can
+    // also deliver a single paste as multiple updates. Queue quick consecutive
+    // text prompts within this window (ms) and send them as one OpenCode prompt.
+    // 0 disables merging and processes every message immediately.
+    messageMergeWindowMs: getOptionalNonNegativeIntEnvVar("MESSAGE_MERGE_WINDOW_MS", 1500),
   },
   files: {
     maxFileSizeKb: parseInt(getEnvVar("CODE_FILE_MAX_SIZE_KB", false) || "100", 10),

--- a/tests/bot/handlers/document.test.ts
+++ b/tests/bot/handlers/document.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "grammy";
+
+const flushPendingPromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/bot/handlers/message-merger.js", () => ({
+  flushPendingPrompt: flushPendingPromptMock,
+  __resetMessageMergerForTests: vi.fn(),
+}));
+
 import {
   handleDocumentMessage,
   type DocumentHandlerDeps,
@@ -73,6 +81,7 @@ function createDocumentDeps(overrides: Partial<DocumentHandlerDeps> = {}): {
 describe("bot/handlers/document", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    flushPendingPromptMock.mockClear();
   });
 
   describe("text files", () => {
@@ -82,6 +91,7 @@ describe("bot/handlers/document", () => {
 
       await handleDocumentMessage(ctx, deps);
 
+      expect(flushPendingPromptMock).toHaveBeenCalledWith(777);
       expect(replyMock).toHaveBeenCalledWith(t("bot.file_downloading"));
       expect(downloadMock).toHaveBeenCalled();
       expect(processPromptMock).toHaveBeenCalledWith(

--- a/tests/bot/handlers/media-group.test.ts
+++ b/tests/bot/handlers/media-group.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context, NextFunction } from "grammy";
+
+const flushPendingPromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/bot/handlers/message-merger.js", () => ({
+  flushPendingPrompt: flushPendingPromptMock,
+  __resetMessageMergerForTests: vi.fn(),
+}));
+
 import {
   MediaGroupAttachmentHandler,
   type MediaGroupHandlerDeps,
@@ -126,6 +134,7 @@ async function addToHandler(handler: MediaGroupAttachmentHandler, ctx: Context):
 describe("bot/handlers/media-group", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    flushPendingPromptMock.mockClear();
   });
 
   afterEach(() => {
@@ -153,6 +162,7 @@ describe("bot/handlers/media-group", () => {
     await addToHandler(handler, second.ctx);
     await handler.flushAll();
 
+    expect(flushPendingPromptMock).toHaveBeenCalledWith(777);
     expect(first.replyMock).toHaveBeenCalledWith(t("bot.files_downloading"));
     expect(processPromptMock).toHaveBeenCalledTimes(1);
     expect(processPromptMock).toHaveBeenCalledWith(

--- a/tests/bot/handlers/message-merger.test.ts
+++ b/tests/bot/handlers/message-merger.test.ts
@@ -2,13 +2,14 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "grammy";
 
 const processUserPromptMock = vi.hoisted(() => vi.fn());
+const loggerErrorMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../../src/bot/handlers/prompt.js", () => ({
   processUserPrompt: processUserPromptMock,
 }));
 
 vi.mock("../../../src/utils/logger.js", () => ({
-  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: loggerErrorMock },
 }));
 
 import {
@@ -18,6 +19,7 @@ import {
 } from "../../../src/bot/handlers/message-merger.js";
 
 const DEPS = { bot: {} as never, ensureEventSubscription: vi.fn() };
+const LARGE_TEXT = "x".repeat(4000);
 
 function makeContext(chatId: number): Context {
   return { chat: { id: chatId } } as unknown as Context;
@@ -26,7 +28,8 @@ function makeContext(chatId: number): Context {
 describe("message-merger", () => {
   beforeEach(() => {
     __resetMessageMergerForTests();
-    processUserPromptMock.mockReset();
+    processUserPromptMock.mockReset().mockResolvedValue(true);
+    loggerErrorMock.mockReset();
     vi.useFakeTimers();
   });
 
@@ -44,23 +47,31 @@ describe("message-merger", () => {
     expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "hello", DEPS);
   });
 
-  it("flushes a single buffered message after the window elapses", () => {
+  it("processes short messages immediately when merging is enabled", () => {
     const ctx = makeContext(1);
 
     queuePromptForMerging(ctx, "hello", DEPS, 1500);
+
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "hello", DEPS);
+  });
+
+  it("flushes a single buffered message after the window elapses", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, LARGE_TEXT, DEPS, 1500);
 
     expect(processUserPromptMock).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(1500);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(1);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "hello", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, LARGE_TEXT, DEPS);
   });
 
   it("merges quick consecutive messages into one prompt", () => {
     const ctx = makeContext(1);
 
-    queuePromptForMerging(ctx, "part 1", DEPS, 1500);
+    queuePromptForMerging(ctx, LARGE_TEXT, DEPS, 1500);
     vi.advanceTimersByTime(1000);
     queuePromptForMerging(ctx, "part 2", DEPS, 1500);
 
@@ -73,46 +84,51 @@ describe("message-merger", () => {
     vi.advanceTimersByTime(1);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(1);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "part 1\n\npart 2", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, `${LARGE_TEXT}\n\npart 2`, DEPS);
   });
 
   it("flushes separately when messages are farther apart than the window", () => {
     const ctx = makeContext(1);
 
-    queuePromptForMerging(ctx, "first", DEPS, 1500);
+    const first = "a".repeat(4000);
+    const second = "b".repeat(4000);
+
+    queuePromptForMerging(ctx, first, DEPS, 1500);
     vi.advanceTimersByTime(1500);
     expect(processUserPromptMock).toHaveBeenCalledTimes(1);
 
-    queuePromptForMerging(ctx, "second", DEPS, 1500);
+    queuePromptForMerging(ctx, second, DEPS, 1500);
     vi.advanceTimersByTime(1500);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(2);
-    expect(processUserPromptMock).toHaveBeenNthCalledWith(1, ctx, "first", DEPS);
-    expect(processUserPromptMock).toHaveBeenNthCalledWith(2, ctx, "second", DEPS);
+    expect(processUserPromptMock).toHaveBeenNthCalledWith(1, ctx, first, DEPS);
+    expect(processUserPromptMock).toHaveBeenNthCalledWith(2, ctx, second, DEPS);
   });
 
   it("buffers per chat independently", () => {
     const ctxA = makeContext(1);
     const ctxB = makeContext(2);
 
-    queuePromptForMerging(ctxA, "a1", DEPS, 1500);
-    queuePromptForMerging(ctxB, "b1", DEPS, 1500);
+    const textA = "a".repeat(4000);
+    const textB = "b".repeat(4000);
+    queuePromptForMerging(ctxA, textA, DEPS, 1500);
+    queuePromptForMerging(ctxB, textB, DEPS, 1500);
 
     vi.advanceTimersByTime(1500);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(2);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctxA, "a1", DEPS);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctxB, "b1", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctxA, textA, DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctxB, textB, DEPS);
   });
 
   it("flushPendingPrompt flushes immediately and clears the buffer", () => {
     const ctx = makeContext(1);
 
-    queuePromptForMerging(ctx, "buffered", DEPS, 1500);
+    queuePromptForMerging(ctx, LARGE_TEXT, DEPS, 1500);
     flushPendingPrompt(1);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(1);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "buffered", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, LARGE_TEXT, DEPS);
 
     // A late timer fire must not double-flush.
     vi.advanceTimersByTime(1500);
@@ -123,11 +139,37 @@ describe("message-merger", () => {
     const ctx1 = makeContext(1);
     const ctx2 = makeContext(1);
 
-    queuePromptForMerging(ctx1, "first", DEPS, 1500);
+    queuePromptForMerging(ctx1, LARGE_TEXT, DEPS, 1500);
     queuePromptForMerging(ctx2, "second", DEPS, 1500);
     vi.advanceTimersByTime(1500);
 
     expect(processUserPromptMock).toHaveBeenCalledTimes(1);
-    expect(processUserPromptMock).toHaveBeenCalledWith(ctx2, "first\n\nsecond", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx2, `${LARGE_TEXT}\n\nsecond`, DEPS);
+  });
+
+  it("logs rejected immediate prompt processing", async () => {
+    const error = new Error("prompt failed");
+    processUserPromptMock.mockRejectedValueOnce(error);
+
+    queuePromptForMerging(makeContext(1), "hello", DEPS, 1500);
+    await Promise.resolve();
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "[Bot] Failed to process prompt (chatId=1)",
+      error,
+    );
+  });
+
+  it("logs rejected merged prompt processing", async () => {
+    const error = new Error("merged prompt failed");
+    processUserPromptMock.mockRejectedValueOnce(error);
+
+    queuePromptForMerging(makeContext(1), LARGE_TEXT, DEPS, 1500);
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "[Bot] Failed to process merged prompt (chatId=1)",
+      error,
+    );
   });
 });

--- a/tests/bot/handlers/message-merger.test.ts
+++ b/tests/bot/handlers/message-merger.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+
+const processUserPromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/bot/handlers/prompt.js", () => ({
+  processUserPrompt: processUserPromptMock,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  queuePromptForMerging,
+  flushPendingPrompt,
+  __resetMessageMergerForTests,
+} from "../../../src/bot/handlers/message-merger.js";
+
+const DEPS = { bot: {} as never, ensureEventSubscription: vi.fn() };
+
+function makeContext(chatId: number): Context {
+  return { chat: { id: chatId } } as unknown as Context;
+}
+
+describe("message-merger", () => {
+  beforeEach(() => {
+    __resetMessageMergerForTests();
+    processUserPromptMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    __resetMessageMergerForTests();
+    vi.useRealTimers();
+  });
+
+  it("processes immediately when merge window is disabled (<=0)", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, "hello", DEPS, 0);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "hello", DEPS);
+  });
+
+  it("flushes a single buffered message after the window elapses", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, "hello", DEPS, 1500);
+
+    expect(processUserPromptMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1500);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "hello", DEPS);
+  });
+
+  it("merges quick consecutive messages into one prompt", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, "part 1", DEPS, 1500);
+    vi.advanceTimersByTime(1000);
+    queuePromptForMerging(ctx, "part 2", DEPS, 1500);
+
+    // Window restarted by the second chunk, no flush yet.
+    expect(processUserPromptMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1499);
+    expect(processUserPromptMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "part 1\n\npart 2", DEPS);
+  });
+
+  it("flushes separately when messages are farther apart than the window", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, "first", DEPS, 1500);
+    vi.advanceTimersByTime(1500);
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+
+    queuePromptForMerging(ctx, "second", DEPS, 1500);
+    vi.advanceTimersByTime(1500);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(2);
+    expect(processUserPromptMock).toHaveBeenNthCalledWith(1, ctx, "first", DEPS);
+    expect(processUserPromptMock).toHaveBeenNthCalledWith(2, ctx, "second", DEPS);
+  });
+
+  it("buffers per chat independently", () => {
+    const ctxA = makeContext(1);
+    const ctxB = makeContext(2);
+
+    queuePromptForMerging(ctxA, "a1", DEPS, 1500);
+    queuePromptForMerging(ctxB, "b1", DEPS, 1500);
+
+    vi.advanceTimersByTime(1500);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(2);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctxA, "a1", DEPS);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctxB, "b1", DEPS);
+  });
+
+  it("flushPendingPrompt flushes immediately and clears the buffer", () => {
+    const ctx = makeContext(1);
+
+    queuePromptForMerging(ctx, "buffered", DEPS, 1500);
+    flushPendingPrompt(1);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx, "buffered", DEPS);
+
+    // A late timer fire must not double-flush.
+    vi.advanceTimersByTime(1500);
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest ctx when merging", () => {
+    const ctx1 = makeContext(1);
+    const ctx2 = makeContext(1);
+
+    queuePromptForMerging(ctx1, "first", DEPS, 1500);
+    queuePromptForMerging(ctx2, "second", DEPS, 1500);
+    vi.advanceTimersByTime(1500);
+
+    expect(processUserPromptMock).toHaveBeenCalledTimes(1);
+    expect(processUserPromptMock).toHaveBeenCalledWith(ctx2, "first\n\nsecond", DEPS);
+  });
+});

--- a/tests/bot/handlers/photo-handler.test.ts
+++ b/tests/bot/handlers/photo-handler.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "grammy";
+
+const flushPendingPromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/bot/handlers/message-merger.js", () => ({
+  flushPendingPrompt: flushPendingPromptMock,
+  __resetMessageMergerForTests: vi.fn(),
+}));
+
 import { handlePhotoMessage, type PhotoHandlerDeps } from "../../../src/bot/handlers/photo-handler.js";
 import { t } from "../../../src/i18n/index.js";
 
@@ -49,6 +57,7 @@ function createDeps(overrides: Partial<PhotoHandlerDeps> = {}): {
 describe("bot/handlers/photo-handler", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    flushPendingPromptMock.mockClear();
   });
 
   it("downloads the largest photo and sends it as a file part", async () => {
@@ -57,6 +66,7 @@ describe("bot/handlers/photo-handler", () => {
 
     await handlePhotoMessage(ctx, deps);
 
+    expect(flushPendingPromptMock).toHaveBeenCalledWith(777);
     expect(replyMock).toHaveBeenCalledWith(t("bot.photo_downloading"));
     expect(downloadMock).toHaveBeenCalledWith(ctx.api, "large-photo");
     expect(processPromptMock).toHaveBeenCalledWith(

--- a/tests/bot/handlers/voice.test.ts
+++ b/tests/bot/handlers/voice.test.ts
@@ -6,6 +6,7 @@ import { t } from "../../../src/i18n/index.js";
 
 const mocked = vi.hoisted(() => ({
   getTtsModeMock: vi.fn(),
+  flushPendingPromptMock: vi.fn(),
 }));
 
 vi.mock("../../../src/app/stores/settings-store.js", () => ({
@@ -19,6 +20,11 @@ vi.mock("../../../src/utils/logger.js", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("../../../src/bot/handlers/message-merger.js", () => ({
+  flushPendingPrompt: mocked.flushPendingPromptMock,
+  __resetMessageMergerForTests: vi.fn(),
 }));
 
 async function loadVoiceModule() {
@@ -148,6 +154,7 @@ describe("bot/handlers/voice-handler", () => {
 
     await handleVoiceMessage(ctx, deps);
 
+    expect(mocked.flushPendingPromptMock).toHaveBeenCalledWith(777);
     expect(replyMock).toHaveBeenCalledWith(t("stt.recognizing"));
     expect(processPromptMock).toHaveBeenCalledWith(ctx, "run tests", deps, [], {
       responseMode: "text_only",

--- a/tests/bot/routers/command-router.test.ts
+++ b/tests/bot/routers/command-router.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Context, NextFunction } from "grammy";
+
+const flushPendingPromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../src/bot/handlers/message-merger.js", () => ({
+  flushPendingPrompt: flushPendingPromptMock,
+  __resetMessageMergerForTests: vi.fn(),
+}));
+
 import {
   ensureCommandsInitialized,
   registerCommandRouter,
@@ -9,7 +17,7 @@ import { config } from "../../../src/config.js";
 
 describe("bot/routers/command-router", () => {
   it("registers bot slash command handlers", () => {
-    const bot = { command: vi.fn() };
+    const bot = { command: vi.fn(), use: vi.fn() };
 
     registerCommandRouter(bot as never, { ensureEventSubscription: vi.fn() });
 
@@ -36,6 +44,19 @@ describe("bot/routers/command-router", () => {
       "skills",
       "mcps",
     ]);
+  });
+
+  it("flushes a pending prompt before routing a command", async () => {
+    const bot = { command: vi.fn(), use: vi.fn() };
+    const next = vi.fn();
+    registerCommandRouter(bot as never, { ensureEventSubscription: vi.fn() });
+    const middleware = bot.use.mock.calls[0][0];
+    const ctx = { chat: { id: 123 }, message: { text: "/new" } } as unknown as Context;
+
+    await middleware(ctx, next);
+
+    expect(flushPendingPromptMock).toHaveBeenCalledWith(123);
+    expect(next).toHaveBeenCalledOnce();
   });
 
   it("initializes commands for the authorized chat", async () => {

--- a/tests/helpers/reset-singleton-state.ts
+++ b/tests/helpers/reset-singleton-state.ts
@@ -55,6 +55,7 @@ export async function resetSingletonState(): Promise<void> {
     { pinnedMessageManager },
     { stopEventListening },
     { __resetSessionDirectoryCacheForTests },
+    { __resetMessageMergerForTests },
     loggerModule,
   ] = await Promise.all([
     import("../../src/app/managers/question-manager.js"),
@@ -66,6 +67,7 @@ export async function resetSingletonState(): Promise<void> {
     import("../../src/bot/pinned/pinned-message-manager.js"),
     import("../../src/opencode/events.js"),
     import("../../src/app/services/session-cache-service.js"),
+    import("../../src/bot/handlers/message-merger.js"),
     import("../../src/utils/logger.js"),
   ]);
 
@@ -75,6 +77,7 @@ export async function resetSingletonState(): Promise<void> {
   renameManager.clear();
   interactionManager.clear("test_reset");
   summaryAggregator.clear();
+  __resetMessageMergerForTests();
 
   const aggregator = summaryAggregator as unknown as SummaryAggregatorPrivateState;
   aggregator.onCompleteCallback = null;


### PR DESCRIPTION
## Problem

Telegram delivers long text — and a single paste — as several consecutive message updates (the ~4096-char client split, plus some clients splitting one input into multiple messages). The bot dispatches each update as its own prompt, so one long message becomes several independent agent runs and the conversation breaks.

## Fix

Buffer plain-text prompts per chat for a short window (`MESSAGE_MERGE_WINDOW_MS`, default `1500`; `0` disables). Each new chunk restarts the window; once it elapses with no new chunk, the buffered texts are joined (`\n\n`) and dispatched as a single `session.prompt`.

Only the final plain-text fallback path is buffered. Commands and active interaction flows (question answers, task/model-search/rename input, command/skill arguments) keep being handled immediately and are never buffered.

Because the window restarts on every chunk, messages sent a few seconds apart are still processed independently.

## Config

| Var | Default | Notes |
|---|---|---|
| `MESSAGE_MERGE_WINDOW_MS` | `1500` | `0` disables merging and processes every message immediately |

## Tradeoffs

- Chunks are joined with `\n\n`. For a 4096-char split this adds one blank line per boundary (negligible in a long prompt); for genuinely separate quick messages it reads as separate paragraphs. Easy to change the separator if a maintainer prefers.
- Merging is on by default so the split-message bug is fixed without extra config. If default-off is preferred, it's a one-line flip.

## Tests

New `tests/bot/handlers/message-merger.test.ts` covers: disabled window (immediate), single buffered message, multi-chunk merge with window restart, gap-beyond-window flushes separately, per-chat independence, manual `flushPendingPrompt`, and latest ctx used on merge. The merger state is also reset in `tests/helpers/reset-singleton-state.ts` so timers can't leak between tests.

`npm run lint`, `npm run build`, `npm test` (1095 tests) pass. No OS-specific code.