### PR TITLE
feat: render tables, large code blocks, and thinking as native Telegram rich messages

### DIFF
--- a/src/bot/messages/telegram-text.ts
+++ b/src/bot/messages/telegram-text.ts
@@ -93,11 +93,14 @@ function stripRichFormattingOptions<T extends TelegramSendMessageOptions | undef
 }
 
 export function getTelegramRenderedPartSignature(
-  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows" | "codeDetails">,
+  part: Pick<
+    TelegramRenderedPart,
+    "text" | "entities" | "tableRows" | "codeDetails" | "thinkingText"
+  >,
 ): string {
   return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
     part.tableRows ?? null,
-  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
+  )}\n${JSON.stringify(part.codeDetails ?? null)}\n${JSON.stringify(part.thinkingText ?? null)}`;
 }
 
 function buildNativeTableRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
@@ -153,8 +156,31 @@ function buildNativeCodeDetailsMessage(part: TelegramRenderedPart): RichMessageP
   };
 }
 
+function buildNativeThinkingMessage(part: TelegramRenderedPart): RichMessageParam | null {
+  if (!part.thinkingText) {
+    return null;
+  }
+
+  return {
+    blocks: [
+      {
+        type: "thinking",
+        text: part.thinkingText,
+      },
+    ],
+  };
+}
+
 function buildNativeRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
   return buildNativeTableRichMessage(part) ?? buildNativeCodeDetailsMessage(part);
+}
+
+function buildNativeDraftRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
+  return (
+    buildNativeTableRichMessage(part) ??
+    buildNativeCodeDetailsMessage(part) ??
+    buildNativeThinkingMessage(part)
+  );
 }
 
 export async function sendBotText({
@@ -324,7 +350,7 @@ export async function sendDraftBotPart({
     tableRows: part.tableRows?.length ?? 0,
   });
 
-  const nativeTableMessage = buildNativeRichMessage(part);
+  const nativeTableMessage = buildNativeDraftRichMessage(part);
   if (nativeTableMessage && api.sendRichMessageDraft) {
     try {
       await api.sendRichMessageDraft(chatId, draftId, nativeTableMessage as RichMessageDraftParam);

--- a/src/bot/messages/telegram-text.ts
+++ b/src/bot/messages/telegram-text.ts
@@ -6,9 +6,16 @@ import {
 } from "./send-with-markdown-fallback.js";
 import type { TelegramRenderedPart } from "../render/types.js";
 
-type SendMessageApi = Pick<Api<RawApi>, "sendMessage">;
+type SendMessageApi = Pick<Api<RawApi>, "sendMessage"> & {
+  sendRichMessage?: Api<RawApi>["sendRichMessage"];
+};
 type EditMessageApi = Pick<Api<RawApi>, "editMessageText">;
-type SendDraftApi = Pick<Api<RawApi>, "sendMessageDraft">;
+type SendDraftApi = Pick<Api<RawApi>, "sendMessageDraft"> & {
+  sendRichMessageDraft?: Api<RawApi>["sendRichMessageDraft"];
+};
+
+type RichMessageParam = Parameters<NonNullable<SendMessageApi["sendRichMessage"]>>[1];
+type RichMessageDraftParam = Parameters<NonNullable<SendDraftApi["sendRichMessageDraft"]>>[2];
 
 type TelegramSendMessageOptions = Parameters<SendMessageApi["sendMessage"]>[2];
 type TelegramEditMessageOptions = Parameters<EditMessageApi["editMessageText"]>[3];
@@ -86,9 +93,36 @@ function stripRichFormattingOptions<T extends TelegramSendMessageOptions | undef
 }
 
 export function getTelegramRenderedPartSignature(
-  part: Pick<TelegramRenderedPart, "text" | "entities">,
+  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows">,
 ): string {
-  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
+    part.tableRows ?? null,
+  )}`;
+}
+
+function buildNativeTableRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
+  if (!part.tableRows?.length) {
+    return null;
+  }
+
+  const cells = part.tableRows.map((row, rowIndex) =>
+    row.map((cell) => ({
+      text: String(cell ?? ""),
+      ...(rowIndex === 0 ? { is_header: true as const } : {}),
+      align: "left" as const,
+      valign: "top" as const,
+    })),
+  );
+
+  return {
+    blocks: [
+      {
+        type: "table",
+        cells,
+        is_bordered: true,
+      },
+    ],
+  };
 }
 
 export async function sendBotText({
@@ -122,7 +156,21 @@ export async function sendRenderedBotPart({
     textLength: part.text.length,
     fallbackTextLength: part.fallbackText.length,
     entityCount: part.entities?.length ?? 0,
+    tableRows: part.tableRows?.length ?? 0,
   });
+
+  const nativeTableMessage = buildNativeTableRichMessage(part);
+  if (nativeTableMessage && api.sendRichMessage) {
+    try {
+      const sentMessage = await api.sendRichMessage(chatId, nativeTableMessage, rawOptions);
+      return {
+        messageId: sentMessage.message_id,
+        deliveredSignature: getTelegramRenderedPartSignature(part),
+      };
+    } catch (error) {
+      logger.warn("[Bot] Native table send failed, falling back to text part", error);
+    }
+  }
 
   if (!part.entities?.length) {
     const sentMessage = await api.sendMessage(chatId, part.text, rawOptions);
@@ -173,7 +221,20 @@ export async function editRenderedBotPart({
     textLength: part.text.length,
     fallbackTextLength: part.fallbackText.length,
     entityCount: part.entities?.length ?? 0,
+    tableRows: part.tableRows?.length ?? 0,
   });
+
+  const nativeTableMessage = buildNativeTableRichMessage(part);
+  if (nativeTableMessage) {
+    try {
+      await api.editMessageText(chatId, messageId, nativeTableMessage, rawOptions);
+      return {
+        deliveredSignature: getTelegramRenderedPartSignature(part),
+      };
+    } catch (error) {
+      logger.warn("[Bot] Native table edit failed, falling back to text edit", error);
+    }
+  }
 
   if (!part.entities?.length) {
     await api.editMessageText(chatId, messageId, part.text, rawOptions);
@@ -228,7 +289,20 @@ export async function sendDraftBotPart({
     draftId,
     textLength: part.text.length,
     entityCount: part.entities?.length ?? 0,
+    tableRows: part.tableRows?.length ?? 0,
   });
+
+  const nativeTableMessage = buildNativeTableRichMessage(part);
+  if (nativeTableMessage && api.sendRichMessageDraft) {
+    try {
+      await api.sendRichMessageDraft(chatId, draftId, nativeTableMessage as RichMessageDraftParam);
+      return {
+        deliveredSignature: getTelegramRenderedPartSignature(part),
+      };
+    } catch (error) {
+      logger.warn("[Bot] Native table draft failed, falling back to text draft", error);
+    }
+  }
 
   if (!part.entities?.length) {
     await api.sendMessageDraft(chatId, draftId, part.text);
@@ -264,7 +338,21 @@ export async function completeDraftPart({
   logger.debug("[Bot] Completing draft with real message", {
     textLength: part.text.length,
     entityCount: part.entities?.length ?? 0,
+    tableRows: part.tableRows?.length ?? 0,
   });
+
+  const nativeTableMessage = buildNativeTableRichMessage(part);
+  if (nativeTableMessage && api.sendRichMessage) {
+    try {
+      const sentMessage = await api.sendRichMessage(chatId, nativeTableMessage, rawOptions);
+      return {
+        messageId: sentMessage.message_id,
+        deliveredSignature: getTelegramRenderedPartSignature(part),
+      };
+    } catch (error) {
+      logger.warn("[Bot] Native table complete failed, falling back to text", error);
+    }
+  }
 
   if (!part.entities?.length) {
     const sentMessage = await api.sendMessage(chatId, part.text, rawOptions);

--- a/src/bot/messages/telegram-text.ts
+++ b/src/bot/messages/telegram-text.ts
@@ -93,11 +93,11 @@ function stripRichFormattingOptions<T extends TelegramSendMessageOptions | undef
 }
 
 export function getTelegramRenderedPartSignature(
-  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows">,
+  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows" | "codeDetails">,
 ): string {
   return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
     part.tableRows ?? null,
-  )}`;
+  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
 }
 
 function buildNativeTableRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
@@ -123,6 +123,38 @@ function buildNativeTableRichMessage(part: TelegramRenderedPart): RichMessagePar
       },
     ],
   };
+}
+
+function buildNativeCodeDetailsMessage(part: TelegramRenderedPart): RichMessageParam | null {
+  if (!part.codeDetails) {
+    return null;
+  }
+
+  const { language, text } = part.codeDetails;
+  const lineCount = text.split("\n").length;
+  const summary = language
+    ? `Code — ${language} (${lineCount} lines)`
+    : `Code (${lineCount} lines)`;
+
+  return {
+    blocks: [
+      {
+        type: "details",
+        summary,
+        blocks: [
+          {
+            type: "pre",
+            text,
+            ...(language ? { language } : {}),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildNativeRichMessage(part: TelegramRenderedPart): RichMessageParam | null {
+  return buildNativeTableRichMessage(part) ?? buildNativeCodeDetailsMessage(part);
 }
 
 export async function sendBotText({
@@ -159,7 +191,7 @@ export async function sendRenderedBotPart({
     tableRows: part.tableRows?.length ?? 0,
   });
 
-  const nativeTableMessage = buildNativeTableRichMessage(part);
+  const nativeTableMessage = buildNativeRichMessage(part);
   if (nativeTableMessage && api.sendRichMessage) {
     try {
       const sentMessage = await api.sendRichMessage(chatId, nativeTableMessage, rawOptions);
@@ -224,7 +256,7 @@ export async function editRenderedBotPart({
     tableRows: part.tableRows?.length ?? 0,
   });
 
-  const nativeTableMessage = buildNativeTableRichMessage(part);
+  const nativeTableMessage = buildNativeRichMessage(part);
   if (nativeTableMessage) {
     try {
       await api.editMessageText(chatId, messageId, nativeTableMessage, rawOptions);
@@ -292,7 +324,7 @@ export async function sendDraftBotPart({
     tableRows: part.tableRows?.length ?? 0,
   });
 
-  const nativeTableMessage = buildNativeTableRichMessage(part);
+  const nativeTableMessage = buildNativeRichMessage(part);
   if (nativeTableMessage && api.sendRichMessageDraft) {
     try {
       await api.sendRichMessageDraft(chatId, draftId, nativeTableMessage as RichMessageDraftParam);
@@ -341,7 +373,7 @@ export async function completeDraftPart({
     tableRows: part.tableRows?.length ?? 0,
   });
 
-  const nativeTableMessage = buildNativeTableRichMessage(part);
+  const nativeTableMessage = buildNativeRichMessage(part);
   if (nativeTableMessage && api.sendRichMessage) {
     try {
       const sentMessage = await api.sendRichMessage(chatId, nativeTableMessage, rawOptions);

--- a/src/bot/messages/thinking-rendering.ts
+++ b/src/bot/messages/thinking-rendering.ts
@@ -60,6 +60,7 @@ function createThinkingPart(header: string, text: string, expandable: boolean): 
     entities: [entity],
     fallbackText: `${header}\n${quoteFallbackText(text)}`,
     source: "entities",
+    thinkingText: renderedText,
   };
 }
 
@@ -92,6 +93,7 @@ export function makeThinkingPayloadExpandable(
     ...payload,
     parts: payload.parts.map((part) => ({
       ...part,
+      thinkingText: part.thinkingText,
       entities: part.entities?.map((entity) =>
         entity.type === "blockquote" ? { ...entity, type: "expandable_blockquote" } : entity,
       ),

--- a/src/bot/render/block-renderer.ts
+++ b/src/bot/render/block-renderer.ts
@@ -591,7 +591,9 @@ export function renderTelegramBlock(
         return createRenderedBlock(block.type, mode, text, text);
       }
 
-      return renderPreformattedBlock(block.type, mode, text);
+      const rendered = renderPreformattedBlock(block.type, mode, text);
+      rendered.tableRows = block.rows;
+      return rendered;
     }
     case "rule":
       return createRenderedBlock(block.type, mode, "──────────", "──────────");

--- a/src/bot/render/block-renderer.ts
+++ b/src/bot/render/block-renderer.ts
@@ -3,6 +3,8 @@ import { renderInlineNodesValidated } from "./inline-renderer.js";
 import type { BlockRenderMode, InlineNode, TelegramBlock, TelegramRenderedBlock } from "./types.js";
 import { validateTelegramEntities } from "./validator.js";
 
+const CODE_DETAILS_MIN_LINES = 8;
+
 interface RenderedSegment {
   text: string;
   fallbackText: string;
@@ -584,7 +586,14 @@ export function renderTelegramBlock(
         return createRenderedBlock(block.type, mode, block.text, block.text);
       }
 
-      return renderPreformattedBlock(block.type, mode, block.text, block.language);
+      {
+        const rendered = renderPreformattedBlock(block.type, mode, block.text, block.language);
+        const lineCount = block.text.split("\n").length;
+        if (lineCount >= CODE_DETAILS_MIN_LINES) {
+          rendered.codeDetails = { language: block.language, text: block.text };
+        }
+        return rendered;
+      }
     case "table": {
       const text = buildAlignedTableText(block.rows);
       if (mode === "plain" || mode === "line-by-line") {

--- a/src/bot/render/chunker.ts
+++ b/src/bot/render/chunker.ts
@@ -121,6 +121,9 @@ function createRenderedPartWithDetails(
   if (block.codeDetails) {
     part.codeDetails = block.codeDetails;
   }
+  if (block.thinkingText) {
+    part.thinkingText = block.thinkingText;
+  }
 
   return part;
 }
@@ -133,6 +136,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
     source: part.source,
     tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
     codeDetails: part.codeDetails ? { ...part.codeDetails } : undefined,
+    thinkingText: part.thinkingText,
   };
 }
 

--- a/src/bot/render/chunker.ts
+++ b/src/bot/render/chunker.ts
@@ -108,15 +108,18 @@ function createRenderedPart(
   };
 }
 
-function createRenderedPartWithTableRows(
+function createRenderedPartWithDetails(
   text: string,
   fallbackText: string,
   entities: MessageEntity[] | undefined,
-  tableRows: string[][] | undefined,
+  block: TelegramRenderedBlock,
 ): TelegramRenderedPart {
   const part = createRenderedPart(text, fallbackText, entities);
-  if (tableRows?.length) {
-    part.tableRows = tableRows;
+  if (block.tableRows?.length) {
+    part.tableRows = block.tableRows;
+  }
+  if (block.codeDetails) {
+    part.codeDetails = block.codeDetails;
   }
 
   return part;
@@ -129,6 +132,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
     fallbackText: part.fallbackText,
     source: part.source,
     tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
+    codeDetails: part.codeDetails ? { ...part.codeDetails } : undefined,
   };
 }
 
@@ -305,7 +309,7 @@ function splitBlockToParts(
   }
 
   if (block.text.length <= maxLength) {
-    return [createRenderedPartWithTableRows(block.text, block.fallbackText, block.entities, block.tableRows)];
+    return [createRenderedPartWithDetails(block.text, block.fallbackText, block.entities, block)];
   }
 
   const preEntity = isFullRangePreEntity(block);
@@ -395,7 +399,7 @@ export function chunkTelegramRenderedBlocks(
       const needsSeparator = index === 0 && current.text.length > 0;
       const prefix = needsSeparator ? blockSeparator : "";
 
-      if (chunk.tableRows) {
+      if (chunk.tableRows || chunk.codeDetails) {
         flushCurrent();
         parts.push(chunk);
         continue;

--- a/src/bot/render/chunker.ts
+++ b/src/bot/render/chunker.ts
@@ -108,12 +108,27 @@ function createRenderedPart(
   };
 }
 
+function createRenderedPartWithTableRows(
+  text: string,
+  fallbackText: string,
+  entities: MessageEntity[] | undefined,
+  tableRows: string[][] | undefined,
+): TelegramRenderedPart {
+  const part = createRenderedPart(text, fallbackText, entities);
+  if (tableRows?.length) {
+    part.tableRows = tableRows;
+  }
+
+  return part;
+}
+
 function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
   return {
     text: part.text,
     entities: part.entities ? [...part.entities] : undefined,
     fallbackText: part.fallbackText,
     source: part.source,
+    tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
   };
 }
 
@@ -290,7 +305,7 @@ function splitBlockToParts(
   }
 
   if (block.text.length <= maxLength) {
-    return [createRenderedPart(block.text, block.fallbackText, block.entities)];
+    return [createRenderedPartWithTableRows(block.text, block.fallbackText, block.entities, block.tableRows)];
   }
 
   const preEntity = isFullRangePreEntity(block);
@@ -366,6 +381,13 @@ export function chunkTelegramRenderedBlocks(
     .filter((group) => group.length > 0);
   const parts: TelegramRenderedPart[] = [];
   let current = createBuilder();
+  const flushCurrent = (): void => {
+    const finalized = finalizeBuilder(current);
+    if (finalized) {
+      parts.push(finalized);
+    }
+    current = createBuilder();
+  };
 
   for (const blockParts of blockGroups) {
     for (let index = 0; index < blockParts.length; index++) {
@@ -373,15 +395,17 @@ export function chunkTelegramRenderedBlocks(
       const needsSeparator = index === 0 && current.text.length > 0;
       const prefix = needsSeparator ? blockSeparator : "";
 
+      if (chunk.tableRows) {
+        flushCurrent();
+        parts.push(chunk);
+        continue;
+      }
+
       if (
         current.text.length > 0 &&
         current.text.length + prefix.length + chunk.text.length > maxPartLength
       ) {
-        const finalized = finalizeBuilder(current);
-        if (finalized) {
-          parts.push(finalized);
-        }
-        current = createBuilder();
+        flushCurrent();
         appendToBuilder(current, chunk, "");
         continue;
       }

--- a/src/bot/render/types.ts
+++ b/src/bot/render/types.ts
@@ -9,6 +9,7 @@ export interface TelegramRenderedPart {
   source: "entities" | "plain";
   tableRows?: string[][];
   codeDetails?: { language?: string; text: string };
+  thinkingText?: string;
 }
 
 export interface TelegramRenderedBlock {
@@ -20,6 +21,7 @@ export interface TelegramRenderedBlock {
   source: "entities" | "plain";
   tableRows?: string[][];
   codeDetails?: { language?: string; text: string };
+  thinkingText?: string;
 }
 
 export type TelegramBlock =

--- a/src/bot/render/types.ts
+++ b/src/bot/render/types.ts
@@ -8,6 +8,7 @@ export interface TelegramRenderedPart {
   fallbackText: string;
   source: "entities" | "plain";
   tableRows?: string[][];
+  codeDetails?: { language?: string; text: string };
 }
 
 export interface TelegramRenderedBlock {
@@ -18,6 +19,7 @@ export interface TelegramRenderedBlock {
   fallbackText: string;
   source: "entities" | "plain";
   tableRows?: string[][];
+  codeDetails?: { language?: string; text: string };
 }
 
 export type TelegramBlock =

--- a/src/bot/render/types.ts
+++ b/src/bot/render/types.ts
@@ -7,6 +7,7 @@ export interface TelegramRenderedPart {
   entities?: MessageEntity[];
   fallbackText: string;
   source: "entities" | "plain";
+  tableRows?: string[][];
 }
 
 export interface TelegramRenderedBlock {
@@ -16,6 +17,7 @@ export interface TelegramRenderedBlock {
   entities?: MessageEntity[];
   fallbackText: string;
   source: "entities" | "plain";
+  tableRows?: string[][];
 }
 
 export type TelegramBlock =

--- a/src/bot/streaming/response-streamer.ts
+++ b/src/bot/streaming/response-streamer.ts
@@ -69,6 +69,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
     source: part.source,
     tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
     codeDetails: part.codeDetails ? { ...part.codeDetails } : undefined,
+    thinkingText: part.thinkingText,
   };
 }
 
@@ -114,11 +115,14 @@ function getRetryAfterMs(error: unknown): number | null {
 }
 
 function createSignature(
-  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows" | "codeDetails">,
+  part: Pick<
+    TelegramRenderedPart,
+    "text" | "entities" | "tableRows" | "codeDetails" | "thinkingText"
+  >,
 ): string {
   return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
     part.tableRows ?? null,
-  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
+  )}\n${JSON.stringify(part.codeDetails ?? null)}\n${JSON.stringify(part.thinkingText ?? null)}`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/bot/streaming/response-streamer.ts
+++ b/src/bot/streaming/response-streamer.ts
@@ -67,6 +67,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
     entities: part.entities ? [...part.entities] : undefined,
     fallbackText: part.fallbackText,
     source: part.source,
+    tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
   };
 }
 
@@ -111,8 +112,8 @@ function getRetryAfterMs(error: unknown): number | null {
   return seconds * 1000;
 }
 
-function createSignature(part: Pick<TelegramRenderedPart, "text" | "entities">): string {
-  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
+function createSignature(part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows">): string {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(part.tableRows ?? null)}`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/bot/streaming/response-streamer.ts
+++ b/src/bot/streaming/response-streamer.ts
@@ -68,6 +68,7 @@ function clonePart(part: TelegramRenderedPart): TelegramRenderedPart {
     fallbackText: part.fallbackText,
     source: part.source,
     tableRows: part.tableRows ? part.tableRows.map((row) => [...row]) : undefined,
+    codeDetails: part.codeDetails ? { ...part.codeDetails } : undefined,
   };
 }
 
@@ -112,8 +113,12 @@ function getRetryAfterMs(error: unknown): number | null {
   return seconds * 1000;
 }
 
-function createSignature(part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows">): string {
-  return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(part.tableRows ?? null)}`;
+function createSignature(
+  part: Pick<TelegramRenderedPart, "text" | "entities" | "tableRows" | "codeDetails">,
+): string {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
+    part.tableRows ?? null,
+  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
 }
 
 function delay(ms: number): Promise<void> {

--- a/tests/bot/messages/telegram-text.test.ts
+++ b/tests/bot/messages/telegram-text.test.ts
@@ -399,4 +399,45 @@ describe("bot/messages/telegram-text", () => {
     expect(sendRichMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("sends native details block for large code parts via sendRichMessage", async () => {
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 778 });
+    const sendMessage = vi.fn();
+
+    const code = Array.from({ length: 10 }, (_, index) => `line ${index}`).join("\n");
+
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage, sendRichMessage },
+        chatId: 100,
+        part: {
+          text: `\`\`\`ts\n${code}\n\`\`\``,
+          fallbackText: code,
+          source: "plain",
+          codeDetails: { language: "ts", text: code },
+        },
+      }),
+    ).resolves.toEqual({
+      messageId: 778,
+      deliveredSignature: getTelegramRenderedPartSignature({
+        text: `\`\`\`ts\n${code}\n\`\`\``,
+        codeDetails: { language: "ts", text: code },
+      }),
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendRichMessage).toHaveBeenCalledWith(
+      100,
+      {
+        blocks: [
+          {
+            type: "details",
+            summary: "Code — ts (10 lines)",
+            blocks: [{ type: "pre", text: code, language: "ts" }],
+          },
+        ],
+      },
+      undefined,
+    );
+  });
 });

