### PR TITLE
fix(bot): retry transient Telegram server errors instead of dropping responses

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -98,7 +98,7 @@ export function createBot(): Bot<Context> {
       maxRetries: 5,
       onRetry: ({ attempt, retryAfterMs, error }) => {
         logger.warn(
-          `[Bot API] Telegram rate limit on ${method}, retrying in ${retryAfterMs}ms (attempt=${attempt})`,
+          `[Bot API] Retryable Telegram error on ${method}, retrying in ${retryAfterMs}ms (attempt=${attempt})`,
           error,
         );
       },

--- a/src/bot/services/event-subscription-service.ts
+++ b/src/bot/services/event-subscription-service.ts
@@ -477,7 +477,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           this.compactProgressStreamer.clearSession(sessionId, "assistant_finalize_failed");
           assistantRunState.clearRun(sessionId, "assistant_finalize_failed");
           logger.error("Failed to send message to Telegram:", err);
-          logger.error("[Bot] CRITICAL: Stopping event processing due to error");
+          logger.error(`[Bot] Dropped the assistant response for session ${sessionId}`);
           summaryAggregator.clear();
           foregroundSessionState.markIdle(sessionId);
         } finally {

--- a/src/utils/telegram-rate-limit-retry.ts
+++ b/src/utils/telegram-rate-limit-retry.ts
@@ -1,3 +1,14 @@
+/**
+ * Telegram occasionally answers with a transient gateway error (`502 Bad
+ * Gateway` is the common one) instead of a proper Bot API response. These are
+ * not caller mistakes and usually succeed on the next attempt, so they are
+ * retried with an exponential backoff just like `429` is retried with the
+ * server-provided `retry_after`.
+ */
+const TRANSIENT_SERVER_ERROR_CODES = new Set([500, 502, 503, 504]);
+
+const MAX_SERVER_ERROR_BACKOFF_MS = 8000;
+
 interface RetryAttemptInfo {
   attempt: number;
   retryAfterMs: number;
@@ -61,21 +72,47 @@ function getRetryAfterSecondsFromError(error: unknown): number | null {
   return parsedSeconds;
 }
 
-function isTelegramRateLimitError(error: unknown): boolean {
+function getStatusCode(error: unknown): number | null {
   if (typeof error === "object" && error !== null) {
     const status = Reflect.get(error, "status");
-    if (typeof status === "number" && status === 429) {
-      return true;
+    if (typeof status === "number" && Number.isFinite(status)) {
+      return status;
     }
 
     const errorCode = Reflect.get(error, "error_code");
-    if (typeof errorCode === "number" && errorCode === 429) {
-      return true;
+    if (typeof errorCode === "number" && Number.isFinite(errorCode)) {
+      return errorCode;
     }
+  }
+
+  return null;
+}
+
+function isTelegramRateLimitError(error: unknown): boolean {
+  if (getStatusCode(error) === 429) {
+    return true;
   }
 
   const message = getErrorMessage(error).toLowerCase();
   return /\b429\b/.test(message) || message.includes("too many requests");
+}
+
+export function isTransientTelegramServerError(error: unknown): boolean {
+  const status = getStatusCode(error);
+  if (status !== null) {
+    return TRANSIENT_SERVER_ERROR_CODES.has(status);
+  }
+
+  const message = getErrorMessage(error);
+  return [...TRANSIENT_SERVER_ERROR_CODES].some((code) =>
+    new RegExp(`\\b${code}\\b`).test(message),
+  );
+}
+
+function getServerErrorBackoffMs(attempt: number, baseDelayMs: number): number {
+  const normalizedAttempt = Math.max(0, Math.floor(attempt));
+  const delayMs = baseDelayMs * 2 ** normalizedAttempt;
+  return Math.min(Math.max(1, Math.floor(delayMs)), MAX_SERVER_ERROR_BACKOFF_MS);
 }
 
 function wait(ms: number): Promise<void> {
@@ -84,20 +121,30 @@ function wait(ms: number): Promise<void> {
   });
 }
 
+/**
+ * Returns how long to wait before retrying, or `null` when the error is not
+ * worth retrying. `attempt` is the number of retries already performed and only
+ * affects the transient-server-error backoff.
+ */
 export function getTelegramRetryAfterMs(
   error: unknown,
   fallbackDelayMs: number = 1000,
+  attempt: number = 0,
 ): number | null {
-  if (!isTelegramRateLimitError(error)) {
-    return null;
+  if (isTelegramRateLimitError(error)) {
+    const retryAfterSeconds = getRetryAfterSecondsFromError(error);
+    if (retryAfterSeconds !== null) {
+      return retryAfterSeconds * 1000;
+    }
+
+    return Math.max(1, Math.floor(fallbackDelayMs));
   }
 
-  const retryAfterSeconds = getRetryAfterSecondsFromError(error);
-  if (retryAfterSeconds !== null) {
-    return retryAfterSeconds * 1000;
+  if (isTransientTelegramServerError(error)) {
+    return getServerErrorBackoffMs(attempt, fallbackDelayMs);
   }
 
-  return Math.max(1, Math.floor(fallbackDelayMs));
+  return null;
 }
 
 export async function withTelegramRateLimitRetry<T>(
@@ -112,7 +159,7 @@ export async function withTelegramRateLimitRetry<T>(
     try {
       return await operation();
     } catch (error) {
-      const retryAfterMs = getTelegramRetryAfterMs(error, fallbackDelayMs);
+      const retryAfterMs = getTelegramRetryAfterMs(error, fallbackDelayMs, attempt);
       if (retryAfterMs === null || attempt >= maxRetries) {
         throw error;
       }

--- a/tests/utils/telegram-rate-limit-retry.test.ts
+++ b/tests/utils/telegram-rate-limit-retry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getTelegramRetryAfterMs,
+  isTransientTelegramServerError,
   withTelegramRateLimitRetry,
 } from "../../src/utils/telegram-rate-limit-retry.js";
 
@@ -36,12 +37,72 @@ describe("utils/telegram-rate-limit-retry", () => {
     expect(operation).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry non-rate-limit errors", async () => {
+  it("does not retry non-retryable errors", async () => {
     const operation = vi.fn().mockRejectedValueOnce(new Error("400: Bad Request"));
 
     await expect(withTelegramRateLimitRetry(operation, { maxRetries: 2 })).rejects.toThrow(
       "400: Bad Request",
     );
     expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects transient Telegram server errors", () => {
+    expect(isTransientTelegramServerError({ error_code: 502, description: "Bad Gateway" })).toBe(
+      true,
+    );
+    expect(
+      isTransientTelegramServerError(new Error("Call to 'sendMessage' failed! (502: Bad Gateway)")),
+    ).toBe(true);
+    expect(isTransientTelegramServerError({ error_code: 400 })).toBe(false);
+    expect(isTransientTelegramServerError(new Error("400: Bad Request"))).toBe(false);
+  });
+
+  it("backs off exponentially for transient server errors", () => {
+    const error = { error_code: 502, description: "Bad Gateway" };
+
+    expect(getTelegramRetryAfterMs(error, 500, 0)).toBe(500);
+    expect(getTelegramRetryAfterMs(error, 500, 1)).toBe(1000);
+    expect(getTelegramRetryAfterMs(error, 500, 2)).toBe(2000);
+  });
+
+  it("caps the transient server error backoff", () => {
+    expect(getTelegramRetryAfterMs({ error_code: 503 }, 1000, 20)).toBe(8000);
+  });
+
+  it("retries transient server errors and eventually succeeds", async () => {
+    vi.useFakeTimers();
+
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Call to 'sendMessage' failed! (502: Bad Gateway)"))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withTelegramRateLimitRetry(operation, {
+      maxRetries: 3,
+      fallbackDelayMs: 500,
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(promise).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up on transient server errors after maxRetries", async () => {
+    vi.useFakeTimers();
+
+    const operation = vi
+      .fn()
+      .mockRejectedValue(new Error("Call to 'sendMessage' failed! (503: Service Unavailable)"));
+
+    const promise = withTelegramRateLimitRetry(operation, {
+      maxRetries: 2,
+      fallbackDelayMs: 500,
+    }).catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(promise).resolves.toMatchObject({ message: expect.stringContaining("503") });
+    expect(operation).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## What happened

I hit this while using the bot. Telegram rate-limited me, and a few seconds later the same calls started coming back as `502 Bad Gateway`. Every live message froze: the typing indicator disappeared, the streamed reply stopped updating, and nothing recovered afterwards.

From my logs, the whole thing takes 9 seconds:

```
[2026-07-25T01:14:52.788Z] [WARN] [ToolCallStreamer] Stream sync rate-limited, retrying in 5000ms:
  session=ses_0692c1fa..., reason=throttle_elapsed
  GrammyError: Call to 'sendMessage' failed! (429: Too Many Requests: retry after 5)

[2026-07-25T01:14:54.707Z] [WARN] [ResponseStreamer] Stream sync rate-limited, retrying in 5000ms:
  message=thinking:msg_f96d6dab..., reason=throttle_elapsed
  GrammyError: Call to 'sendMessage' failed! (429: Too Many Requests: retry after 5)

[2026-07-25T01:14:58.897Z] [ERROR] [ResponseStreamer] Stream marked as broken:
  message=msg_f96d6dab..., reason=throttle_elapsed,
  error=Call to 'sendMessage' failed! (502: Bad Gateway)

[2026-07-25T01:14:58.902Z] [ERROR] [ToolCallStreamer] Stream marked as broken:
  reason=throttle_elapsed, error=Call to 'sendMessage' failed! (502: Bad Gateway)

[2026-07-25T01:14:59.762Z] [ERROR] [ResponseStreamer] Stream marked as broken:
  message=msg_f96d6ad5..., reason=complete,
  error=Call to 'editMessageText' failed! (502: Bad Gateway)

[2026-07-25T01:15:01.516Z] [ERROR] [ResponseStreamer] Stream marked as broken:
  message=thinking:msg_f96d6dab..., reason=throttle_elapsed,
  error=Call to 'sendMessage' failed! (502: Bad Gateway)
```

The `429` at the start is handled correctly. It gets retried after 5 seconds, using the `retry_after` Telegram sends back. The `502` six seconds later gets no retry at all, and four streams (the reply, the thinking stream, the tool-call stream, and one final edit) are marked broken within 2.6 seconds. Once a stream is broken it stays broken for the rest of the run, so the message never updates again even though Telegram recovers a moment later.

## Cause

`getTelegramRetryAfterMs()` in `src/utils/telegram-rate-limit-retry.ts` only classifies `429` as retryable. Everything else returns `null`, which the global `bot.api.config` middleware in `src/bot/index.ts` treats as "give up and rethrow". A `502` from Telegram's gateway is transient and usually succeeds on the next attempt, but it currently propagates on the first failure.

The same 502s also hit `sendChatAction` (that is the disappearing typing indicator) and `finalizeAssistantResponse`, where a failed send drops the finished reply entirely.

## Fix

Treat `500/502/503/504` as retryable, with an exponential backoff of 1s, 2s, 4s, 8s capped at 8s. The `429` handling is unchanged and still honours `retry_after`.

The change is in the shared helper, so the existing global `bot.api.config` middleware picks it up for every API call. `maxRetries` stays at 5. Callers are not modified, so a persistent outage still marks the stream broken as before.

One log line in `event-subscription-service.ts` said `CRITICAL: Stopping event processing due to error`, which does not describe what the code does: the catch block clears state, marks the session idle, and event processing continues. Changed it to say the response was dropped.

Network-level failures (`HttpError: Network request for 'sendChatAction' failed!`) show up in the same logs and are also not retried, but they carry no `error_code` and need different handling, so they are out of scope here.

## Tests

Five new cases in `tests/utils/telegram-rate-limit-retry.test.ts` covering 5xx detection, the backoff curve and cap, retrying after a `502`, and giving up after `maxRetries`.

Full suite passes (1194 tests) and `npm run lint` is clean. `npm run typecheck` reports three pre-existing `date_time` errors in `src/bot/render/` from grammY typings; they reproduce on a clean `main`.
