### PR TITLE
fix(process): resolve opencode.exe from PATH directly when no .cmd shim exists

### DIFF
--- a/src/opencode/process.ts
+++ b/src/opencode/process.ts
@@ -46,11 +46,20 @@ export function resolveLocalOpencodeTarget(apiUrl: string): LocalOpencodeTarget 
 }
 
 function resolveWindowsOpencodeExe(): string {
-  // npm on Windows usually puts opencode.cmd on PATH (not opencode.exe).
-  // We locate the shim and derive the real exe path from its directory.
   const pathEnv = process.env.PATH ?? "";
   const pathEntries = pathEnv.split(path.delimiter).filter(Boolean);
 
+  // First pass: look for opencode.exe directly on PATH.
+  // Covers non-npm installations (install script, scoop, choco, manual download, etc.).
+  for (const entry of pathEntries) {
+    const candidateExe = path.join(entry, "opencode.exe");
+    if (existsSync(candidateExe)) {
+      return candidateExe;
+    }
+  }
+
+  // Second pass: look for opencode.cmd (npm global install).
+  // Derive the real exe path from the shim location.
   for (const entry of pathEntries) {
     const opencodeCmd = path.join(entry, "opencode.cmd");
     if (!existsSync(opencodeCmd)) {

--- a/tests/opencode/process.test.ts
+++ b/tests/opencode/process.test.ts
@@ -76,6 +76,35 @@ describe("opencode/process", () => {
     }
   });
 
+  it("resolves opencode.exe directly from PATH when no .cmd shim exists", () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const originalPath = process.env.PATH;
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-telegram-bot-"));
+    const binDir = path.join(tempRoot, "bin");
+    const exePath = path.join(binDir, "opencode.exe");
+
+    try {
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(exePath, "", "utf8");
+
+      // Isolate PATH to only the temp dir — no npm .cmd shim on PATH
+      process.env.PATH = binDir;
+
+      const command = createOpencodeServeSpawnCommand({ host: "localhost", port: 4987 });
+      expect(command).toEqual({
+        command: exePath,
+        args: ["serve", "--port", "4987"],
+        windowsHide: true,
+      });
+    } finally {
+      process.env.PATH = originalPath;
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("uses resolved opencode.exe on Windows when opencode.cmd is on PATH and exe exists", () => {
     if (process.platform !== "win32") {
       return;


### PR DESCRIPTION
## Description

When opencode is installed via non-npm methods (official install script, scoop, choco, winget, manual download), only \opencode.exe\ is on PATH — no \.cmd\ shim exists. The current code only searches for \opencode.cmd\, so for these users it falls back to \cmd.exe /c opencode serve\, which still shows a visible console window.

## Fix

Added a first pass in \esolveWindowsOpencodeExe()\ that checks each PATH entry for \opencode.exe\ directly. If found, it's used directly with \windowsHide: true\. Falls through to the existing \.cmd\ logic as before.

## Resolution order

1. **opencode.exe directly on PATH** — covers install script, scoop, choco, winget, manual download
2. **opencode.cmd on PATH → derive .exe** — covers npm global install (existing logic)
3. **cmd.exe /c opencode** — last resort safety net

## Testing

- New test: \esolves opencode.exe directly from PATH when no .cmd shim exists\ — isolates PATH to a temp dir with only \opencode.exe\, asserts the resolved absolute exe path is returned
- Existing tests updated and all pass (6/6)
- Lint passes