### PR TITLE
feat(docker): add containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Environment files
+.env
+.env.*
+
+# Local data directories
+data/
+logs/
+backups/
+
+# OMO
+.omo/
+
+# Code editors/IDEs
+.vscode/
+.idea/
+.codex/
+.claude/
+*.swp
+*.swo
+
+# Git
+.git/
+
+# Build artifacts and dependencies (built in image, not copied from host)
+node_modules/
+dist/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local settings and personal files
+settings.json
+settings.json.*
+*.host
+
+# Logs
+*.log
+npm-debug.log*
+
+# Local systemd service file
+opencode-telegram-bot.service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Build stage
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Install only native build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy package files first for better layer caching
+COPY package.json package-lock.json ./
+
+# Install ALL dependencies (including dev for build)
+RUN npm ci
+
+# Copy TypeScript config and source code
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+# Build the project
+RUN npm run build
+
+# Prune dev dependencies from the final image
+RUN npm prune --omit=dev
+
+
+# Runtime stage
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+
+# Install dumb-init and ca-certificates for proper signal handling and HTTPS
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dumb-init \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Set persistent home for the bot
+ENV OPENCODE_TELEGRAM_HOME=/app/data
+
+# Create data directories with correct ownership for node user
+RUN mkdir -p /app/data/logs /app/data/run && \
+    chown -R node:node /app
+
+# Copy built application and production dependencies from builder
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+
+# Run as non-root node user (uid 1000)
+USER node
+
+# Single dumb-init entrypoint
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -436,6 +436,51 @@ Build and run:
 npm run dev
 ```
 
+### Docker Deployment
+
+The bot can also be run as a container using Docker and Docker Compose.
+
+```bash
+git clone https://github.com/grinev/opencode-telegram-bot.git
+cd opencode-telegram-bot
+cp .env.example .env
+# Edit .env with your bot token, user ID, and model settings
+```
+
+Build and start:
+
+```bash
+docker compose up -d --build
+```
+
+Follow logs:
+
+```bash
+docker compose logs -f opencode-bot
+```
+
+Stop:
+
+```bash
+docker compose down
+```
+
+#### Persistence
+
+Runtime state (settings, logs, SQLite databases) is stored in a Docker named volume `opencode-bot-data` mapped to `/app/data` inside the container. The volume is created automatically on first run.
+
+#### Configuration
+
+All configuration is provided through environment variables in the `.env` file. The most relevant variables for Docker are:
+
+- `OPENCODE_API_URL` — URL of the OpenCode server. Default: `http://127.0.0.1:4096`. If running OpenCode on the Docker host (not in a container), `network_mode: host` allows using `127.0.0.1`. If OpenCode runs elsewhere, set the appropriate host/port.
+
+#### Networking Note
+
+The provided `docker-compose.yml` uses `network_mode: host` (Linux only) because OpenCode by default binds to `127.0.0.1:4096` only. This allows the container to reach the OpenCode server on the host without additional configuration. On macOS/Windows, `network_mode: host` is not available; OpenCode must be configured to listen on `0.0.0.0` or a reachable IP, and `OPENCODE_API_URL` set accordingly.
+
+Port 4096 is **not** exposed by the bot image; it belongs to the OpenCode server, which runs separately.
+
 ### Available Scripts
 
 | Script                          | Description                          |

--- a/README.md
+++ b/README.md
@@ -477,7 +477,11 @@ All configuration is provided through environment variables in the `.env` file. 
 
 #### Networking Note
 
-The provided `docker-compose.yml` uses `network_mode: host` (Linux only) because OpenCode by default binds to `127.0.0.1:4096` only. This allows the container to reach the OpenCode server on the host without additional configuration. On macOS/Windows, `network_mode: host` is not available; OpenCode must be configured to listen on `0.0.0.0` or a reachable IP, and `OPENCODE_API_URL` set accordingly.
+The provided `docker-compose.yml` uses `network_mode: host` because OpenCode by default binds to `127.0.0.1:4096` only. This allows the container to reach the OpenCode server on the host without additional configuration.
+
+- **Linux**: `network_mode: host` works natively.
+- **macOS/Windows (Docker Desktop 4.34+)**: host networking is supported when enabled in Settings → "Enable host networking".
+- If host networking is not available or not enabled, OpenCode must be configured to listen on `0.0.0.0` or a reachable IP, and `OPENCODE_API_URL` set accordingly.
 
 Port 4096 is **not** exposed by the bot image; it belongs to the OpenCode server, which runs separately.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  opencode-bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: opencode-telegram-bot
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      - NODE_ENV=production
+      - OPENCODE_API_URL=${OPENCODE_API_URL:-http://127.0.0.1:4096}
+      - OPENCODE_TELEGRAM_HOME=/app/data
+    env_file:
+      - .env
+    volumes:
+      - opencode-bot-data:/app/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  opencode-bot-data:


### PR DESCRIPTION
## Description

Adds Docker support for running OpenCode Telegram Bot as a container.

This is submitted separately from #209 as requested.

### What changed

- adds a multi-stage Docker image with application code and production
  dependencies built into the image;
- runs the bot as a non-root user with dumb-init;
- persists runtime state under /app/data;
- adds a Docker Compose configuration;
- keeps OpenCode as an external dependency configured through
  OPENCODE_API_URL;
- adds Docker usage documentation.

### Design notes

- secrets and .env are not copied into the image;
- source code, dist, and node_modules are not bind-mounted from the host;
- no Docker healthcheck is added because the bot does not currently expose
  its own health endpoint;
- port 4096 is not exposed by the bot image because it belongs to the
  OpenCode server.
- **Networking limitation**: The provided `docker-compose.yml` uses
  `network_mode: host` because OpenCode by default binds to
  `127.0.0.1:4096` only. This allows the container to reach the OpenCode
  server on the host without additional configuration.
  - **Linux**: `network_mode: host` works natively.
  - **macOS/Windows (Docker Desktop 4.34+)**: host networking is supported when enabled in Settings → "Enable host networking".
  - If host networking is not available or not enabled, OpenCode must be configured to listen on `0.0.0.0` or a reachable IP, and `OPENCODE_API_URL` set accordingly.

### Validation

- clean Docker build: PASS
- better-sqlite3 loads inside the container: PASS
- Docker Compose config validation: PASS
- lint: PASS
- typecheck: PASS
- build: PASS
- tests: BASELINE_HANG_CONFIRMED (same pre-existing wizard hang on upstream main)