### PR TITLE
fix(runtime): require Node.js 22.14 so the guard catches the better-sqlite3 segfault

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@grinev/opencode-telegram-bot)](https://www.npmjs.com/package/@grinev/opencode-telegram-bot)
 [![CI](https://github.com/grinev/opencode-telegram-bot/actions/workflows/ci.yml/badge.svg)](https://github.com/grinev/opencode-telegram-bot/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 [![Follow updates](https://img.shields.io/badge/-Follow%20updates-333333?logo=x)](https://x.com/grin_rus)
 [![Community](https://img.shields.io/badge/Community-Telegram-26A5E4?logo=telegram&logoColor=white)](https://t.me/+Fj_IyKRi6-41MGUy)
 
@@ -55,7 +55,7 @@ Planned features currently in development are listed in [Current Task List](PROD
 
 ## Prerequisites
 
-- **Node.js 22+** — [download](https://nodejs.org)
+- **Node.js 22.14+** — [download](https://nodejs.org)
 - **OpenCode** — install from [opencode.ai](https://opencode.ai) or [GitHub](https://github.com/sst/opencode)
 - **Telegram Bot** — you'll create one during setup (takes 1 minute)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     ".env.example"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=22.14"
   },
   "scripts": {
     "build": "tsc",

--- a/src/runtime/node-version.ts
+++ b/src/runtime/node-version.ts
@@ -1,23 +1,32 @@
 const MINIMUM_NODE_MAJOR = 22;
+const MINIMUM_NODE_MINOR = 14;
+const MINIMUM_NODE_VERSION = `${MINIMUM_NODE_MAJOR}.${MINIMUM_NODE_MINOR}`;
 
 /**
  * Returns an error message when the running Node.js is too old, otherwise null.
  *
  * Must be checked before any module that loads a native addon is imported:
- * better-sqlite3 crashes the process with SIGSEGV on Node.js 20, and such a
- * crash cannot be caught by try/catch.
+ * better-sqlite3 crashes the process with SIGSEGV on unsupported Node.js
+ * versions, and such a crash cannot be caught by try/catch. Its prebuilt addon
+ * requires Node-API v10, which is only available from Node.js 22.14.
  */
 export function getUnsupportedNodeVersionMessage(
   version: string = process.versions.node,
 ): string | null {
-  const major = Number.parseInt(version.split(".")[0] ?? "", 10);
+  const [rawMajor, rawMinor] = version.split(".");
+  const major = Number.parseInt(rawMajor ?? "", 10);
+  const minor = Number.parseInt(rawMinor ?? "", 10);
 
-  if (!Number.isInteger(major) || major >= MINIMUM_NODE_MAJOR) {
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) {
+    return null;
+  }
+
+  if (major > MINIMUM_NODE_MAJOR || (major === MINIMUM_NODE_MAJOR && minor >= MINIMUM_NODE_MINOR)) {
     return null;
   }
 
   return [
-    `OpenCode Telegram Bot requires Node.js ${MINIMUM_NODE_MAJOR} or newer, but the current version is v${version}.`,
+    `OpenCode Telegram Bot requires Node.js ${MINIMUM_NODE_VERSION} or newer, but the current version is v${version}.`,
     "Update Node.js and try again: https://nodejs.org",
   ].join("\n");
 }

--- a/tests/runtime/node-version.test.ts
+++ b/tests/runtime/node-version.test.ts
@@ -5,12 +5,19 @@ describe("getUnsupportedNodeVersionMessage", () => {
   it("rejects Node.js versions below 22", () => {
     const message = getUnsupportedNodeVersionMessage("20.20.1");
 
-    expect(message).toContain("requires Node.js 22 or newer");
+    expect(message).toContain("requires Node.js 22.14 or newer");
     expect(message).toContain("v20.20.1");
   });
 
+  it("rejects Node.js 22 minors without Node-API v10", () => {
+    const message = getUnsupportedNodeVersionMessage("22.12.0");
+
+    expect(message).toContain("requires Node.js 22.14 or newer");
+    expect(message).toContain("v22.12.0");
+  });
+
   it("accepts the minimum supported version", () => {
-    expect(getUnsupportedNodeVersionMessage("22.0.0")).toBeNull();
+    expect(getUnsupportedNodeVersionMessage("22.14.0")).toBeNull();
   });
 
   it("accepts newer major versions", () => {


### PR DESCRIPTION
## Problem

On Node.js 22.0–22.13 the bot starts, logs a few lines, then dies with a bare `Segmentation fault: 11`:

```
[INFO] Starting OpenCode Telegram Bot v0.22.5...
[INFO] Node.js v22.12.0 on darwin arm64
...
[INFO] [SessionCache] Pruned 9 stale directories from cache
sh: line 1: 63248 Segmentation fault: 11  npm start
```

The crash is `better-sqlite3`'s prebuilt addon. macOS crash report:

```
exception: EXC_BAD_ACCESS / SIGSEGV, KERN_INVALID_ADDRESS at 0x90
napi_module_register_by_symbol(...)
node::binding::DLOpen(...)
```

The prebuild is built against Node-API v10, which only ships from Node.js **22.14**. On older 22.x, `dlopen` faults inside the N-API registration instead of failing cleanly.

`getUnsupportedNodeVersionMessage()` was meant to catch exactly this before any native addon is imported, but it only parsed the major version, so every 22.x passed the check.

Minimal repro:

```
node -e "new (require('better-sqlite3'))(':memory:')"   # exit 139
```

Verified locally across installed minors:

| Node | result |
| --- | --- |
| 22.12.0 | SIGSEGV (139) |
| 22.13.1 | SIGSEGV (139) |
| 22.14.0 | OK |

## Change

- `src/runtime/node-version.ts`: compare major **and** minor against 22.14. Unparseable versions still pass through without blocking startup.
- `tests/runtime/node-version.test.ts`: added a case for 22.12.0; minimum-version case is now 22.14.0.
- `package.json`: `engines.node` → `>=22.14`.
- `README.md`: badge and prerequisite line → 22.14+.

CI's `node-version: 22` already resolves to the latest 22.x, so it is left alone.

## Verification

On Node 22.14.0: `npm run build`, `npm run lint`, `npm run typecheck` clean; `npm test` → 135 files, 1317 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
