### PR TITLE
fix(permission): deduplicate equivalent permission prompts in Telegram UI

### DIFF
--- a/src/app/managers/permission-manager.ts
+++ b/src/app/managers/permission-manager.ts
@@ -1,12 +1,26 @@
-import type { PermissionRequest, PermissionState } from "../types/permission.js";
+import type {
+  GroupedPermissionMessage,
+  PermissionRequest,
+  PermissionState,
+} from "../types/permission.js";
 import { logger } from "../../utils/logger.js";
 
 class PermissionManager {
   private state: PermissionState = {
     requestsByMessageId: new Map(),
+    requestIdsByMessageId: new Map(),
+    messageIdBySignature: new Map(),
   };
   private resolvedRequestIDs = new Set<string>();
   private generation = 0;
+
+  private getRequestSignature(request: PermissionRequest): string {
+    return JSON.stringify({
+      sessionID: request.sessionID,
+      permission: request.permission,
+      patterns: [...request.patterns].sort(),
+    });
+  }
 
   /**
    * Register a new permission request message
@@ -27,17 +41,65 @@ class PermissionManager {
       return false;
     }
 
-    if (this.state.requestsByMessageId.has(messageId)) {
+    const previous = this.state.requestsByMessageId.get(messageId);
+    if (previous) {
       logger.warn(`[PermissionManager] Message ID already tracked, replacing: ${messageId}`);
+      // Drop the replaced request's signature so it cannot later group new
+      // requests behind a message that now shows something else.
+      this.state.messageIdBySignature.delete(this.getRequestSignature(previous));
     }
 
     this.state.requestsByMessageId.set(messageId, request);
+    this.state.requestIdsByMessageId.set(messageId, [request.id]);
+    this.state.messageIdBySignature.set(this.getRequestSignature(request), messageId);
 
     logger.info(
       `[PermissionManager] New permission request: type=${request.permission}, patterns=${request.patterns.join(", ")}, pending=${this.state.requestsByMessageId.size}`,
     );
 
     return true;
+  }
+
+  /**
+   * Attach an equivalent OpenCode request to an already visible Telegram permission message.
+   */
+  addEquivalentRequest(
+    request: PermissionRequest,
+    generation: number = this.generation,
+  ): GroupedPermissionMessage | null {
+    if (generation !== this.generation || this.resolvedRequestIDs.has(request.id)) {
+      logger.debug(
+        `[PermissionManager] Ignoring stale or already resolved equivalent request: id=${request.id}`,
+      );
+      return null;
+    }
+
+    const signature = this.getRequestSignature(request);
+    const messageId = this.state.messageIdBySignature.get(signature);
+    if (messageId === undefined) {
+      return null;
+    }
+
+    const visibleRequest = this.state.requestsByMessageId.get(messageId);
+    if (!visibleRequest) {
+      logger.warn(
+        `[PermissionManager] Dropping orphan permission signature: messageId=${messageId}`,
+      );
+      this.state.messageIdBySignature.delete(signature);
+      return null;
+    }
+
+    const requestIds = this.state.requestIdsByMessageId.get(messageId) ?? [];
+    if (!requestIds.includes(request.id)) {
+      requestIds.push(request.id);
+      this.state.requestIdsByMessageId.set(messageId, requestIds);
+    }
+
+    logger.info(
+      `[PermissionManager] Merged equivalent permission request: id=${request.id}, messageId=${messageId}, grouped=${requestIds.length}`,
+    );
+
+    return { messageId, request: visibleRequest, count: requestIds.length };
   }
 
   /**
@@ -56,6 +118,17 @@ class PermissionManager {
    */
   getRequestID(messageId: number | null): string | null {
     return this.getRequest(messageId)?.id ?? null;
+  }
+
+  /**
+   * Get all OpenCode request IDs grouped behind a Telegram message.
+   */
+  getRequestIDs(messageId: number | null): string[] {
+    if (messageId === null) {
+      return [];
+    }
+
+    return [...(this.state.requestIdsByMessageId.get(messageId) ?? [])];
   }
 
   /**
@@ -108,6 +181,8 @@ class PermissionManager {
     }
 
     this.state.requestsByMessageId.delete(messageId);
+    this.state.requestIdsByMessageId.delete(messageId);
+    this.state.messageIdBySignature.delete(this.getRequestSignature(request));
 
     logger.debug(
       `[PermissionManager] Removed permission request: id=${request.id}, messageId=${messageId}, pending=${this.state.requestsByMessageId.size}`,
@@ -124,11 +199,14 @@ class PermissionManager {
     const removedMessageIds: number[] = [];
 
     for (const [messageId, request] of this.state.requestsByMessageId) {
-      if (request.id !== requestID) {
+      const requestIds = this.state.requestIdsByMessageId.get(messageId) ?? [request.id];
+      if (!requestIds.includes(requestID)) {
         continue;
       }
 
       this.state.requestsByMessageId.delete(messageId);
+      this.state.requestIdsByMessageId.delete(messageId);
+      this.state.messageIdBySignature.delete(this.getRequestSignature(request));
       removedMessageIds.push(messageId);
     }
 
@@ -173,6 +251,8 @@ class PermissionManager {
 
     this.state = {
       requestsByMessageId: new Map(),
+      requestIdsByMessageId: new Map(),
+      messageIdBySignature: new Map(),
     };
     this.resolvedRequestIDs.clear();
     this.generation++;

--- a/src/app/managers/summary-aggregation-manager.ts
+++ b/src/app/managers/summary-aggregation-manager.ts
@@ -253,6 +253,7 @@ class SummaryAggregator {
   private onSessionRetryCallback: SessionRetryCallback | null = null;
   private onSessionIdleCallback: SessionIdleCallback | null = null;
   private onPermissionCallback: PermissionCallback | null = null;
+  private permissionQueue: Promise<void> = Promise.resolve();
   private onPermissionRepliedCallback: PermissionRepliedCallback | null = null;
   private onSessionDiffCallback: SessionDiffCallback | null = null;
   private onFileChangeCallback: FileChangeCallback | null = null;
@@ -509,6 +510,7 @@ class SummaryAggregator {
     this.pendingChildSessionIdsByParent.clear();
     this.fallbackSubagentCardIdsByParent.clear();
     this.lastSubagentSnapshot = "";
+    this.permissionQueue = Promise.resolve();
     this.messageCount = 0;
     this.lastUpdated = 0;
 
@@ -2117,13 +2119,11 @@ class SummaryAggregator {
 
     if (this.onPermissionCallback) {
       const callback = this.onPermissionCallback;
-      try {
-        void Promise.resolve(callback(request as PermissionRequest)).catch((err) => {
+      this.permissionQueue = this.permissionQueue
+        .then(() => callback(request as PermissionRequest))
+        .catch((err) => {
           logger.error("[Aggregator] Error in permission callback:", err);
         });
-      } catch (err) {
-        logger.error("[Aggregator] Error in permission callback:", err);
-      }
     }
   }
 

--- a/src/app/types/permission.ts
+++ b/src/app/types/permission.ts
@@ -15,6 +15,15 @@ export interface PermissionRequest {
 }
 
 /**
+ * A visible Telegram permission prompt that groups equivalent OpenCode requests
+ */
+export interface GroupedPermissionMessage {
+  messageId: number; // Telegram message ID showing the prompt
+  request: PermissionRequest; // The request the visible prompt was rendered from
+  count: number; // Number of OpenCode requests grouped behind the prompt
+}
+
+/**
  * Possible permission responses
  */
 export type PermissionReply = "once" | "always" | "reject";
@@ -24,4 +33,6 @@ export type PermissionReply = "once" | "always" | "reject";
  */
 export interface PermissionState {
   requestsByMessageId: Map<number, PermissionRequest>; // Telegram message ID -> request
+  requestIdsByMessageId: Map<number, string[]>; // Telegram message ID -> OpenCode request IDs
+  messageIdBySignature: Map<string, number>; // Equivalent permission signature -> Telegram message ID
 }

--- a/src/bot/callbacks/permission-callback-handler.ts
+++ b/src/bot/callbacks/permission-callback-handler.ts
@@ -30,10 +30,15 @@ function isPermissionRequestNotFound(error: unknown): boolean {
   }
 
   const candidate = error as {
+    _tag?: unknown;
     name?: unknown;
     message?: unknown;
     data?: { message?: unknown };
   };
+
+  if (candidate._tag === "PermissionNotFoundError") {
+    return true;
+  }
 
   if (candidate.name === "NotFoundError") {
     return true;
@@ -67,8 +72,8 @@ export async function handlePermissionCallback(ctx: Context): Promise<boolean> {
     return true;
   }
 
-  const requestID = permissionManager.getRequestID(callbackMessageId);
-  if (!requestID) {
+  const requestIDs = permissionManager.getRequestIDs(callbackMessageId);
+  if (requestIDs.length === 0) {
     await ctx.answerCallbackQuery({ text: t("permission.inactive_callback"), show_alert: true });
     return true;
   }
@@ -85,7 +90,7 @@ export async function handlePermissionCallback(ctx: Context): Promise<boolean> {
   }
 
   try {
-    await handlePermissionReply(ctx, action, requestID, callbackMessageId);
+    await handlePermissionReply(ctx, action, requestIDs, callbackMessageId);
   } catch (err) {
     logger.error("[PermissionHandler] Error handling callback:", err);
     await ctx.answerCallbackQuery({
@@ -100,7 +105,7 @@ export async function handlePermissionCallback(ctx: Context): Promise<boolean> {
 async function handlePermissionReply(
   ctx: Context,
   reply: PermissionReply,
-  requestID: string,
+  requestIDs: string[],
   callbackMessageId: number | null,
 ): Promise<void> {
   const currentProject = getCurrentProject();
@@ -130,20 +135,46 @@ async function handlePermissionReply(
 
   summaryAggregator.stopTypingIndicator();
 
-  logger.info(`[PermissionHandler] Sending permission reply: ${reply}, requestID=${requestID}`);
+  logger.info(
+    `[PermissionHandler] Sending permission reply: ${reply}, requestIDs=${requestIDs.join(",")}`,
+  );
 
   safeBackgroundTask({
     taskName: "permission.reply",
-    task: () =>
-      opencodeClient.permission.reply({
-        requestID,
-        directory,
-        reply,
-      }),
+    task: async () => {
+      let firstError: unknown = null;
+      let lastResponse: Awaited<ReturnType<typeof opencodeClient.permission.reply>> | null = null;
+
+      for (const requestID of requestIDs) {
+        const response = await opencodeClient.permission.reply({
+          requestID,
+          directory,
+          reply,
+        });
+        lastResponse = response;
+
+        if (!response.error) {
+          continue;
+        }
+
+        if (requestIDs.length > 1 && isPermissionRequestNotFound(response.error)) {
+          logger.debug(
+            `[PermissionHandler] Ignoring duplicate permission reply miss: requestID=${requestID}`,
+          );
+          continue;
+        }
+
+        firstError ??= response.error;
+      }
+
+      return { ...lastResponse, error: firstError };
+    },
     onSuccess: ({ error }) => {
       if (error) {
         if (isPermissionRequestNotFound(error)) {
-          logger.debug(`[PermissionHandler] Permission request already resolved: ${requestID}`);
+          logger.debug(
+            `[PermissionHandler] Permission request already resolved: requestIDs=${requestIDs.join(",")}`,
+          );
           return;
         }
 
@@ -166,6 +197,6 @@ async function handlePermissionReply(
   }
 
   syncPermissionInteractionState({
-    lastRepliedRequestID: requestID,
+    lastRepliedRequestIDs: requestIDs,
   });
 }

--- a/src/bot/menus/permission-menu.ts
+++ b/src/bot/menus/permission-menu.ts
@@ -94,6 +94,31 @@ export async function showPermissionRequest(
     return;
   }
 
+  const grouped = permissionManager.addEquivalentRequest(request, generation);
+  if (grouped) {
+    // Re-render the visible prompt so the user can see the answer will apply
+    // to more than one pending request.
+    await bot
+      .editMessageText(
+        chatId,
+        grouped.messageId,
+        formatPermissionText(grouped.request, grouped.count),
+        { reply_markup: buildPermissionKeyboard() },
+      )
+      .catch((err) => {
+        logger.warn("[PermissionHandler] Failed to update grouped permission message:", err);
+      });
+
+    syncPermissionInteractionState({
+      requestID: request.id,
+      messageId: grouped.messageId,
+      deduplicated: true,
+      groupedCount: grouped.count,
+    });
+    summaryAggregator.stopTypingIndicator();
+    return;
+  }
+
   const text = formatPermissionText(request);
   const keyboard = buildPermissionKeyboard();
 
@@ -125,7 +150,7 @@ export async function showPermissionRequest(
 /**
  * Format permission request text
  */
-function formatPermissionText(request: PermissionRequest): string {
+function formatPermissionText(request: PermissionRequest, groupedCount: number = 1): string {
   const emoji = PERMISSION_EMOJIS[request.permission] || "🔐";
   const nameKey = PERMISSION_NAME_KEYS[request.permission];
   const name = nameKey ? t(nameKey) : request.permission;
@@ -137,6 +162,10 @@ function formatPermissionText(request: PermissionRequest): string {
     request.patterns.forEach((pattern) => {
       text += `• ${pattern}\n`;
     });
+  }
+
+  if (groupedCount > 1) {
+    text += t("permission.grouped_count", { count: groupedCount });
   }
 
   return text;

--- a/src/i18n/ar.ts
+++ b/src/i18n/ar.ts
@@ -336,6 +336,7 @@ export const ar: I18nDictionary = {
   "permission.blocked.command_not_allowed":
     "⚠️ لا يمكن استخدام هذا الأمر قبل الرد على طلب الصلاحية.",
   "permission.header": "{emoji} طلب صلاحية: {name}\n\n",
+  "permission.grouped_count": "\n⚠️ يوجد {count} طلبات متطابقة قيد الانتظار — سيُطبَّق ردك عليها جميعًا.\n",
   "permission.button.allow": "✅ سماح لمرة واحدة",
   "permission.button.always": "🔓 سماح دائم",
   "permission.button.reject": "❌ رفض",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -365,6 +365,7 @@ export const de: I18nDictionary = {
   "permission.blocked.command_not_allowed":
     "⚠️ Dieser Befehl ist erst verfügbar, wenn du die Berechtigungsanfrage beantwortet hast.",
   "permission.header": "{emoji} Berechtigungsanfrage: {name}\n\n",
+  "permission.grouped_count": "\n⚠️ {count} identische Anfragen ausstehend – deine Antwort gilt für alle.\n",
   "permission.button.allow": "✅ Einmal erlauben",
   "permission.button.always": "🔓 Immer erlauben",
   "permission.button.reject": "❌ Ablehnen",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -347,6 +347,7 @@ export const en = {
   "permission.blocked.command_not_allowed":
     "⚠️ This command is not available until you answer the permission request.",
   "permission.header": "{emoji} Permission request: {name}\n\n",
+  "permission.grouped_count": "\n⚠️ {count} identical requests pending — your answer applies to all of them.\n",
   "permission.button.allow": "✅ Allow once",
   "permission.button.always": "🔓 Allow always",
   "permission.button.reject": "❌ Reject",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -362,6 +362,7 @@ export const es: I18nDictionary = {
   "permission.blocked.command_not_allowed":
     "⚠️ Este comando no está disponible hasta que respondas a la solicitud de permisos.",
   "permission.header": "{emoji} Solicitud de permisos: {name}\n\n",
+  "permission.grouped_count": "\n⚠️ {count} solicitudes idénticas pendientes: tu respuesta se aplica a todas.\n",
   "permission.button.allow": "✅ Permitir una vez",
   "permission.button.always": "🔓 Permitir siempre",
   "permission.button.reject": "❌ Rechazar",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -366,6 +366,7 @@ export const fr: I18nDictionary = {
   "permission.blocked.command_not_allowed":
     "⚠️ Cette commande n'est pas disponible tant que vous n'avez pas répondu à la demande d'autorisation.",
   "permission.header": "{emoji} Demande d'autorisation : {name}\n\n",
+  "permission.grouped_count": "\n⚠️ {count} demandes identiques en attente — votre réponse s'applique à toutes.\n",
   "permission.button.allow": "✅ Autoriser une fois",
   "permission.button.always": "🔓 Toujours autoriser",
   "permission.button.reject": "❌ Refuser",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -349,6 +349,7 @@ export const ru: I18nDictionary = {
   "permission.blocked.command_not_allowed":
     "⚠️ Эта команда недоступна, пока вы не ответите на запрос разрешения.",
   "permission.header": "{emoji} Запрос разрешения: {name}\n\n",
+  "permission.grouped_count": "\n⚠️ Ожидают {count} одинаковых запроса — ваш ответ применится ко всем.\n",
   "permission.button.allow": "✅ Разрешить один раз",
   "permission.button.always": "🔓 Разрешить всегда",
   "permission.button.reject": "❌ Отклонить",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -314,6 +314,7 @@ export const zh: I18nDictionary = {
   "permission.blocked.expected_reply": "⚠️ 请先使用上方按钮回答权限请求。",
   "permission.blocked.command_not_allowed": "⚠️ 在你回答权限请求之前不可用此命令。",
   "permission.header": "{emoji} 权限请求：{name}\n\n",
+  "permission.grouped_count": "\n⚠️ 有 {count} 个相同的请求待处理，你的回答将同时应用于全部。\n",
   "permission.button.allow": "✅ 允许一次",
   "permission.button.always": "🔓 始终允许",
   "permission.button.reject": "❌ 拒绝",

--- a/tests/app/managers/summary-aggregation-manager.test.ts
+++ b/tests/app/managers/summary-aggregation-manager.test.ts
@@ -1826,7 +1826,7 @@ describe("summary/aggregator", () => {
     expect(onTokens).not.toHaveBeenCalled();
   });
 
-  it("forwards permission.asked events from tracked subagent (child) sessions synchronously", () => {
+  it("forwards permission.asked events from tracked subagent (child) sessions", async () => {
     const onPermission = vi.fn();
     summaryAggregator.setOnPermission(onPermission);
     summaryAggregator.setSession("root-session");
@@ -1876,7 +1876,9 @@ describe("summary/aggregator", () => {
       },
     } as unknown as Event);
 
-    expect(onPermission).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(onPermission).toHaveBeenCalledTimes(1);
+    });
     expect(onPermission.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         id: "req-child-1",
@@ -1885,6 +1887,59 @@ describe("summary/aggregator", () => {
       }),
     );
     expect(summaryAggregator.isSubagentSession("child-session-1")).toBe(true);
+  });
+
+  it("serializes permission callbacks so equivalent requests can be registered before the next dispatch", async () => {
+    let releaseFirstPermission: () => void = () => {};
+    const firstPermissionDone = new Promise<void>((resolve) => {
+      releaseFirstPermission = resolve;
+    });
+    const calls: string[] = [];
+
+    summaryAggregator.setOnPermission(async (request) => {
+      calls.push(`start:${request.id}`);
+
+      if (request.id === "req-1") {
+        await firstPermissionDone;
+      }
+
+      calls.push(`end:${request.id}`);
+    });
+    summaryAggregator.setSession("session-1");
+
+    summaryAggregator.processEvent({
+      type: "permission.asked",
+      properties: {
+        id: "req-1",
+        sessionID: "session-1",
+        permission: "bash",
+        patterns: ["pwd"],
+        metadata: {},
+        always: [],
+      },
+    } as unknown as Event);
+
+    summaryAggregator.processEvent({
+      type: "permission.asked",
+      properties: {
+        id: "req-2",
+        sessionID: "session-1",
+        permission: "bash",
+        patterns: ["pwd"],
+        metadata: {},
+        always: [],
+      },
+    } as unknown as Event);
+
+    await vi.waitFor(() => {
+      expect(calls).toEqual(["start:req-1"]);
+    });
+
+    releaseFirstPermission();
+
+    await vi.waitFor(() => {
+      expect(calls).toEqual(["start:req-1", "end:req-1", "start:req-2", "end:req-2"]);
+    });
   });
 
   it("ignores permission.asked events from unrelated sessions", async () => {

--- a/tests/bot/callbacks/permission-callback-handler.test.ts
+++ b/tests/bot/callbacks/permission-callback-handler.test.ts
@@ -74,6 +74,7 @@ function createPermissionRequest(
 function createBotApi(messageId: number = 500): Context["api"] {
   return {
     sendMessage: vi.fn().mockResolvedValue({ message_id: messageId }),
+    editMessageText: vi.fn().mockResolvedValue(true),
     deleteMessage: vi.fn().mockResolvedValue(true),
   } as unknown as Context["api"];
 }
@@ -106,6 +107,8 @@ function getCallbackData(button: unknown): string | undefined {
 }
 
 async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
 }
@@ -163,7 +166,11 @@ describe("bot permission menu/callbacks", () => {
     const sendMessageMock = botApi.sendMessage as unknown as ReturnType<typeof vi.fn>;
     sendMessageMock.mockResolvedValueOnce({ message_id: 501 });
 
-    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-2"));
+    await showPermissionRequest(
+      botApi,
+      777,
+      createPermissionRequest("perm-2", { patterns: ["npm run build"] }),
+    );
 
     const deleteMessageMock = botApi.deleteMessage as unknown as ReturnType<typeof vi.fn>;
     expect(deleteMessageMock).not.toHaveBeenCalled();
@@ -243,7 +250,11 @@ describe("bot permission menu/callbacks", () => {
 
     const sendMessageMock = botApi.sendMessage as unknown as ReturnType<typeof vi.fn>;
     sendMessageMock.mockResolvedValueOnce({ message_id: 501 });
-    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-2"));
+    await showPermissionRequest(
+      botApi,
+      777,
+      createPermissionRequest("perm-2", { patterns: ["npm run build"] }),
+    );
 
     const staleCtx = createPermissionCallbackContext("permission:once", 499);
     const handled = await handlePermissionCallback(staleCtx);
@@ -283,6 +294,122 @@ describe("bot permission menu/callbacks", () => {
     expect(interactionManager.getSnapshot()).toBeNull();
   });
 
+  it("deduplicates equivalent permission requests behind one Telegram message", async () => {
+    const botApi = createBotApi(650);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-1"));
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-duplicate"));
+
+    const sendMessageMock = botApi.sendMessage as unknown as ReturnType<typeof vi.fn>;
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(permissionManager.getPendingCount()).toBe(1);
+    expect(permissionManager.getRequestID(650)).toBe("perm-1");
+    expect(permissionManager.getRequestIDs(650)).toEqual(["perm-1", "perm-duplicate"]);
+
+    const ctx = createPermissionCallbackContext("permission:always", 650);
+    const handled = await handlePermissionCallback(ctx);
+
+    expect(handled).toBe(true);
+    expect(ctx.answerCallbackQuery).toHaveBeenCalledWith({ text: t("permission.reply.always") });
+
+    await flushMicrotasks();
+
+    expect(mocked.permissionReplyMock).toHaveBeenCalledTimes(2);
+    expect(mocked.permissionReplyMock).toHaveBeenNthCalledWith(1, {
+      requestID: "perm-1",
+      directory: "D:/repo",
+      reply: "always",
+    });
+    expect(mocked.permissionReplyMock).toHaveBeenNthCalledWith(2, {
+      requestID: "perm-duplicate",
+      directory: "D:/repo",
+      reply: "always",
+    });
+    expect(permissionManager.isActive()).toBe(false);
+    expect(interactionManager.getSnapshot()).toBeNull();
+  });
+
+  it("shows the grouped request count on the visible permission message", async () => {
+    const botApi = createBotApi(651);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-1"));
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-duplicate"));
+
+    const editMessageTextMock = botApi.editMessageText as unknown as ReturnType<typeof vi.fn>;
+    expect(editMessageTextMock).toHaveBeenCalledTimes(1);
+
+    const [chatId, messageId, text] = editMessageTextMock.mock.calls[0];
+    expect(chatId).toBe(777);
+    expect(messageId).toBe(651);
+    expect(text).toContain(t("permission.grouped_count", { count: 2 }));
+  });
+
+  it("refuses to group stale or already resolved equivalent requests", async () => {
+    const botApi = createBotApi(652);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-1"));
+    const generation = permissionManager.getGeneration();
+
+    permissionManager.resolveRequest("perm-resolved");
+    expect(
+      permissionManager.addEquivalentRequest(createPermissionRequest("perm-resolved")),
+    ).toBeNull();
+    expect(
+      permissionManager.addEquivalentRequest(createPermissionRequest("perm-stale"), generation - 1),
+    ).toBeNull();
+
+    expect(permissionManager.getRequestIDs(652)).toEqual(["perm-1"]);
+  });
+
+  it("does not group behind a message whose request was replaced", async () => {
+    const botApi = createBotApi(653);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-replaced"));
+    // Same Telegram message id, different scope: the replaced request's
+    // signature must no longer group new requests behind it.
+    permissionManager.startPermission(createPermissionRequest("perm-2", { patterns: ["ls"] }), 653);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-3"));
+
+    const sendMessageMock = botApi.sendMessage as unknown as ReturnType<typeof vi.fn>;
+    expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("resolves a grouped permission prompt by any grouped request id", async () => {
+    const botApi = createBotApi(655);
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-1"));
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-duplicate"));
+
+    expect(permissionManager.resolveRequest("perm-duplicate")).toEqual([655]);
+    expect(permissionManager.isActive()).toBe(false);
+    expect(permissionManager.getRequestIDs(655)).toEqual([]);
+  });
+
+  it("ignores duplicate permission not-found errors after replying grouped requests", async () => {
+    const botApi = createBotApi(660);
+    mocked.permissionReplyMock
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({
+        error: {
+          _tag: "PermissionNotFoundError",
+          requestID: "perm-duplicate",
+          message: "Permission request not found: perm-duplicate",
+        },
+      });
+
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-1"));
+    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-duplicate"));
+
+    const ctx = createPermissionCallbackContext("permission:always", 660);
+    await handlePermissionCallback(ctx);
+    await flushMicrotasks();
+
+    expect(mocked.permissionReplyMock).toHaveBeenCalledTimes(2);
+    expect(ctx.api.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("keeps permission interaction active until all requests are replied", async () => {
     const botApi = createBotApi(700);
 
@@ -290,7 +417,11 @@ describe("bot permission menu/callbacks", () => {
 
     const sendMessageMock = botApi.sendMessage as unknown as ReturnType<typeof vi.fn>;
     sendMessageMock.mockResolvedValueOnce({ message_id: 701 });
-    await showPermissionRequest(botApi, 777, createPermissionRequest("perm-2"));
+    await showPermissionRequest(
+      botApi,
+      777,
+      createPermissionRequest("perm-2", { patterns: ["npm run build"] }),
+    );
 
     const firstCtx = createPermissionCallbackContext("permission:once", 700);
     const firstHandled = await handlePermissionCallback(firstCtx);

--- a/tests/bot/services/event-subscription-service.test.ts
+++ b/tests/bot/services/event-subscription-service.test.ts
@@ -138,6 +138,7 @@ function emitSessionIdle(summaryAggregator: { processEvent(event: Event): void }
 function emitPermissionAsked(
   summaryAggregator: { processEvent(event: Event): void },
   requestID: string,
+  patterns: string[] = ["D:/shared/*"],
 ): void {
   summaryAggregator.processEvent({
     type: "permission.asked",
@@ -145,7 +146,7 @@ function emitPermissionAsked(
       id: requestID,
       sessionID: "session-1",
       permission: "external_directory",
-      patterns: ["D:/shared/*"],
+      patterns,
       metadata: {},
       always: ["D:/shared/*"],
     },
@@ -400,7 +401,7 @@ describe("bot/services/event-subscription-service", () => {
       .mockResolvedValueOnce({ message_id: 501 });
 
     emitPermissionAsked(summaryAggregator, "permission-1");
-    emitPermissionAsked(summaryAggregator, "permission-2");
+    emitPermissionAsked(summaryAggregator, "permission-2", ["D:/other/*"]);
 
     await vi.waitFor(() => {
       expect(permissionManager.getPendingCount()).toBe(2);
@@ -465,7 +466,7 @@ describe("bot/services/event-subscription-service", () => {
       .mockResolvedValueOnce({ message_id: 510 })
       .mockResolvedValueOnce({ message_id: 511 });
     emitPermissionAsked(summaryAggregator, "permission-1");
-    emitPermissionAsked(summaryAggregator, "permission-2");
+    emitPermissionAsked(summaryAggregator, "permission-2", ["D:/other/*"]);
     await vi.waitFor(() => {
       expect(permissionManager.getPendingCount()).toBe(2);
     });


### PR DESCRIPTION
## Summary
This makes the Telegram client resilient to equivalent concurrent permission requests by collapsing them into one visible prompt and replying to the grouped upstream request IDs together.

## Scope
This is a Telegram client UX fix, not an upstream permission semantics change. Requests are considered equivalent when `sessionID`, `permission`, and `patterns` match, with `patterns` compared order-insensitively.

This PR is a Telegram-side workaround for an upstream-driven behavior, and is intended to be referable even if it is not merged as-is.

## Trade-off
This intentionally deduplicates by effective permission scope rather than per-tool-call identity. In exchange, it may collapse requests that differ only in tool-call-level metadata, but that keeps the chat UI simple and fixes duplicate prompts / stale buttons while leaving upstream behavior unchanged.

## Validation
I have been using this locally for several days without issues, and the regression tests cover deduplication, grouped replies, and duplicate `Permission request not found` handling.

Refs:
- closes #182
- related: anomalyco/opencode#36055