### PR TITLE
fix: verify process creation time to detect recycled PIDs + improve logging

### DIFF
--- a/src/app/bootstrap/start-bot-app.ts
+++ b/src/app/bootstrap/start-bot-app.ts
@@ -43,12 +43,28 @@ export async function startBotApp(): Promise<void> {
   const logFilePath = getLogFilePath();
 
   logger.info(`Starting OpenCode Telegram Bot v${version}...`);
+  logger.info(`Node.js ${process.version} on ${process.platform} ${process.arch}`);
   logger.info(`Config loaded from ${runtimePaths.envFilePath}`);
   if (logFilePath) {
     logger.info(`Logs are written to ${logFilePath}`);
   }
   logger.info(`Allowed User ID: ${config.telegram.allowedUserId}`);
   logger.debug(`[Runtime] Application start mode: ${mode}`);
+
+  const unhandledRejectionHandler = (reason: unknown): void => {
+    logger.error("[App] Unhandled promise rejection", reason);
+    void clearManagedServiceState().catch(() => {});
+    process.exit(1);
+  };
+
+  const uncaughtExceptionHandler = (error: Error): void => {
+    logger.error("[App] Uncaught exception", error);
+    void clearManagedServiceState().catch(() => {});
+    process.exit(1);
+  };
+
+  process.on("unhandledRejection", unhandledRejectionHandler);
+  process.on("uncaughtException", uncaughtExceptionHandler);
 
   await loadSettings();
   await reconcileStoredModelSelection();
@@ -142,6 +158,8 @@ export async function startBotApp(): Promise<void> {
       },
     });
   } finally {
+    process.off("unhandledRejection", unhandledRejectionHandler);
+    process.off("uncaughtException", uncaughtExceptionHandler);
     process.off("SIGINT", handleSigint);
     process.off("SIGTERM", handleSigterm);
     if (shutdownTimeout) {

--- a/src/app/bootstrap/start-bot-app.ts
+++ b/src/app/bootstrap/start-bot-app.ts
@@ -53,14 +53,16 @@ export async function startBotApp(): Promise<void> {
 
   const unhandledRejectionHandler = (reason: unknown): void => {
     logger.error("[App] Unhandled promise rejection", reason);
-    void clearManagedServiceState().catch(() => {});
-    process.exit(1);
+    void clearManagedServiceState()
+      .catch(() => {})
+      .finally(() => process.exit(1));
   };
 
   const uncaughtExceptionHandler = (error: Error): void => {
     logger.error("[App] Uncaught exception", error);
-    void clearManagedServiceState().catch(() => {});
-    process.exit(1);
+    void clearManagedServiceState()
+      .catch(() => {})
+      .finally(() => process.exit(1));
   };
 
   process.on("unhandledRejection", unhandledRejectionHandler);

--- a/src/opencode/events.ts
+++ b/src/opencode/events.ts
@@ -31,6 +31,7 @@ let isListening = false;
 let activeDirectory: string | null = null;
 let streamAbortController: AbortController | null = null;
 let listenerGeneration = 0;
+let consecutiveTimeouts = 0;
 
 type StreamReadResult =
   | { type: "next"; result: IteratorResult<unknown, unknown> }
@@ -260,6 +261,7 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
         }
 
         reconnectAttempt = 0;
+        consecutiveTimeouts = 0;
         eventStream = subscription.stream;
         let usefulEventCount = 0;
 
@@ -347,6 +349,7 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
         }
 
         reconnectAttempt++;
+        consecutiveTimeouts = 0;
         const reconnectDelay = getReconnectDelayMs(reconnectAttempt);
         logger.warn(
           `Event stream ended for ${directory}, reconnecting in ${reconnectDelay}ms (attempt=${reconnectAttempt})`,
@@ -371,10 +374,15 @@ export async function subscribeToEvents(directory: string, callback: EventCallba
         }
 
         reconnectAttempt++;
+        consecutiveTimeouts++;
         const reconnectDelay = getReconnectDelayMs(reconnectAttempt);
         if (isEventStreamIdleTimeoutError(error)) {
+          const timeoutWarning =
+            consecutiveTimeouts >= 5
+              ? ` (${consecutiveTimeouts} consecutive timeouts — OpenCode server may be unreachable)`
+              : "";
           logger.warn(
-            `Event stream idle timeout for ${directory}, reconnecting in ${reconnectDelay}ms (attempt=${reconnectAttempt})`,
+            `Event stream idle timeout for ${directory}, reconnecting in ${reconnectDelay}ms (attempt=${reconnectAttempt})${timeoutWarning}`,
           );
         } else if (isExpectedOpencodeUnavailableError(error)) {
           logger.warn(

--- a/src/runtime/service/manager.ts
+++ b/src/runtime/service/manager.ts
@@ -3,7 +3,6 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
-import { getRuntimeMode } from "../mode.js";
 import { getRuntimePaths } from "../paths.js";
 import { buildServiceChildEnv } from "./env.js";
 import { logger } from "../../utils/logger.js";

--- a/src/runtime/service/manager.ts
+++ b/src/runtime/service/manager.ts
@@ -5,6 +5,7 @@ import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { getRuntimePaths } from "../paths.js";
 import { buildServiceChildEnv } from "./env.js";
+import { logger } from "../../utils/logger.js";
 import type {
   BotServiceState,
   BotServiceStatus,
@@ -88,6 +89,41 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+async function getProcessCreationTime(pid: number): Promise<Date | null> {
+  try {
+    if (process.platform === "win32") {
+      const { stdout } = await execAsync(
+        `wmic process where ProcessId=${pid} get CreationDate`,
+      );
+      const lines = stdout.trim().split(/\r?\n/);
+      if (lines.length < 2) {
+        return null;
+      }
+      const dateStr = lines[1]?.trim();
+      if (!dateStr) {
+        return null;
+      }
+      const match = dateStr.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
+      if (!match) {
+        return null;
+      }
+      return new Date(
+        `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}`,
+      );
+    }
+
+    const { stdout } = await execAsync(`ps -o lstart= -p ${pid}`);
+    const dateStr = stdout.trim();
+    if (!dateStr) {
+      return null;
+    }
+    const timestamp = Date.parse(dateStr);
+    return Number.isNaN(timestamp) ? null : new Date(timestamp);
+  } catch {
+    return null;
+  }
+}
+
 async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
   const startTime = Date.now();
 
@@ -167,6 +203,30 @@ export async function getBotServiceStatus(): Promise<BotServiceStatus> {
   }
 
   if (!isProcessAlive(service.pid)) {
+    logger.info(
+      `[Manager] Stale daemon state cleaned up: PID=${service.pid} no longer exists`,
+    );
+    await clearServiceStateFile(stateFilePath);
+    return {
+      status: "stopped",
+      service: null,
+      cleanupReason: "stale",
+    };
+  }
+
+  const processCreationTime = await getProcessCreationTime(service.pid);
+  const storedStartedAtMs = Date.parse(service.startedAt);
+
+  if (
+    processCreationTime &&
+    !Number.isNaN(storedStartedAtMs) &&
+    processCreationTime.getTime() > storedStartedAtMs
+  ) {
+    logger.warn(
+      `[Manager] Stale daemon state detected: PID=${service.pid} exists but was created ` +
+      `at ${processCreationTime.toISOString()} (daemon started at ${service.startedAt}). ` +
+      `The original process died and the PID was reused.`,
+    );
     await clearServiceStateFile(stateFilePath);
     return {
       status: "stopped",

--- a/src/runtime/service/manager.ts
+++ b/src/runtime/service/manager.ts
@@ -3,6 +3,7 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
+import { getRuntimeMode } from "../mode.js";
 import { getRuntimePaths } from "../paths.js";
 import { buildServiceChildEnv } from "./env.js";
 import { logger } from "../../utils/logger.js";
@@ -244,7 +245,14 @@ export async function getBotServiceStatus(): Promise<BotServiceStatus> {
 
 export async function startBotDaemon(mode?: string): Promise<ServiceOperationResult> {
   const currentStatus = await getBotServiceStatus();
+  const cleanupInfo = currentStatus.cleanupReason
+    ? ` (previous state: ${currentStatus.cleanupReason})`
+    : "";
+
   if (currentStatus.status === "running" && currentStatus.service) {
+    logger.info(
+      `[Manager] Daemon start rejected: already running (PID=${currentStatus.service.pid})${cleanupInfo}`,
+    );
     return {
       success: false,
       service: currentStatus.service,
@@ -290,6 +298,9 @@ export async function startBotDaemon(mode?: string): Promise<ServiceOperationRes
     };
 
     await writeFileAtomically(stateFilePath, `${JSON.stringify(serviceState, null, 2)}\n`);
+    logger.info(
+      `[Manager] Daemon started: PID=${childProcess.pid}, log=${logFilePath}${cleanupInfo}`,
+    );
 
     return {
       success: true,
@@ -297,12 +308,14 @@ export async function startBotDaemon(mode?: string): Promise<ServiceOperationRes
       cleanupReason: currentStatus.cleanupReason,
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`[Manager] Daemon start failed: ${errorMessage}${cleanupInfo}`);
     await clearServiceStateFile(stateFilePath);
     return {
       success: false,
       service: null,
       cleanupReason: currentStatus.cleanupReason,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
     };
   } finally {
     fs.closeSync(logFileDescriptor);
@@ -314,6 +327,9 @@ export async function stopBotDaemon(
 ): Promise<ServiceOperationResult> {
   const currentStatus = await getBotServiceStatus();
   if (currentStatus.status !== "running" || !currentStatus.service) {
+    logger.info(
+      `[Manager] Daemon stop skipped: not running (reason=${currentStatus.cleanupReason ?? "none"})`,
+    );
     return {
       success: true,
       service: null,
@@ -323,6 +339,7 @@ export async function stopBotDaemon(
   }
 
   const { pid } = currentStatus.service;
+  logger.info(`[Manager] Stopping daemon: PID=${pid}`);
 
   try {
     if (process.platform === "win32") {
@@ -332,6 +349,7 @@ export async function stopBotDaemon(
     }
 
     if (isProcessAlive(pid)) {
+      logger.warn(`[Manager] Daemon stop failed: process PID=${pid} still alive after ${timeoutMs}ms`);
       return {
         success: false,
         service: currentStatus.service,
@@ -341,6 +359,7 @@ export async function stopBotDaemon(
     }
 
     await clearServiceStateFile();
+    logger.info(`[Manager] Daemon stopped: PID=${pid}`);
 
     return {
       success: true,
@@ -348,11 +367,13 @@ export async function stopBotDaemon(
       cleanupReason: currentStatus.cleanupReason,
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`[Manager] Daemon stop error: ${errorMessage}`);
     return {
       success: false,
       service: currentStatus.service,
       cleanupReason: currentStatus.cleanupReason,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
     };
   }
 }

--- a/src/runtime/service/manager.ts
+++ b/src/runtime/service/manager.ts
@@ -93,13 +93,9 @@ async function getProcessCreationTime(pid: number): Promise<Date | null> {
   try {
     if (process.platform === "win32") {
       const { stdout } = await execAsync(
-        `wmic process where ProcessId=${pid} get CreationDate`,
+        `powershell -NoProfile -Command "Get-WmiObject Win32_Process -Filter 'ProcessId=${pid}' | Select-Object -ExpandProperty CreationDate"`,
       );
-      const lines = stdout.trim().split(/\r?\n/);
-      if (lines.length < 2) {
-        return null;
-      }
-      const dateStr = lines[1]?.trim();
+      const dateStr = stdout.trim().split(/\r?\n/).find((l) => l.trim().length > 0)?.trim();
       if (!dateStr) {
         return null;
       }

--- a/tests/runtime/service/manager.test.ts
+++ b/tests/runtime/service/manager.test.ts
@@ -52,10 +52,6 @@ vi.mock("../../../src/runtime/paths.js", () => ({
   getRuntimePaths: getRuntimePathsMock,
 }));
 
-vi.mock("../../../src/runtime/mode.js", () => ({
-  getRuntimeMode: vi.fn(() => "installed"),
-}));
-
 vi.mock("../../../src/utils/logger.js", () => ({
   logger: {
     debug: vi.fn(),

--- a/tests/runtime/service/manager.test.ts
+++ b/tests/runtime/service/manager.test.ts
@@ -3,10 +3,27 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { spawnMock, execMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn(),
-  execMock: vi.fn(),
-}));
+const { spawnMock, execMock } = vi.hoisted(() => {
+  const spawnMock = vi.fn();
+  const execMock = vi.fn() as ReturnType<typeof vi.fn> & {
+    [key: symbol]: (command: string) => Promise<{ stdout: string; stderr: string }>;
+  };
+
+  const customPromisifySymbol = Symbol.for("nodejs.util.promisify.custom");
+  execMock[customPromisifySymbol] = function (this: unknown, command: string) {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      execMock(command, (error: Error | null, stdout: string, stderr: string) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
+    });
+  };
+
+  return { spawnMock, execMock };
+});
 
 const { getRuntimePathsMock, runtimePathsState } = vi.hoisted(() => {
   const runtimePathsState = {
@@ -33,6 +50,19 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("../../../src/runtime/paths.js", () => ({
   getRuntimePaths: getRuntimePathsMock,
+}));
+
+vi.mock("../../../src/runtime/mode.js", () => ({
+  getRuntimeMode: vi.fn(() => "installed"),
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 import {
@@ -209,6 +239,151 @@ describe("runtime/service/manager", () => {
         }),
       );
       await expect(fs.access(getServiceStateFilePath())).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it("detects recycled PID via process creation time", async () => {
+    const restorePlatform = setPlatform("win32");
+
+    const daemonStartedAt = new Date("2026-07-18T20:56:06.413Z");
+    const stolenPid = 11236;
+
+    await fs.mkdir(path.dirname(getServiceStateFilePath()), { recursive: true });
+    await fs.writeFile(
+      getServiceStateFilePath(),
+      JSON.stringify({
+        pid: stolenPid,
+        startedAt: daemonStartedAt.toISOString(),
+        logFilePath: path.join(tempDirPath, "logs", "bot-service.log"),
+        mode: "daemon",
+      }),
+    );
+
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    execMock.mockImplementation(
+      (
+        command: string,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (command.includes("wmic") && command.includes(String(stolenPid))) {
+          callback(null, "CreationDate\n20260719095542.123456+180", "");
+        } else {
+          callback(null, "", "");
+        }
+        return {};
+      },
+    );
+
+    try {
+      const status = await getBotServiceStatus();
+
+      expect(status).toEqual({
+        status: "stopped",
+        service: null,
+        cleanupReason: "stale",
+      });
+      await expect(fs.access(getServiceStateFilePath())).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it("returns running when PID exists and creation time matches", async () => {
+    const restorePlatform = setPlatform("win32");
+
+    const daemonStartedAt = new Date("2026-07-18T20:56:06.413Z");
+    const pid = 11236;
+
+    await fs.mkdir(path.dirname(getServiceStateFilePath()), { recursive: true });
+    await fs.writeFile(
+      getServiceStateFilePath(),
+      JSON.stringify({
+        pid,
+        startedAt: daemonStartedAt.toISOString(),
+        logFilePath: path.join(tempDirPath, "logs", "bot-service.log"),
+        mode: "daemon",
+      }),
+    );
+
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    execMock.mockImplementation(
+      (
+        command: string,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (command.includes("wmic") && command.includes(String(pid))) {
+          const creationDateStr =
+            daemonStartedAt.getFullYear().toString() +
+            String(daemonStartedAt.getMonth() + 1).padStart(2, "0") +
+            String(daemonStartedAt.getDate()).padStart(2, "0") +
+            String(daemonStartedAt.getHours()).padStart(2, "0") +
+            String(daemonStartedAt.getMinutes()).padStart(2, "0") +
+            String(daemonStartedAt.getSeconds()).padStart(2, "0") +
+            ".000000+180";
+          callback(null, `CreationDate\n${creationDateStr}`, "");
+        } else {
+          callback(null, "", "");
+        }
+        return {};
+      },
+    );
+
+    try {
+      const status = await getBotServiceStatus();
+
+      expect(status).toEqual({
+        status: "running",
+        service: expect.objectContaining({ pid, mode: "daemon" }),
+        cleanupReason: null,
+      });
+      await expect(fs.access(getServiceStateFilePath())).resolves.toBeUndefined();
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it("falls back to PID-only check when creation time cannot be determined", async () => {
+    const restorePlatform = setPlatform("win32");
+
+    await fs.mkdir(path.dirname(getServiceStateFilePath()), { recursive: true });
+    await fs.writeFile(
+      getServiceStateFilePath(),
+      JSON.stringify({
+        pid: 9999,
+        startedAt: new Date().toISOString(),
+        logFilePath: path.join(tempDirPath, "logs", "bot-service.log"),
+        mode: "daemon",
+      }),
+    );
+
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    execMock.mockImplementation(
+      (
+        command: string,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (command.includes("wmic")) {
+          callback(new Error("WMIC failed"), "", "");
+        } else {
+          callback(null, "", "");
+        }
+        return {};
+      },
+    );
+
+    try {
+      const status = await getBotServiceStatus();
+
+      expect(status).toEqual({
+        status: "running",
+        service: expect.objectContaining({ pid: 9999, mode: "daemon" }),
+        cleanupReason: null,
+      });
     } finally {
       restorePlatform();
     }

--- a/tests/runtime/service/manager.test.ts
+++ b/tests/runtime/service/manager.test.ts
@@ -264,8 +264,8 @@ describe("runtime/service/manager", () => {
         command: string,
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
-        if (command.includes("wmic") && command.includes(String(stolenPid))) {
-          callback(null, "CreationDate\n20260719095542.123456+180", "");
+        if (command.includes("powershell") && command.includes(String(stolenPid))) {
+          callback(null, "20260719095542.123456+180\n", "");
         } else {
           callback(null, "", "");
         }
@@ -311,7 +311,7 @@ describe("runtime/service/manager", () => {
         command: string,
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
-        if (command.includes("wmic") && command.includes(String(pid))) {
+        if (command.includes("powershell") && command.includes(String(pid))) {
           const creationDateStr =
             daemonStartedAt.getFullYear().toString() +
             String(daemonStartedAt.getMonth() + 1).padStart(2, "0") +
@@ -320,7 +320,7 @@ describe("runtime/service/manager", () => {
             String(daemonStartedAt.getMinutes()).padStart(2, "0") +
             String(daemonStartedAt.getSeconds()).padStart(2, "0") +
             ".000000+180";
-          callback(null, `CreationDate\n${creationDateStr}`, "");
+          callback(null, `${creationDateStr}\n`, "");
         } else {
           callback(null, "", "");
         }
@@ -363,8 +363,8 @@ describe("runtime/service/manager", () => {
         command: string,
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
-        if (command.includes("wmic")) {
-          callback(new Error("WMIC failed"), "", "");
+        if (command.includes("powershell")) {
+          callback(new Error("PowerShell failed"), "", "");
         } else {
           callback(null, "", "");
         }


### PR DESCRIPTION
﻿## Description

Two commits:

### 1. PID verification fix
The isProcessAlive() check only verifies a PID number exists, not that it belongs to the original bot process. After a system reboot, a different process may hold the same PID, causing a false "already running" status that prevents the daemon from starting.

Added getProcessCreationTime() that uses wmic (Windows) or ps (Unix) to retrieve the process birth time. getBotServiceStatus() now compares the actual process creation time against the stored startedAt from ot-service.json. If the process started after the recorded bot start time, the PID was recycled and the state is treated as stale.

### 2. Logging improvements
- Added process.on('unhandledRejection') and process.on('uncaughtException') handlers that log the error and clean up the service state file before exit
- Better daemon lifecycle logs (start/stop attempts, stale state reasons)
- Track consecutive idle timeouts in event stream, warn after 5 that server may be unreachable
- Log Node.js version + OS platform at startup

### Testing
- 3 new unit tests verify: recycled PID detection, matching PID case, fallback when creation time unavailable
- Manually verified end-to-end by pointing the state file at a Notepad process with an old startedAt - the fix correctly detected the stale PID and started a fresh daemon