--- a/tests/bot/messages/telegram-text.test.ts
+++ b/tests/bot/messages/telegram-text.test.ts
@@ -4,6 +4,7 @@ import {
   editBotText,
   getTelegramRenderedPartSignature,
   sendBotText,
+  sendDraftBotPart,
   sendRenderedBotPart,
 } from "../../../src/bot/messages/telegram-text.js";
 
@@ -438,6 +439,39 @@ describe("bot/messages/telegram-text", () => {
         ],
       },
       undefined,
+    );
+  });
+
+  it("sends native thinking block via sendRichMessageDraft when part has thinkingText", async () => {
+    const sendRichMessageDraft = vi.fn().mockResolvedValue(true);
+    const sendMessageDraft = vi.fn();
+
+    await expect(
+      sendDraftBotPart({
+        api: { sendRichMessageDraft, sendMessageDraft },
+        chatId: 100,
+        draftId: 500,
+        part: {
+          text: "Thinking — Analysis\nline one",
+          fallbackText: "Thinking — Analysis\n> line one",
+          source: "entities",
+          thinkingText: "Thinking — Analysis\nline one",
+        },
+      }),
+    ).resolves.toEqual({
+      deliveredSignature: getTelegramRenderedPartSignature({
+        text: "Thinking — Analysis\nline one",
+        thinkingText: "Thinking — Analysis\nline one",
+      }),
+    });
+
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1);
+    expect(sendRichMessageDraft).toHaveBeenCalledWith(
+      100,
+      500,
+      {
+        blocks: [{ type: "thinking", text: "Thinking — Analysis\nline one" }],
+      },
     );
   });
 });

--- a/tests/bot/messages/telegram-text.test.ts
+++ b/tests/bot/messages/telegram-text.test.ts
@@ -290,4 +290,113 @@ describe("bot/messages/telegram-text", () => {
       reply_markup: { inline_keyboard: [] },
     });
   });
+
+  it("sends native rich table via sendRichMessage when part has tableRows", async () => {
+    const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 777 });
+    const sendMessage = vi.fn();
+
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage, sendRichMessage },
+        chatId: 100,
+        part: {
+          text: "A | B\n---|---\n1 | 2",
+          fallbackText: "A | B\n---|---\n1 | 2",
+          source: "plain",
+          tableRows: [
+            ["A", "B"],
+            ["1", "2"],
+          ],
+        },
+      }),
+    ).resolves.toEqual({
+      messageId: 777,
+      deliveredSignature: getTelegramRenderedPartSignature({
+        text: "A | B\n---|---\n1 | 2",
+        tableRows: [
+          ["A", "B"],
+          ["1", "2"],
+        ],
+      }),
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendRichMessage).toHaveBeenCalledWith(
+      100,
+      {
+        blocks: [
+          {
+            type: "table",
+            cells: [
+              [
+                { text: "A", is_header: true, align: "left", valign: "top" },
+                { text: "B", is_header: true, align: "left", valign: "top" },
+              ],
+              [
+                { text: "1", align: "left", valign: "top" },
+                { text: "2", align: "left", valign: "top" },
+              ],
+            ],
+            is_bordered: true,
+          },
+        ],
+      },
+      undefined,
+    );
+  });
+
+  it("falls back to plain text when sendRichMessage is unavailable", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 123 });
+
+    await expect(
+      sendRenderedBotPart({
+        api: { sendMessage },
+        chatId: 100,
+        part: {
+          text: "A | B\n---|---\n1 | 2",
+          fallbackText: "A | B\n---|---\n1 | 2",
+          source: "plain",
+          tableRows: [
+            ["A", "B"],
+            ["1", "2"],
+          ],
+        },
+      }),
+    ).resolves.toEqual({
+      messageId: 123,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: "A | B\n---|---\n1 | 2" }),
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(100, "A | B\n---|---\n1 | 2", undefined);
+  });
+
+  it("falls back to plain text when native table send fails", async () => {
+    const sendRichMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Bad Request: cannot send rich message"));
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 123 });
+
+    await expect(
+      sendRenderedBotPart({
+        api: { sendRichMessage, sendMessage },
+        chatId: 100,
+        part: {
+          text: "A | B\n---|---\n1 | 2",
+          fallbackText: "A | B\n---|---\n1 | 2",
+          source: "plain",
+          tableRows: [
+            ["A", "B"],
+            ["1", "2"],
+          ],
+        },
+      }),
+    ).resolves.toEqual({
+      messageId: 123,
+      deliveredSignature: getTelegramRenderedPartSignature({ text: "A | B\n---|---\n1 | 2" }),
+    });
+
+    expect(sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/bot/messages/thinking-rendering.test.ts
+++ b/tests/bot/messages/thinking-rendering.test.ts
@@ -22,6 +22,7 @@ describe("bot/messages/thinking-rendering", () => {
         entities: [{ type: "expandable_blockquote", offset: header.length + 1, length: text.length }],
         fallbackText: `${header}\n> Line one\n> Line two`,
         source: "entities",
+        thinkingText: `${header}\n${text}`,
       },
     ]);
   });

--- a/tests/bot/render/block-renderer.test.ts
+++ b/tests/bot/render/block-renderer.test.ts
@@ -118,6 +118,21 @@ describe("bot/render/block-renderer", () => {
     });
   });
 
+  it("carries codeDetails on large code blocks", () => {
+    const text = Array.from({ length: 10 }, (_, index) => `line ${index}`).join("\n");
+    const block: TelegramBlock = {
+      type: "code",
+      language: "ts",
+      text,
+    };
+
+    expect(renderTelegramBlock(block)).toMatchObject({
+      blockType: "code",
+      mode: "full",
+      codeDetails: { language: "ts", text },
+    });
+  });
+
   it("renders tables as aligned preformatted text", () => {
     const block: TelegramBlock = {
       type: "table",

--- a/tests/bot/render/block-renderer.test.ts
+++ b/tests/bot/render/block-renderer.test.ts
@@ -135,6 +135,11 @@ describe("bot/render/block-renderer", () => {
       entities: [{ type: "pre", offset: 0, length: 63 }],
       fallbackText: "Name    | Score\n--------|------\napi.js  | +1.5 \nalert() | -1.5 ",
       source: "entities",
+      tableRows: [
+        ["Name", "Score"],
+        ["api.js", "+1.5"],
+        ["alert()", "-1.5"],
+      ],
     });
   });
 

--- a/tests/bot/streaming/response-streamer.test.ts
+++ b/tests/bot/streaming/response-streamer.test.ts
@@ -21,8 +21,10 @@ function richPart(
   };
 }
 
-function signature(part: { text: string; entities?: unknown[] }) {
-  return `${part.text}\n${JSON.stringify(part.entities ?? null)}`;
+function signature(part: { text: string; entities?: unknown[]; tableRows?: unknown[][] }) {
+  return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
+    part.tableRows ?? null,
+  )}`;
 }
 
 describe("bot/streaming/response-streamer", () => {

--- a/tests/bot/streaming/response-streamer.test.ts
+++ b/tests/bot/streaming/response-streamer.test.ts
@@ -21,10 +21,15 @@ function richPart(
   };
 }
 
-function signature(part: { text: string; entities?: unknown[]; tableRows?: unknown[][] }) {
+function signature(part: {
+  text: string;
+  entities?: unknown[];
+  tableRows?: unknown[][];
+  codeDetails?: { language?: string; text: string };
+}) {
   return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
     part.tableRows ?? null,
-  )}`;
+  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
 }
 
 describe("bot/streaming/response-streamer", () => {

--- a/tests/bot/streaming/response-streamer.test.ts
+++ b/tests/bot/streaming/response-streamer.test.ts
@@ -26,10 +26,11 @@ function signature(part: {
   entities?: unknown[];
   tableRows?: unknown[][];
   codeDetails?: { language?: string; text: string };
+  thinkingText?: string;
 }) {
   return `${part.text}\n${JSON.stringify(part.entities ?? null)}\n${JSON.stringify(
     part.tableRows ?? null,
-  )}\n${JSON.stringify(part.codeDetails ?? null)}`;
+  )}\n${JSON.stringify(part.codeDetails ?? null)}\n${JSON.stringify(part.thinkingText ?? null)}`;
 }
 
 describe("bot/streaming/response-streamer", () => {


### PR DESCRIPTION
## What

Assistant markdown output is currently rendered as plain text with entities (tables as ASCII text, code as preformatted text, thinking as blockquote). Since **Bot API 10.1** (Rich Messages, June 2026) Telegram supports native **rich message blocks**. This PR renders three high-value elements as native Telegram blocks, keeping the existing text rendering as a fallback:

1. **Markdown tables → native table blocks** (`InputRichBlockTable`, bordered).
2. **Large fenced code blocks (8+ lines) → collapsible `details` blocks** (summary = language + line count) wrapping a native `pre` block.
3. **Thinking/analysis sections → native `thinking` blocks** on the streaming path.

## How

- `src/bot/render/types.ts` — add `tableRows`, `codeDetails`, `thinkingText` to `TelegramRenderedBlock`/`TelegramRenderedPart`.
- `src/bot/render/block-renderer.ts` — table blocks carry raw rows; code blocks (≥8 lines) carry `codeDetails`.
- `src/bot/messages/thinking-rendering.ts` — thinking parts carry `thinkingText`.
- `src/bot/render/chunker.ts` — table/details parts stay **standalone**; metadata preserved through splitting/cloning.
- `src/bot/streaming/response-streamer.ts` — `clonePart`/`createSignature` preserve the new fields.
- `src/bot/messages/telegram-text.ts`:
  - parts with table/code metadata are sent via `sendRichMessage` (send + complete), `sendRichMessageDraft` (streaming), or `editMessageText` with a rich message; **text fallback** on error or when the method is unavailable.
  - **thinking is draft-only**: `sendRichMessageDraft` accepts the `thinking` block (verified HTTP 200), but `sendRichMessage` rejects it (`RICH_MESSAGE_BLOCK_UNSUPPORTED`), so native thinking is sent only while streaming and the completed message falls back to the existing blockquote text.

## Verification

- `npm run typecheck` / `npm run lint` / `npm run build` — clean.
- `npm test` — **1425 tests pass**, including new tests (table send, details send, thinking draft, both fallbacks) and updated renderer/streamer expectations.
- Live smoke tests against the Telegram Bot API:
  - `sendRichMessage` table block → HTTP 200
  - `sendRichMessage` `details`+`pre` → HTTP 200
  - `sendRichMessageDraft` `thinking` block → HTTP 200; `sendRichMessage` `thinking` → HTTP 400 (`RICH_MESSAGE_BLOCK_UNSUPPORTED`), confirming the draft-only handling.

## Notes

- Native rich messages require a Telegram client that supports Rich Messages; text fallback keeps older clients working.
- Small code blocks (<8 lines) intentionally keep the existing preformatted rendering.
- No stored tokens or config changes.