### PR TITLE
feat(bot): multi-operator sessions — N operators × 1 token = N independent session tapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ Configuration can be provided through process environment variables or an `.env`
 | Variable                                   | Description                                                                                                           | Required | Default                  |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | :------: | ------------------------ |
 | `TELEGRAM_BOT_TOKEN`                       | Bot token from @BotFather                                                                                             |   Yes    | —                        |
-| `TELEGRAM_ALLOWED_USER_ID`                 | Your numeric Telegram user ID                                                                                         |   Yes    | —                        |
+| `TELEGRAM_ALLOWED_USER_ID`                 | Your numeric Telegram user ID (also the primary delivery chat)                                                        |   Yes    | —                        |
+| `TELEGRAM_ALLOWED_USER_IDS`                | Comma-separated list of authorized Telegram user IDs; absorbs `TELEGRAM_ALLOWED_USER_ID` (multi-operator sessions)     |    No    | —                        |
 | `TELEGRAM_PROXY_URL`                       | Proxy URL for Telegram API (SOCKS5/HTTP)                                                                              |    No    | —                        |
 | `TELEGRAM_API_ROOT`                        | Custom Telegram Bot API root URL (e.g. nginx reverse-proxying `api.telegram.org`); applied to API calls and file downloads | No | `https://api.telegram.org` |
 | `TELEGRAM_PROXY_SECRET`                    | Shared secret sent as `X-Proxy-Secret` header on every Bot API request and file download (used with `TELEGRAM_API_ROOT`) | No | —                        |
@@ -413,7 +414,9 @@ To pick a model that is neither a favorite nor recent, tap **🗂 Providers** in
 
 ## Security
 
-The bot enforces a strict **user ID whitelist**. Only the Telegram user whose numeric ID matches `TELEGRAM_ALLOWED_USER_ID` can interact with the bot. Messages from any other user are silently ignored and logged as unauthorized access attempts.
+The bot enforces a strict **user ID whitelist**. Only a Telegram user whose numeric ID is listed in `TELEGRAM_ALLOWED_USER_IDS` (comma-separated, e.g. `1234,5678`) or matches the single `TELEGRAM_ALLOWED_USER_ID` can interact with the bot. Messages from any other user are silently ignored and logged as unauthorized access attempts.
+
+With multiple allowed users, each operator gets an **independent session tape** - its own `/new`, context, and notification stream. The first listed user (`TELEGRAM_ALLOWED_USER_ID`) remains the primary chat for scheduled-task notifications and startup messages.
 
 Since the bot runs locally on your machine and connects to your local OpenCode server, there is no external attack surface beyond the Telegram Bot API itself.
 

--- a/src/app/managers/background-session-manager.ts
+++ b/src/app/managers/background-session-manager.ts
@@ -1,5 +1,6 @@
 import type { Event, Message, Session } from "@opencode-ai/sdk/v2";
 import { isScheduledTaskSessionIgnored } from "../services/scheduled-task-session-ignore-service.js";
+import { getSessionChatBinding } from "../stores/settings-store.js";
 import { logger } from "../../utils/logger.js";
 
 export type BackgroundSessionNotificationKind =
@@ -171,6 +172,10 @@ class BackgroundSessionTracker {
   private shouldIgnoreSession(sessionId: string, currentSessionId: string | null): boolean {
     return (
       sessionId === currentSessionId ||
+      // A session bound to any operator's lane is a live lane, never
+      // "background" - otherwise scoped sessions get demoted to notification
+      // cards instead of streaming inline.
+      getSessionChatBinding(sessionId) != null ||
       this.childSessionIds.has(sessionId) ||
       isScheduledTaskSessionIgnored(sessionId)
     );

--- a/src/app/managers/summary-aggregation-manager.ts
+++ b/src/app/managers/summary-aggregation-manager.ts
@@ -591,6 +591,19 @@ class SummaryAggregator {
     return this.isTrackedChildSession(sessionId);
   }
 
+  /**
+   * Public lookup: the tracked parent (root) session of a subagent, or null
+   * when the session is not a tracked child. Used to resolve which operator's
+   * chat owns a subagent's prompts.
+   */
+  getParentSessionId(sessionId: string): string | null {
+    const parentSessionId = this.trackedSessionParents.get(sessionId);
+    if (parentSessionId == null || parentSessionId === sessionId) {
+      return null;
+    }
+    return parentSessionId;
+  }
+
   private getQueue(map: Map<string, string[]>, parentSessionId: string): string[] {
     const existing = map.get(parentSessionId);
     if (existing) {
@@ -1173,7 +1186,6 @@ class SummaryAggregator {
       // (both intermediate and completed). This keeps keyboard context in sync.
       const assistantInfo = info;
 
-
       if (this.onTokensCallback && assistantInfo.tokens) {
         const tokens: TokensInfo = {
           input: assistantInfo.tokens.input,
@@ -1223,13 +1235,12 @@ class SummaryAggregator {
           });
         }
 
-          this.cleanupCompletedMessage(messageID);
+        this.cleanupCompletedMessage(messageID);
 
-          logger.debug(
-            `[Aggregator] Message completed cleanup: remaining messages=${this.textMessageStates.size}`,
-          );
-        }
-
+        logger.debug(
+          `[Aggregator] Message completed cleanup: remaining messages=${this.textMessageStates.size}`,
+        );
+      }
     }
   }
 
@@ -1303,11 +1314,7 @@ class SummaryAggregator {
     }
 
     if (part.type === "reasoning") {
-      this.registerThinkingPart(
-        messageID,
-        part.id,
-        this.extractReasoningTitle(part),
-      );
+      this.registerThinkingPart(messageID, part.id, this.extractReasoningTitle(part));
     }
 
     const deltaFromUpdated = "delta" in event.properties ? event.properties.delta : undefined;
@@ -1503,8 +1510,7 @@ class SummaryAggregator {
     // Same filter as in handleMessagePartUpdated, applied to the streaming path: a delta
     // event often carries only the part id, so the flag is looked up in the registry too.
     const isSynthetic =
-      part?.synthetic === true ||
-      (this.syntheticPartIds.get(messageID)?.has(partID) ?? false);
+      part?.synthetic === true || (this.syntheticPartIds.get(messageID)?.has(partID) ?? false);
     if (isSynthetic) {
       this.registerSyntheticPart(messageID, partID);
       return;
@@ -1705,11 +1711,7 @@ class SummaryAggregator {
       .map((section) => ({ ...section }));
   }
 
-  private emitThinkingUpdate(
-    sessionId: string,
-    messageId: string,
-    isFirstUpdate: boolean,
-  ): void {
+  private emitThinkingUpdate(sessionId: string, messageId: string, isFirstUpdate: boolean): void {
     if (!this.onThinkingCallback) {
       return;
     }
@@ -1742,7 +1744,10 @@ class SummaryAggregator {
   }
 
   private emitExternalUserInputIfReady(sessionId: string, messageId: string): void {
-    if (sessionId !== this.currentSessionId || this.deliveredExternalUserMessageIds.has(messageId)) {
+    if (
+      sessionId !== this.currentSessionId ||
+      this.deliveredExternalUserMessageIds.has(messageId)
+    ) {
       return;
     }
 
@@ -1947,7 +1952,9 @@ class SummaryAggregator {
       const filePathFromTitle = title ? extractFirstUpdatedFileFromTitle(title) : "";
 
       const filePath =
-        (typeof filediff?.file === "string" && filediff.file && normalizePathForDisplay(filediff.file)) ||
+        (typeof filediff?.file === "string" &&
+          filediff.file &&
+          normalizePathForDisplay(filediff.file)) ||
         filePathFromInput ||
         normalizePathForDisplay(filePathFromTitle);
       const diffText =

--- a/src/app/stores/settings-store.ts
+++ b/src/app/stores/settings-store.ts
@@ -59,10 +59,7 @@ async function readSettingsFile(): Promise<Settings> {
     return await readSettingsFileAt(settingsFilePath);
   } catch (primaryError) {
     if (!isFileNotFound(primaryError)) {
-      logger.warn(
-        `[SettingsManager] Cannot read settings file ${settingsFilePath}:`,
-        primaryError,
-      );
+      logger.warn(`[SettingsManager] Cannot read settings file ${settingsFilePath}:`, primaryError);
     }
 
     try {
@@ -174,7 +171,7 @@ export function getCurrentSession(): SessionInfo | undefined {
     // Backward-compat seed: a solo operator adopts the legacy tape on first
     // contact, so upgrading never orphans an existing conversation. With two or
     // more operators nobody inherits anything - clean start per human, by design.
-    if (currentSettings.currentSession && config.telegram.allowedUserIds.length === 1) {
+    if (currentSettings.currentSession && isSoloOperator()) {
       currentSettings.userSessions ??= {};
       currentSettings.userSessions[key] = currentSettings.currentSession;
       void writeSettingsFile(currentSettings);
@@ -187,11 +184,21 @@ export function getCurrentSession(): SessionInfo | undefined {
   return currentSettings.currentSession;
 }
 
+function isSoloOperator(): boolean {
+  return config.telegram.allowedUserIds.length === 1;
+}
+
 export function setCurrentSession(sessionInfo: SessionInfo): void {
   const userId = scopedUserId();
   if (userId != null) {
     currentSettings.userSessions ??= {};
     currentSettings.userSessions[String(userId)] = sessionInfo;
+    // Solo mode has ONE logical tape: mirror onto the legacy pointer so
+    // unscoped readers (boot-time restore) and a restart observe the session
+    // the operator actually selected. Multi-operator keeps the tapes isolated.
+    if (isSoloOperator()) {
+      currentSettings.currentSession = sessionInfo;
+    }
   } else {
     currentSettings.currentSession = sessionInfo;
   }
@@ -203,6 +210,11 @@ export function clearSession(): void {
   if (userId != null) {
     if (currentSettings.userSessions) {
       delete currentSettings.userSessions[String(userId)];
+    }
+    // Solo: drop the legacy pointer too, otherwise the backward-compat seed in
+    // getCurrentSession resurrects the cleared tape on the very next read.
+    if (isSoloOperator()) {
+      currentSettings.currentSession = undefined;
     }
   } else {
     currentSettings.currentSession = undefined;
@@ -424,9 +436,7 @@ function applyInitialSettingsPreset(preset: Record<string, unknown>): void {
     } else {
       // Boolean settings: compactOutputMode, showThinkingContent, showAssistantRunFooter, sendDiffFileAttachments, promptQueueEnabled
       if (typeof value !== "boolean") {
-        throw new Error(
-          `INITIAL_SETTINGS_PRESET: "${key}" must be a boolean.`,
-        );
+        throw new Error(`INITIAL_SETTINGS_PRESET: "${key}" must be a boolean.`);
       }
       switch (key) {
         case "compactOutputMode":

--- a/src/app/stores/settings-store.ts
+++ b/src/app/stores/settings-store.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types/settings.js";
 import { config } from "../../config.js";
 import { getRuntimePaths } from "../../runtime/paths.js";
+import { scopedUserId } from "./user-scope.js";
 import { logger } from "../../utils/logger.js";
 
 function cloneScheduledTasks(tasks: ScheduledTask[] | undefined): ScheduledTask[] | undefined {
@@ -158,18 +159,76 @@ export function clearProject(): void {
   void writeSettingsFile(currentSettings);
 }
 
+// Inside a user scope (Telegram update), sessions resolve per operator via the
+// persisted userSessions map; outside any scope (server event pumps, boot), the
+// legacy single pointer applies unchanged.
 export function getCurrentSession(): SessionInfo | undefined {
+  const userId = scopedUserId();
+  if (userId != null) {
+    const key = String(userId);
+    const scopedSession = currentSettings.userSessions?.[key];
+    if (scopedSession) {
+      return scopedSession;
+    }
+
+    // Backward-compat seed: a solo operator adopts the legacy tape on first
+    // contact, so upgrading never orphans an existing conversation. With two or
+    // more operators nobody inherits anything - clean start per human, by design.
+    if (currentSettings.currentSession && config.telegram.allowedUserIds.length === 1) {
+      currentSettings.userSessions ??= {};
+      currentSettings.userSessions[key] = currentSettings.currentSession;
+      void writeSettingsFile(currentSettings);
+      return currentSettings.currentSession;
+    }
+
+    return undefined;
+  }
+
   return currentSettings.currentSession;
 }
 
 export function setCurrentSession(sessionInfo: SessionInfo): void {
-  currentSettings.currentSession = sessionInfo;
+  const userId = scopedUserId();
+  if (userId != null) {
+    currentSettings.userSessions ??= {};
+    currentSettings.userSessions[String(userId)] = sessionInfo;
+  } else {
+    currentSettings.currentSession = sessionInfo;
+  }
   void writeSettingsFile(currentSettings);
 }
 
 export function clearSession(): void {
-  currentSettings.currentSession = undefined;
+  const userId = scopedUserId();
+  if (userId != null) {
+    if (currentSettings.userSessions) {
+      delete currentSettings.userSessions[String(userId)];
+    }
+  } else {
+    currentSettings.currentSession = undefined;
+  }
   void writeSettingsFile(currentSettings);
+}
+
+// Unscoped accessor for server-event routing: the legacy pointer, whatever the
+// active AsyncLocalStorage scope says.
+export function getRawCurrentSession(): SessionInfo | undefined {
+  return currentSettings.currentSession;
+}
+
+export function getAllUserSessions(): Record<string, SessionInfo> {
+  return currentSettings.userSessions ?? {};
+}
+
+// Which operator's chat receives events for this session? Resolved from the
+// persisted per-user map; null when no operator owns it.
+export function getSessionChatBinding(sessionId: string): number | null {
+  for (const [userId, session] of Object.entries(getAllUserSessions())) {
+    if (session?.id === sessionId) {
+      return Number(userId);
+    }
+  }
+  return null;
 }
 
 export type TtsMode = "off" | "all" | "auto";

--- a/src/app/stores/user-scope.ts
+++ b/src/app/stores/user-scope.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// Per-operator request scope. Set by authMiddleware around every Telegram
+// update; consumed by the settings store so each operator gets an isolated
+// session tape. Server-originated work (event streams, boot) runs outside any
+// scope and falls back to the legacy single-session pointer.
+export interface UserScope {
+  userId: number;
+}
+
+export const userScope = new AsyncLocalStorage<UserScope>();
+
+export function scopedUserId(): number | undefined {
+  return userScope.getStore()?.userId;
+}

--- a/src/app/types/settings.ts
+++ b/src/app/types/settings.ts
@@ -13,6 +13,8 @@ export interface ScheduledTaskSessionIgnoreInfo {
 export interface Settings {
   currentProject?: ProjectInfo | undefined;
   currentSession?: SessionInfo | undefined;
+  // Per-operator session tapes, keyed by the stringified Telegram user id.
+  userSessions?: Record<string, SessionInfo> | undefined;
   currentAgent?: string | undefined;
   currentModel?: ModelInfo | undefined;
   pinnedMessageId?: number | undefined;

--- a/src/bot/callbacks/agent-selection-callback-handler.ts
+++ b/src/bot/callbacks/agent-selection-callback-handler.ts
@@ -1,4 +1,5 @@
 import { Context } from "grammy";
+import { config } from "../../config.js";
 import { selectAgent } from "../../app/services/agent-selection-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
 import { formatVariantForButton } from "../../app/services/variant-selection-service.js";
@@ -31,7 +32,10 @@ export async function handleAgentSelect(ctx: Context): Promise<boolean> {
   logger.debug(`[AgentHandler] Received callback: ${callbackQuery.data}`);
 
   try {
-    if (ctx.chat) {
+    // Single-slot reply keyboard: never re-arm it from one operator's callback
+    // in multi-operator mode (same suppression as /start and /status).
+    const soloOperator = config.telegram.allowedUserIds.length <= 1;
+    if (ctx.chat && soloOperator) {
       keyboardManager.initialize(ctx.api, ctx.chat.id);
     }
 

--- a/src/bot/callbacks/model-selection-callback-handler.ts
+++ b/src/bot/callbacks/model-selection-callback-handler.ts
@@ -1,4 +1,5 @@
 import { Context, InlineKeyboard } from "grammy";
+import { config } from "../../config.js";
 import { getStoredAgent, resolveProjectAgent } from "../../app/services/agent-selection-service.js";
 import {
   fetchCurrentModel,
@@ -290,7 +291,10 @@ async function showProvidersScreen(ctx: Context, page: number): Promise<void> {
  * Used by both the regular inline menu flow and the search results flow.
  */
 async function applyModelSelectionAndNotify(ctx: Context, modelInfo: ModelInfo): Promise<void> {
-  if (ctx.chat) {
+  // Single-slot reply keyboard: never re-arm it from one operator's callback
+  // in multi-operator mode (same suppression as /start and /status).
+  const soloOperator = config.telegram.allowedUserIds.length <= 1;
+  if (ctx.chat && soloOperator) {
     keyboardManager.initialize(ctx.api, ctx.chat.id);
   }
 

--- a/src/bot/callbacks/variant-selection-callback-handler.ts
+++ b/src/bot/callbacks/variant-selection-callback-handler.ts
@@ -1,4 +1,5 @@
 import { Context } from "grammy";
+import { config } from "../../config.js";
 import { getStoredAgent, resolveProjectAgent } from "../../app/services/agent-selection-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
 import {
@@ -34,7 +35,10 @@ export async function handleVariantSelect(ctx: Context): Promise<boolean> {
   logger.debug(`[VariantHandler] Received callback: ${callbackQuery.data}`);
 
   try {
-    if (ctx.chat) {
+    // Single-slot reply keyboard: never re-arm it from one operator's callback
+    // in multi-operator mode (same suppression as /start and /status).
+    const soloOperator = config.telegram.allowedUserIds.length <= 1;
+    if (ctx.chat && soloOperator) {
       keyboardManager.initialize(ctx.api, ctx.chat.id);
     }
 

--- a/src/bot/commands/detach-command.ts
+++ b/src/bot/commands/detach-command.ts
@@ -1,4 +1,5 @@
 import { CommandContext, Context } from "grammy";
+import { config } from "../../config.js";
 import { getCurrentProject } from "../../app/stores/settings-store.js";
 import { clearSession, getCurrentSession } from "../../app/services/session-service.js";
 import { detachAttachedSession } from "../../app/services/attach-service.js";
@@ -40,7 +41,10 @@ export async function detachCommand(ctx: CommandContext<Context>): Promise<void>
       }
     }
 
-    if (ctx.chat) {
+    // Single-slot reply keyboard: never re-arm it from one operator's /detach
+    // in multi-operator mode (same suppression as /start and /status).
+    const soloOperator = config.telegram.allowedUserIds.length <= 1;
+    if (ctx.chat && soloOperator) {
       keyboardManager.initialize(ctx.api, ctx.chat.id);
     }
 

--- a/src/bot/commands/start-command.ts
+++ b/src/bot/commands/start-command.ts
@@ -1,4 +1,5 @@
 import { Context } from "grammy";
+import { config } from "../../config.js";
 import { createMainKeyboard } from "../keyboards/main-reply-keyboard.js";
 import { getStoredAgent } from "../../app/services/agent-selection-service.js";
 import { getStoredModel } from "../../app/services/model-selection-service.js";
@@ -14,7 +15,11 @@ import { assistantRunState } from "../../app/managers/assistant-run-state-manage
 import { detachAttachedSession } from "../../app/services/attach-service.js";
 
 export async function startCommand(ctx: Context): Promise<void> {
-  if (ctx.chat) {
+  // The pinned card + reply keyboard are single-slot globals: in multi-operator
+  // mode they must not re-arm inside whichever operator ran this command first
+  // (attach-presentation suppresses them there for the same reason).
+  const soloOperator = config.telegram.allowedUserIds.length <= 1;
+  if (ctx.chat && soloOperator) {
     if (!pinnedMessageManager.isInitialized()) {
       pinnedMessageManager.initialize(ctx.api, ctx.chat.id);
     }

--- a/src/bot/commands/status-command.ts
+++ b/src/bot/commands/status-command.ts
@@ -1,4 +1,5 @@
 import { CommandContext, Context } from "grammy";
+import { config } from "../../config.js";
 import { opencodeClient } from "../../opencode/client.js";
 import { getGitWorktreeContext } from "../../app/services/worktree-service.js";
 import { getCurrentSession } from "../../app/services/session-service.js";
@@ -86,14 +87,19 @@ export async function statusCommand(ctx: CommandContext<Context>) {
     }
 
     if (ctx.chat) {
-      if (!pinnedMessageManager.isInitialized()) {
+      // Single-slot pinned card: never arm it from one operator's /status in
+      // multi-operator mode (same suppression as attach-presentation).
+      const soloOperator = config.telegram.allowedUserIds.length <= 1;
+      if (soloOperator && !pinnedMessageManager.isInitialized()) {
         pinnedMessageManager.initialize(ctx.api, ctx.chat.id);
       }
       // Fetch context limit if not yet loaded (e.g. fresh bot start)
       if (pinnedMessageManager.getContextLimit() === 0) {
         await pinnedMessageManager.refreshContextLimit();
       }
-      keyboardManager.initialize(ctx.api, ctx.chat.id);
+      if (soloOperator) {
+        keyboardManager.initialize(ctx.api, ctx.chat.id);
+      }
     }
     // Sync current context (tokens used + limit) into keyboard state
     const contextInfo = pinnedMessageManager.getContextInfo();

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,6 +1,10 @@
 import { Bot, Context } from "grammy";
 import { config } from "../config.js";
-import { getCurrentProject } from "../app/stores/settings-store.js";
+import {
+  getCurrentProject,
+  getRawCurrentSession,
+  getSessionChatBinding,
+} from "../app/stores/settings-store.js";
 import { attachManager } from "../app/managers/attach-manager.js";
 import { clearAllInteractionState } from "../app/managers/interaction-manager.js";
 import {
@@ -16,10 +20,7 @@ import { initializePromptQueueDispatch } from "./handlers/prompt-queue-dispatch.
 import { authMiddleware } from "./middleware/auth.js";
 import { interactionGuardMiddleware } from "./middleware/interaction-guard.js";
 import { staleUpdateMiddleware } from "./middleware/stale-update.js";
-import {
-  ensureCommandsInitialized,
-  registerCommandRouter,
-} from "./routers/command-router.js";
+import { ensureCommandsInitialized, registerCommandRouter } from "./routers/command-router.js";
 import { registerMessageRouter } from "./routers/message-router.js";
 import {
   createEventSubscriptionService,
@@ -93,12 +94,32 @@ export function createBot(): Bot<Context> {
 
   unsubscribeReadyRestore?.();
   unsubscribeReadyRestore = opencodeReadyLifecycle.onReady(async (reason) => {
-    const restored = await restoreAttachedCurrentSession({
-      bot,
-      chatId: config.telegram.allowedUserId,
-      ensureEventSubscription: eventSubscriptionService.ensureEventSubscription,
-      forceFullRestore: true,
-    });
+    // Multi-operator: the legacy pointer predates per-operator ownership, so a
+    // session no operator is bound to must never auto-attach into the primary
+    // chat - that would stream a stale conversation to whichever human happens
+    // to be primary. A session some operator still owns restores into ITS
+    // operator's chat; solo mode keeps the upstream restore untouched.
+    const legacySession = getRawCurrentSession();
+    const restoreChatId =
+      config.telegram.allowedUserIds.length > 1 && legacySession
+        ? getSessionChatBinding(legacySession.id)
+        : config.telegram.allowedUserId;
+
+    if (legacySession && restoreChatId == null) {
+      logger.info(
+        `[Bot] Skipping unbound legacy session restore in multi-operator mode: session=${legacySession.id}, reason=${reason}`,
+      );
+    }
+
+    const restored =
+      restoreChatId != null
+        ? await restoreAttachedCurrentSession({
+            bot,
+            chatId: restoreChatId,
+            ensureEventSubscription: eventSubscriptionService.ensureEventSubscription,
+            forceFullRestore: true,
+          })
+        : false;
 
     if (restored) {
       logger.info(`[Bot] Restored followed session after OpenCode ready: reason=${reason}`);
@@ -137,22 +158,25 @@ export function createBot(): Bot<Context> {
     }
 
     try {
-      return await withTelegramRateLimitRetry(async () => {
-        const response = await prev(method, payload, signal);
-        if (isTelegramApiErrorResponse(response)) {
-          throw new TelegramApiResponseError(response);
-        }
-        return response;
-      }, {
-        maxRetries: 5,
-        retryTransientServerErrors: shouldRetryTelegramServerError(method),
-        onRetry: ({ attempt, retryAfterMs, error }) => {
-          logger.warn(
-            `[Bot API] Retryable Telegram error on ${method}, retrying in ${retryAfterMs}ms (attempt=${attempt})`,
-            error,
-          );
+      return await withTelegramRateLimitRetry(
+        async () => {
+          const response = await prev(method, payload, signal);
+          if (isTelegramApiErrorResponse(response)) {
+            throw new TelegramApiResponseError(response);
+          }
+          return response;
         },
-      });
+        {
+          maxRetries: 5,
+          retryTransientServerErrors: shouldRetryTelegramServerError(method),
+          onRetry: ({ attempt, retryAfterMs, error }) => {
+            logger.warn(
+              `[Bot API] Retryable Telegram error on ${method}, retrying in ${retryAfterMs}ms (attempt=${attempt})`,
+              error,
+            );
+          },
+        },
+      );
     } catch (error) {
       if (error instanceof TelegramApiResponseError) {
         return error.response;

--- a/src/bot/middleware/auth.ts
+++ b/src/bot/middleware/auth.ts
@@ -1,25 +1,31 @@
 import { Context, NextFunction } from "grammy";
 import { config } from "../../config.js";
 import { logger } from "../../utils/logger.js";
+import { userScope } from "../../app/stores/user-scope.js";
+
+// Multi-operator allowlist: allowedUserIds absorbs the legacy single-user
+// variable, so single-operator deployments behave exactly as before.
+const isAllowed = (userId: number): boolean => config.telegram.allowedUserIds.includes(userId);
 
 export async function authMiddleware(ctx: Context, next: NextFunction): Promise<void> {
   const userId = ctx.from?.id;
 
   logger.debug(
-    `[Auth] Checking access: userId=${userId}, allowedUserId=${config.telegram.allowedUserId}, hasCallbackQuery=${!!ctx.callbackQuery}, hasMessage=${!!ctx.message}`,
+    `[Auth] Checking access: userId=${userId}, allowedUsers=${config.telegram.allowedUserIds.join(",")}, hasCallbackQuery=${!!ctx.callbackQuery}, hasMessage=${!!ctx.message}`,
   );
 
-  if (userId && userId === config.telegram.allowedUserId) {
+  if (userId && isAllowed(userId)) {
     logger.debug(`[Auth] Access granted for userId=${userId}`);
-    await next();
+    // Tag every update with its sender so session state resolves per operator.
+    await userScope.run({ userId }, next);
   } else {
     // Silently ignore unauthorized users
     logger.warn(`Unauthorized access attempt from user ID: ${userId}`);
 
     // Actively hide commands for unauthorized users by setting empty command list
-    // Only do this if the chat is NOT the authorized user's chat
+    // Only do this if the chat is NOT an authorized user's chat
     // (to avoid resetting commands when forwarded messages are received)
-    if (ctx.chat?.id && ctx.chat.id !== config.telegram.allowedUserId) {
+    if (ctx.chat?.id && !isAllowed(ctx.chat.id)) {
       try {
         // Set empty commands for this specific chat (more reliable than deleteMyCommands)
         await ctx.api.setMyCommands([], {

--- a/src/bot/routers/command-router.ts
+++ b/src/bot/routers/command-router.ts
@@ -33,7 +33,7 @@ interface CommandRouterDeps {
 let commandsInitialized = false;
 
 export async function ensureCommandsInitialized(ctx: Context, next: NextFunction): Promise<void> {
-  if (commandsInitialized || !ctx.from || ctx.from.id !== config.telegram.allowedUserId) {
+  if (commandsInitialized || !ctx.from || !config.telegram.allowedUserIds.includes(ctx.from.id)) {
     await next();
     return;
   }

--- a/src/bot/services/attach-presentation.ts
+++ b/src/bot/services/attach-presentation.ts
@@ -6,15 +6,17 @@ import { showCurrentQuestion } from "../menus/question-menu.js";
 import { pinnedMessageManager } from "../pinned/pinned-message-manager.js";
 
 export function createAttachPresentation(): AttachPresentationDeps {
+  // The pinned status card and the reply keyboard are single-slot legacy
+  // affordances: with multiple operators they would pin into ONE human's chat
+  // (whichever operator initialized them first - /start and /status arm them
+  // directly) and every operator's activity would tick there. Multi-operator
+  // mode therefore never uses them, regardless of initialization state; each
+  // bound chat gets its own streamers instead.
+  const isMultiOperator = config.telegram.allowedUserIds.length > 1;
+
   return {
     async ensurePinnedSession({ api, chatId, session, forceFullRestore = false }) {
-      // The pinned status card is a single-slot legacy affordance: with multiple
-      // operators it would pin into ONE human's chat and every operator's
-      // activity would tick there - misrouting by construction. Multi-operator
-      // mode therefore never starts the global pin pump; each bound chat gets
-      // its own streamers instead.
-      const multiOperator = config.telegram.allowedUserIds.length > 1;
-      if (multiOperator && !pinnedMessageManager.isInitialized()) {
+      if (isMultiOperator) {
         return;
       }
 
@@ -46,7 +48,7 @@ export function createAttachPresentation(): AttachPresentationDeps {
       }
     },
     async syncAttachState(attached, busy) {
-      if (!pinnedMessageManager.isInitialized()) {
+      if (isMultiOperator || !pinnedMessageManager.isInitialized()) {
         return;
       }
 

--- a/src/bot/services/attach-presentation.ts
+++ b/src/bot/services/attach-presentation.ts
@@ -1,5 +1,6 @@
 import type { AttachPresentationDeps } from "../../app/services/attach-service.js";
 import { keyboardManager } from "../keyboards/keyboard-manager.js";
+import { config } from "../../config.js";
 import { showPermissionRequest } from "../menus/permission-menu.js";
 import { showCurrentQuestion } from "../menus/question-menu.js";
 import { pinnedMessageManager } from "../pinned/pinned-message-manager.js";
@@ -7,6 +8,16 @@ import { pinnedMessageManager } from "../pinned/pinned-message-manager.js";
 export function createAttachPresentation(): AttachPresentationDeps {
   return {
     async ensurePinnedSession({ api, chatId, session, forceFullRestore = false }) {
+      // The pinned status card is a single-slot legacy affordance: with multiple
+      // operators it would pin into ONE human's chat and every operator's
+      // activity would tick there - misrouting by construction. Multi-operator
+      // mode therefore never starts the global pin pump; each bound chat gets
+      // its own streamers instead.
+      const multiOperator = config.telegram.allowedUserIds.length > 1;
+      if (multiOperator && !pinnedMessageManager.isInitialized()) {
+        return;
+      }
+
       if (!pinnedMessageManager.isInitialized()) {
         pinnedMessageManager.initialize(api, chatId);
       }

--- a/src/bot/services/event-subscription-service.ts
+++ b/src/bot/services/event-subscription-service.ts
@@ -9,7 +9,10 @@ import {
   type SubagentInfo,
   type ToolInfo,
 } from "../../app/managers/summary-aggregation-manager.js";
-import { formatCompactToolActivity, formatToolInfo } from "../../app/formatters/summary-formatter.js";
+import {
+  formatCompactToolActivity,
+  formatToolInfo,
+} from "../../app/formatters/summary-formatter.js";
 import { renderSubagentCards } from "../../app/formatters/subagent-formatter.js";
 import {
   RUNNING_ICON,
@@ -62,10 +65,7 @@ import { ResponseStreamer, type StreamingMessagePayload } from "../streaming/res
 import { ToolCallStreamer, type ToolStreamKey } from "../streaming/tool-call-streamer.js";
 import { RunningToolTracker, type RunningToolTick } from "../streaming/running-tool-tracker.js";
 import { CompactProgressStreamer } from "../streaming/compact-progress-streamer.js";
-import {
-  getSessionStreamThrottleMs,
-  resetStreamThrottle,
-} from "../streaming/stream-throttle.js";
+import { getSessionStreamThrottleMs, resetStreamThrottle } from "../streaming/stream-throttle.js";
 import { attachManager } from "../../app/managers/attach-manager.js";
 import {
   markAttachedSessionBusy,
@@ -77,10 +77,7 @@ import {
   prepareAssistantStreamingPayload,
   renderAssistantFinalPartsSafe,
 } from "../messages/assistant-rendering.js";
-import {
-  prepareThinkingPayload,
-  type ThinkingSection,
-} from "../messages/thinking-rendering.js";
+import { prepareThinkingPayload, type ThinkingSection } from "../messages/thinking-rendering.js";
 import { deliverExternalUserInputNotification } from "../messages/external-user-input-notification.js";
 import { dispatchNextQueuedPrompt } from "../handlers/prompt-queue-dispatch.js";
 import {
@@ -150,6 +147,9 @@ class EventSubscriptionService implements BotEventSubscriptionService {
     { callId: string; activity: string }
   >();
   private readonly subagentSnapshots = new Map<string, SubagentInfo[]>();
+  // Where the currently visible question poll lives - question lifecycle
+  // callbacks carry no chat context, so remember it at display time.
+  private activePromptChatId: number | null = null;
 
   constructor() {
     this.runningToolTracker = new RunningToolTracker({
@@ -202,15 +202,11 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
           const keyboard = this.getCurrentReplyKeyboard();
 
-          await this.botInstance.api.sendDocument(
-            targetChatId,
-            new InputFile(tempFilePath),
-            {
-              caption: fileData.caption,
-              disable_notification: true,
-              ...(keyboard ? { reply_markup: keyboard } : {}),
-            },
-          );
+          await this.botInstance.api.sendDocument(targetChatId, new InputFile(tempFilePath), {
+            caption: fileData.caption,
+            disable_notification: true,
+            ...(keyboard ? { reply_markup: keyboard } : {}),
+          });
         } finally {
           await fs.unlink(tempFilePath).catch(() => {});
         }
@@ -361,11 +357,18 @@ class EventSubscriptionService implements BotEventSubscriptionService {
   }
 
   // Which chat should receive events for this session? Prefer the operator
-  // bound via userSessions; fall back to the legacy followed session.
+  // bound via userSessions; fall back to the legacy followed session. Subagent
+  // sessions are never bound themselves - they inherit the operator who owns
+  // their root conversation, so prompts surface in the right human's chat.
   private chatIdForSession(sessionId: string): number | null {
     const bound = getSessionChatBinding(sessionId);
     if (bound != null && Number.isFinite(bound)) {
       return bound;
+    }
+
+    const parentSessionId = summaryAggregator.getParentSessionId(sessionId);
+    if (parentSessionId != null) {
+      return this.chatIdForSession(parentSessionId);
     }
 
     const rawCurrent = getRawCurrentSession();
@@ -619,7 +622,10 @@ class EventSubscriptionService implements BotEventSubscriptionService {
             this.enqueueAssistantResponse(sessionId, messageId, preparedStreamPayload);
           })
           .catch((error) => {
-            logger.error("[Bot] Failed to finalize compact progress before assistant stream", error);
+            logger.error(
+              "[Bot] Failed to finalize compact progress before assistant stream",
+              error,
+            );
           });
         return;
       }
@@ -706,8 +712,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
             prepareStreamingPayload: this.prepareFinalStreamingPayload,
             renderFinalParts: (text) => renderAssistantFinalPartsSafe(text),
             getReplyKeyboard: this.getCurrentReplyKeyboard,
-            notifyFirstFinalPart:
-              assistantResponseMode === "draft" && !getShowAssistantRunFooter(),
+            notifyFirstFinalPart: assistantResponseMode === "draft" && !getShowAssistantRunFooter(),
             sendRenderedPart: async (part, options) => {
               await sendRenderedBotPart({
                 api: botApi,
@@ -757,8 +762,9 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           await deliverExternalUserInputNotification({
             api: this.botInstance.api,
             chatId: notificationChatId,
-            currentSessionId:
-              this.ownsSession(sessionId) ? sessionId : (getCurrentSession()?.id ?? null),
+            currentSessionId: this.ownsSession(sessionId)
+              ? sessionId
+              : (getCurrentSession()?.id ?? null),
             sessionId,
             text: messageText,
             consumeSuppressedInput: (incomingSessionId, incomingText) =>
@@ -963,32 +969,41 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         logger.warn("[Bot] Replacing active poll with a new one");
 
         const previousMessageIds = questionManager.getMessageIds();
-        const pollChatId = this.sendTarget(targetChatId);
+        // Delete the OLD poll from the chat where it was actually shown.
+        const previousPollChatId = this.activePromptChatId ?? this.sendTarget(targetChatId);
         for (const messageId of previousMessageIds) {
-          if (pollChatId != null) {
-            await this.botInstance.api.deleteMessage(pollChatId, messageId).catch(() => {});
+          if (previousPollChatId != null) {
+            await this.botInstance.api.deleteMessage(previousPollChatId, messageId).catch(() => {});
           }
         }
 
         clearAllInteractionState("question_replaced_by_new_poll");
       }
 
-      logger.info(`[Bot] Received ${questions.length} questions from agent, requestID=${requestID}`);
+      logger.info(
+        `[Bot] Received ${questions.length} questions from agent, requestID=${requestID}`,
+      );
       questionManager.startQuestions(questions, requestID);
-      await showCurrentQuestion(this.botInstance.api, this.chatIdInstance);
+      // Render the poll where the asking session's operator lives - never
+      // unconditionally in the primary chat.
+      this.activePromptChatId = targetChatId;
+      await showCurrentQuestion(this.botInstance.api, targetChatId);
     });
 
     summaryAggregator.setOnQuestionError(async () => {
       logger.info("[Bot] Question tool failed, clearing active poll and deleting messages");
 
       const messageIds = questionManager.getMessageIds();
+      const pollChatId =
+        this.activePromptChatId ?? (this.isSoloOperator() ? this.chatIdInstance : null);
       for (const messageId of messageIds) {
-        if (this.chatIdInstance) {
-          await this.botInstance?.api.deleteMessage(this.chatIdInstance, messageId).catch((err) => {
+        if (pollChatId != null) {
+          await this.botInstance?.api.deleteMessage(pollChatId, messageId).catch((err) => {
             logger.error(`[Bot] Failed to delete question message ${messageId}:`, err);
           });
         }
       }
+      this.activePromptChatId = null;
 
       clearAllInteractionState("question_error");
     });
@@ -1019,12 +1034,19 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       logger.info(
         `[Bot] Received permission request from agent: type=${request.permission}, requestID=${request.id}, subagent=${isSubagent}`,
       );
-      await showPermissionRequest(
-        this.botInstance.api,
-        this.chatIdForSession(request.sessionID) ?? this.chatIdInstance,
-        request,
-        generation,
-      );
+
+      const targetChatId = this.sendTarget(this.chatIdForSession(request.sessionID));
+      if (targetChatId == null) {
+        // Multi-operator fail-closed: nobody owns this conversation, so showing
+        // the approval surface in the primary chat would let one operator
+        // approve another operator's work.
+        logger.warn(
+          `[Bot] Dropping permission request with no owning chat: type=${request.permission}, requestID=${request.id}`,
+        );
+        return;
+      }
+
+      await showPermissionRequest(this.botInstance.api, targetChatId, request, generation);
     });
 
     summaryAggregator.setOnPermissionReplied(async (sessionId, requestID) => {
@@ -1036,7 +1058,10 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
       if (this.botInstance && this.chatIdInstance) {
         const api = this.botInstance.api;
-        const chatId = this.chatIdForSession(sessionId) ?? this.chatIdInstance;
+        const chatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (chatId == null) {
+          return;
+        }
         await Promise.all(
           messageIds.map((messageId) =>
             api.deleteMessage(chatId, messageId).catch((err) => {
@@ -1080,9 +1105,11 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
       if (update.isFirstUpdate) {
         this.clearToolElapsedState(update.sessionId, "thinking_started");
-        void this.toolCallStreamer.breakSession(update.sessionId, "thinking_started").catch((error) => {
-          logger.error("[Bot] Failed to break tool stream before thinking message", error);
-        });
+        void this.toolCallStreamer
+          .breakSession(update.sessionId, "thinking_started")
+          .catch((error) => {
+            logger.error("[Bot] Failed to break tool stream before thinking message", error);
+          });
       }
 
       if (getShowThinkingContent()) {
@@ -1433,10 +1460,14 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       : this.assistantEditResponseStreamer;
   }
 
-  private getAssistantResponseStreamMode(sessionId: string, messageId: string): ResponseStreamingMode {
+  private getAssistantResponseStreamMode(
+    sessionId: string,
+    messageId: string,
+  ): ResponseStreamingMode {
     return (
-      this.assistantResponseStreamModes.get(this.getAssistantResponseStreamKey(sessionId, messageId)) ??
-      getResponseStreamingMode()
+      this.assistantResponseStreamModes.get(
+        this.getAssistantResponseStreamKey(sessionId, messageId),
+      ) ?? getResponseStreamingMode()
     );
   }
 
@@ -1611,6 +1642,12 @@ class EventSubscriptionService implements BotEventSubscriptionService {
   }
 
   private getCurrentReplyKeyboard = () => {
+    // The reply keyboard is a single-slot global: in multi-operator mode its
+    // markup must never ride on messages streamed into another operator's chat.
+    if (config.telegram.allowedUserIds.length > 1) {
+      return undefined;
+    }
+
     if (!keyboardManager.isInitialized()) {
       return undefined;
     }
@@ -1648,7 +1685,11 @@ class EventSubscriptionService implements BotEventSubscriptionService {
   }
 
   private clearThinkingStream(sessionId: string, messageId: string, reason: string): void {
-    this.thinkingResponseStreamer.clearMessage(sessionId, this.getThinkingStreamId(messageId), reason);
+    this.thinkingResponseStreamer.clearMessage(
+      sessionId,
+      this.getThinkingStreamId(messageId),
+      reason,
+    );
     this.thinkingSections.delete(this.getThinkingPayloadKey(sessionId, messageId));
   }
 
@@ -1688,7 +1729,10 @@ class EventSubscriptionService implements BotEventSubscriptionService {
     }
   }
 
-  private enqueueSessionCompletionTask(sessionId: string, task: () => Promise<void>): Promise<void> {
+  private enqueueSessionCompletionTask(
+    sessionId: string,
+    task: () => Promise<void>,
+  ): Promise<void> {
     const previousTask = this.sessionCompletionTasks.get(sessionId) ?? Promise.resolve();
     const nextTask = previousTask
       .catch(() => undefined)

--- a/src/bot/services/event-subscription-service.ts
+++ b/src/bot/services/event-subscription-service.ts
@@ -1322,7 +1322,9 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
       await this.botInstance.api
         .sendMessage(
-          this.chatIdForSession(sessionId) ?? this.chatIdInstance,
+          // targetChatId was resolved and null-checked above; no primary
+          // fallback may hide here.
+          targetChatId,
           t("bot.session_error", { message: truncatedMessage }),
         )
         .catch((err) => {
@@ -1816,13 +1818,21 @@ class EventSubscriptionService implements BotEventSubscriptionService {
   private deliverBackgroundSessionNotification = async (
     notification: BackgroundSessionNotification,
   ): Promise<void> => {
-    if (!this.botInstance || !this.chatIdInstance) {
+    if (!this.botInstance) {
       return;
     }
 
-    // Background prompts (permissions/questions) belong to a specific operator's
-    // session - notify the bound chat, falling back to the primary.
-    const chatId = this.chatIdForSession(notification.sessionId) ?? this.chatIdInstance;
+    // Background notifications belong to a specific operator's session -
+    // resolve the bound chat first. Solo keeps the legacy primary-chat target;
+    // multi-operator drops unresolvable sessions instead of misrouting them to
+    // the primary chat (fail-closed, same as every other session-routed send).
+    const chatId = this.sendTarget(this.chatIdForSession(notification.sessionId));
+    if (chatId == null) {
+      logger.debug(
+        `[Bot] Dropping background ${notification.kind} notification for unbound session ${notification.sessionId}`,
+      );
+      return;
+    }
 
     await this.botInstance.api.sendMessage(
       chatId,

--- a/src/bot/services/event-subscription-service.ts
+++ b/src/bot/services/event-subscription-service.ts
@@ -25,6 +25,9 @@ import {
   getSendDiffFileAttachments,
   getShowAssistantRunFooter,
   getShowThinkingContent,
+  getAllUserSessions,
+  getSessionChatBinding,
+  getRawCurrentSession,
   type ResponseStreamingMode,
 } from "../../app/stores/settings-store.js";
 import { getCurrentSession } from "../../app/services/session-service.js";
@@ -165,14 +168,14 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           return;
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
           return;
         }
 
         const keyboard = this.getCurrentReplyKeyboard();
 
-        await this.botInstance.api.sendMessage(this.chatIdInstance, text, {
+        await this.botInstance.api.sendMessage(targetChatId, text, {
           disable_notification: true,
           ...(keyboard ? { reply_markup: keyboard } : {}),
         });
@@ -182,8 +185,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           return;
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
           return;
         }
 
@@ -200,7 +203,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           const keyboard = this.getCurrentReplyKeyboard();
 
           await this.botInstance.api.sendDocument(
-            this.chatIdInstance,
+            targetChatId,
             new InputFile(tempFilePath),
             {
               caption: fileData.caption,
@@ -225,16 +228,22 @@ class EventSubscriptionService implements BotEventSubscriptionService {
     this.compactProgressStreamer = new CompactProgressStreamer({
       throttleMs: getSessionStreamThrottleMs,
       sendText: async (sessionId, text) => {
-        if (!this.botInstance || !this.chatIdInstance || this.chatIdInstance <= 0) {
+        // Multi-operator mode routes by session binding, so the primary chat id
+        // is not required here - solo mode keeps the legacy requirement.
+        if (!this.botInstance || (!this.chatIdInstance && this.isSoloOperator())) {
           throw new Error("Bot context missing for compact progress send");
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        if (!this.ownsSession(sessionId)) {
           throw new Error(`Compact progress session mismatch for send: ${sessionId}`);
         }
 
-        const sentMessage = await this.botInstance.api.sendMessage(this.chatIdInstance, text, {
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
+          throw new Error(`Compact progress delivery target missing for send: ${sessionId}`);
+        }
+
+        const sentMessage = await this.botInstance.api.sendMessage(targetChatId, text, {
           disable_notification: true,
         });
 
@@ -245,13 +254,17 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           throw new Error("Bot context missing for compact progress edit");
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        if (!this.ownsSession(sessionId)) {
           throw new Error(`Compact progress session mismatch for edit: ${sessionId}`);
         }
 
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
+          throw new Error(`Compact progress delivery target missing for edit: ${sessionId}`);
+        }
+
         try {
-          await this.botInstance.api.editMessageText(this.chatIdInstance, messageId, text);
+          await this.botInstance.api.editMessageText(targetChatId, messageId, text);
         } catch (error) {
           const errorMessage =
             error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
@@ -271,12 +284,16 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           throw new Error("Bot context missing for tool stream send");
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        if (!this.ownsSession(sessionId)) {
           throw new Error(`Tool stream session mismatch for send: ${sessionId}`);
         }
 
-        const sentMessage = await this.botInstance.api.sendMessage(this.chatIdInstance, text, {
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
+          throw new Error(`Tool stream delivery target missing for send: ${sessionId}`);
+        }
+
+        const sentMessage = await this.botInstance.api.sendMessage(targetChatId, text, {
           disable_notification: true,
         });
 
@@ -287,13 +304,17 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           throw new Error("Bot context missing for tool stream edit");
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        if (!this.ownsSession(sessionId)) {
           throw new Error(`Tool stream session mismatch for edit: ${sessionId}`);
         }
 
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
+          throw new Error(`Tool stream delivery target missing for edit: ${sessionId}`);
+        }
+
         try {
-          await this.botInstance.api.editMessageText(this.chatIdInstance, messageId, text);
+          await this.botInstance.api.editMessageText(targetChatId, messageId, text);
         } catch (error) {
           const errorMessage =
             error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
@@ -309,12 +330,16 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           throw new Error("Bot context missing for tool stream delete");
         }
 
-        const currentSession = getCurrentSession();
-        if (!currentSession || currentSession.id !== sessionId) {
+        if (!this.ownsSession(sessionId)) {
           throw new Error(`Tool stream session mismatch for delete: ${sessionId}`);
         }
 
-        await this.botInstance.api.deleteMessage(this.chatIdInstance, messageId).catch((error) => {
+        const targetChatId = this.sendTarget(this.chatIdForSession(sessionId));
+        if (targetChatId == null) {
+          throw new Error(`Tool stream delivery target missing for delete: ${sessionId}`);
+        }
+
+        await this.botInstance.api.deleteMessage(targetChatId, messageId).catch((error) => {
           const errorMessage =
             error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
           if (
@@ -335,13 +360,54 @@ class EventSubscriptionService implements BotEventSubscriptionService {
     this.chatIdInstance = chatId;
   }
 
+  // Which chat should receive events for this session? Prefer the operator
+  // bound via userSessions; fall back to the legacy followed session.
+  private chatIdForSession(sessionId: string): number | null {
+    const bound = getSessionChatBinding(sessionId);
+    if (bound != null && Number.isFinite(bound)) {
+      return bound;
+    }
+
+    const rawCurrent = getRawCurrentSession();
+    if (rawCurrent?.id === sessionId) {
+      return this.chatIdInstance;
+    }
+
+    return null;
+  }
+
+  private ownsSession(sessionId: string): boolean {
+    if (getSessionChatBinding(sessionId) != null) {
+      return true;
+    }
+    const rawCurrent = getRawCurrentSession();
+    return rawCurrent != null && rawCurrent.id === sessionId;
+  }
+
+  // Never misroute to a default chat in multi-operator mode: solo operators
+  // keep the legacy default, multi-user deployments drop unbound events.
+  private sendTarget(chatId: number | null): number | null {
+    if (chatId != null && Number.isFinite(chatId)) {
+      return chatId;
+    }
+
+    if (config.telegram.allowedUserIds.length <= 1) {
+      return this.chatIdInstance;
+    }
+
+    return null;
+  }
+
+  private isSoloOperator(): boolean {
+    return config.telegram.allowedUserIds.length <= 1;
+  }
+
   private getLiveToolPrefix(callId: string): string {
     return `${RUNNING_ICON}${callId}`;
   }
 
   private handleRunningToolTick(tick: RunningToolTick): void {
-    const currentSession = getCurrentSession();
-    if (!currentSession || currentSession.id !== tick.sessionId) {
+    if (!this.ownsSession(tick.sessionId)) {
       return;
     }
 
@@ -414,8 +480,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       return;
     }
 
-    const currentSession = getCurrentSession();
-    if (!currentSession || currentSession.id !== sessionId) {
+    if (this.chatIdForSession(sessionId) == null) {
       return;
     }
 
@@ -531,16 +596,15 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         return;
       }
 
       if (isCompactProgressMode()) {
         void this.finalizeCompactProgress(sessionId)
           .then(() => {
-            const activeSession = getCurrentSession();
-            if (!activeSession || activeSession.id !== sessionId) {
+            if (!this.ownsSession(sessionId)) {
               return;
             }
 
@@ -586,8 +650,9 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           return;
         }
 
-        const currentSession = getCurrentSession();
-        if (currentSession?.id !== sessionId) {
+        const boundChatId = this.chatIdForSession(sessionId);
+        const chatId = boundChatId != null ? this.sendTarget(boundChatId) : null;
+        if (chatId == null) {
           clearPromptResponseMode(sessionId);
           this.clearAssistantResponseStream(sessionId, messageId, "session_mismatch");
           this.clearThinkingStream(sessionId, messageId, "session_mismatch");
@@ -601,7 +666,6 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         }
 
         const botApi = this.botInstance.api;
-        const chatId = this.chatIdInstance;
 
         try {
           assistantRunState.markResponseCompleted(sessionId, {
@@ -677,15 +741,24 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
     summaryAggregator.setOnExternalUserInput(async (sessionId, _messageId, messageText) => {
       void this.enqueueSessionCompletionTask(sessionId, async () => {
-        if (!this.botInstance || !this.chatIdInstance) {
+        if (!this.botInstance) {
+          return;
+        }
+
+        // Route external-input notices to the session's bound chat; the legacy
+        // primary chat only for solo operators (fail-closed in multi-op).
+        const notificationChatId =
+          this.chatIdForSession(sessionId) ?? (this.isSoloOperator() ? this.chatIdInstance : null);
+        if (notificationChatId == null) {
           return;
         }
 
         try {
           await deliverExternalUserInputNotification({
             api: this.botInstance.api,
-            chatId: this.chatIdInstance,
-            currentSessionId: getCurrentSession()?.id ?? null,
+            chatId: notificationChatId,
+            currentSessionId:
+              this.ownsSession(sessionId) ? sessionId : (getCurrentSession()?.id ?? null),
             sessionId,
             text: messageText,
             consumeSuppressedInput: (incomingSessionId, incomingText) =>
@@ -698,8 +771,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
     });
 
     summaryAggregator.setOnRootToolUpdate((toolInfo) => {
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== toolInfo.sessionId) {
+      if (!this.ownsSession(toolInfo.sessionId)) {
         return;
       }
 
@@ -766,8 +838,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== toolInfo.sessionId) {
+      if (!this.ownsSession(toolInfo.sessionId)) {
         return;
       }
 
@@ -807,8 +878,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         return;
       }
 
@@ -838,8 +909,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== fileInfo.sessionId) {
+      if (!this.ownsSession(fileInfo.sessionId)) {
         return;
       }
 
@@ -875,8 +945,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         return;
       }
 
@@ -885,16 +955,19 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       }
 
       await Promise.all([
-        this.toolMessageBatcher.flushSession(currentSession.id, "question_asked"),
-        this.toolCallStreamer.flushSession(currentSession.id, "question_asked"),
+        this.toolMessageBatcher.flushSession(sessionId, "question_asked"),
+        this.toolCallStreamer.flushSession(sessionId, "question_asked"),
       ]);
 
       if (questionManager.isActive()) {
         logger.warn("[Bot] Replacing active poll with a new one");
 
         const previousMessageIds = questionManager.getMessageIds();
+        const pollChatId = this.sendTarget(targetChatId);
         for (const messageId of previousMessageIds) {
-          await this.botInstance.api.deleteMessage(this.chatIdInstance, messageId).catch(() => {});
+          if (pollChatId != null) {
+            await this.botInstance.api.deleteMessage(pollChatId, messageId).catch(() => {});
+          }
         }
 
         clearAllInteractionState("question_replaced_by_new_poll");
@@ -928,15 +1001,14 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      const isCurrent = currentSession?.id === request.sessionID;
+      const isCurrent = this.ownsSession(request.sessionID);
       const isSubagent = summaryAggregator.isSubagentSession(request.sessionID);
-      if (!currentSession || (!isCurrent && !isSubagent)) {
+      if (!isCurrent && !isSubagent) {
         return;
       }
 
       if (isCompactProgressMode()) {
-        this.compactProgressStreamer.updateWaitingForPermission(currentSession.id);
+        this.compactProgressStreamer.updateWaitingForPermission(request.sessionID);
       }
 
       await Promise.all([
@@ -947,10 +1019,15 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       logger.info(
         `[Bot] Received permission request from agent: type=${request.permission}, requestID=${request.id}, subagent=${isSubagent}`,
       );
-      await showPermissionRequest(this.botInstance.api, this.chatIdInstance, request, generation);
+      await showPermissionRequest(
+        this.botInstance.api,
+        this.chatIdForSession(request.sessionID) ?? this.chatIdInstance,
+        request,
+        generation,
+      );
     });
 
-    summaryAggregator.setOnPermissionReplied(async (_sessionId, requestID) => {
+    summaryAggregator.setOnPermissionReplied(async (sessionId, requestID) => {
       const messageIds = permissionManager.resolveRequest(requestID);
       const interaction = interactionManager.getSnapshot();
       if (!permissionManager.isActive() || !interaction || interaction.kind === "permission") {
@@ -959,7 +1036,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
       if (this.botInstance && this.chatIdInstance) {
         const api = this.botInstance.api;
-        const chatId = this.chatIdInstance;
+        const chatId = this.chatIdForSession(sessionId) ?? this.chatIdInstance;
         await Promise.all(
           messageIds.map((messageId) =>
             api.deleteMessage(chatId, messageId).catch((err) => {
@@ -981,8 +1058,7 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== update.sessionId) {
+      if (!this.ownsSession(update.sessionId)) {
         return;
       }
 
@@ -1039,8 +1115,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         return;
       }
 
@@ -1125,8 +1201,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         foregroundSessionState.markIdle(sessionId);
         await scheduledTaskRuntime.flushDeferredDeliveries();
         return;
@@ -1144,19 +1220,22 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           const modelID = completedRun.actualModelID || completedRun.configuredModelID;
 
           if (agent && providerID && modelID) {
-            const keyboard = this.getCurrentReplyKeyboard();
-            await this.botInstance.api.sendMessage(
-              this.chatIdInstance,
-              formatAssistantRunFooter({
-                agent,
-                providerID,
-                modelID,
-                elapsedMs: Date.now() - completedRun.startedAt,
-              }),
-              {
-                ...(keyboard ? { reply_markup: keyboard } : {}),
-              },
-            );
+            const footerChatId = this.sendTarget(targetChatId);
+            if (footerChatId != null) {
+              const keyboard = this.getCurrentReplyKeyboard();
+              await this.botInstance.api.sendMessage(
+                footerChatId,
+                formatAssistantRunFooter({
+                  agent,
+                  providerID,
+                  modelID,
+                  elapsedMs: Date.now() - completedRun.startedAt,
+                }),
+                {
+                  ...(keyboard ? { reply_markup: keyboard } : {}),
+                },
+              );
+            }
           }
         }
       } catch (err) {
@@ -1180,10 +1259,10 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         clearPromptResponseMode(sessionId);
-          this.clearAssistantResponseSession(sessionId, "session_error_not_current");
+        this.clearAssistantResponseSession(sessionId, "session_error_not_current");
         this.toolCallStreamer.clearSession(sessionId, "session_error_not_current");
         this.compactProgressStreamer.clearSession(sessionId, "session_error_not_current");
         assistantRunState.clearRun(sessionId, "session_error_not_current");
@@ -1215,7 +1294,10 @@ class EventSubscriptionService implements BotEventSubscriptionService {
           : normalizedMessage;
 
       await this.botInstance.api
-        .sendMessage(this.chatIdInstance, t("bot.session_error", { message: truncatedMessage }))
+        .sendMessage(
+          this.chatIdForSession(sessionId) ?? this.chatIdInstance,
+          t("bot.session_error", { message: truncatedMessage }),
+        )
         .catch((err) => {
           logger.error("[Bot] Failed to send session.error message:", err);
         });
@@ -1230,8 +1312,8 @@ class EventSubscriptionService implements BotEventSubscriptionService {
         return;
       }
 
-      const currentSession = getCurrentSession();
-      if (!currentSession || currentSession.id !== sessionId) {
+      const targetChatId = this.chatIdForSession(sessionId);
+      if (targetChatId == null) {
         return;
       }
 
@@ -1270,9 +1352,20 @@ class EventSubscriptionService implements BotEventSubscriptionService {
 
     summaryAggregator.setOnFileChange((change) => {
       if (isCompactProgressMode()) {
-        const currentSession = getCurrentSession();
-        if (currentSession) {
-          this.compactProgressStreamer.addFileChange(currentSession.id, change.file);
+        // Compact activity has a single slot: route it to whichever operator
+        // actually owns an active turn, legacy pointer first. When the
+        // aggregator grows a per-session active-turn probe it wins; until then
+        // the first known session is used.
+        const activeTurnProbe = summaryAggregator as {
+          hasActiveTurn?: (sessionId: string) => boolean;
+        };
+        const ownerSessionId = [
+          getRawCurrentSession()?.id,
+          ...Object.values(getAllUserSessions()).map((session) => session?.id),
+        ].find((id) => id !== undefined && activeTurnProbe.hasActiveTurn?.(id) !== false);
+
+        if (ownerSessionId !== undefined) {
+          this.compactProgressStreamer.addFileChange(ownerSessionId, change.file);
         }
       }
 
@@ -1683,8 +1776,12 @@ class EventSubscriptionService implements BotEventSubscriptionService {
       return;
     }
 
+    // Background prompts (permissions/questions) belong to a specific operator's
+    // session - notify the bound chat, falling back to the primary.
+    const chatId = this.chatIdForSession(notification.sessionId) ?? this.chatIdInstance;
+
     await this.botInstance.api.sendMessage(
-      this.chatIdInstance,
+      chatId,
       this.formatBackgroundSessionNotification(notification),
       {
         reply_markup: buildBackgroundSessionOpenKeyboard(notification.sessionId, notification.kind),

--- a/src/bot/services/project-switch-presentation.ts
+++ b/src/bot/services/project-switch-presentation.ts
@@ -1,5 +1,6 @@
 import type { Context } from "grammy";
 import type { ProjectSwitchPresentation } from "../../app/services/project-switch-service.js";
+import { config } from "../../config.js";
 import { keyboardManager } from "../keyboards/keyboard-manager.js";
 import { createMainKeyboard } from "../keyboards/main-reply-keyboard.js";
 import { pinnedMessageManager } from "../pinned/pinned-message-manager.js";
@@ -10,7 +11,10 @@ export function createProjectSwitchPresentation(): ProjectSwitchPresentation {
       await pinnedMessageManager.clear();
     },
     initializeKeyboard(ctx: Context) {
-      if (ctx.chat) {
+      // Single-slot reply keyboard: never re-arm it from one operator's
+      // project switch in multi-operator mode (same suppression as /start).
+      const soloOperator = config.telegram.allowedUserIds.length <= 1;
+      if (ctx.chat && soloOperator) {
         keyboardManager.initialize(ctx.api, ctx.chat.id);
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import { getRuntimePaths } from "./runtime/paths.js";
 import { normalizeLocale, type Locale } from "./i18n/index.js";
+import { logger } from "./utils/logger.js";
 
 const runtimePaths = getRuntimePaths();
 dotenv.config({ path: runtimePaths.envFilePath, quiet: true });
@@ -102,14 +103,10 @@ export function parseInitialSettingsPreset(): Record<string, unknown> {
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error(
-      "INITIAL_SETTINGS_PRESET contains invalid JSON. Fix or unset the variable.",
-    );
+    throw new Error("INITIAL_SETTINGS_PRESET contains invalid JSON. Fix or unset the variable.");
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error(
-      "INITIAL_SETTINGS_PRESET must be a JSON object.",
-    );
+    throw new Error("INITIAL_SETTINGS_PRESET must be a JSON object.");
   }
   return parsed as Record<string, unknown>;
 }
@@ -154,17 +151,28 @@ function getOptionalSttRequestFormatEnvVar(
 // Multi-operator allowlist: comma-separated TELEGRAM_ALLOWED_USER_IDS entries plus
 // the legacy single-user TELEGRAM_ALLOWED_USER_ID variable, deduplicated in
 // first-seen order. Junk segments are ignored rather than fatal, so a partially
-// derived list still admits the operators it did parse.
+// derived list still admits the operators it did parse - with a warn naming the
+// ignored count, because a silent typo just looks like "the bot ignores me".
 export function parseAllowedUserIds(...rawLists: string[]): number[] {
   const ids = new Set<number>();
+  let ignoredSegments = 0;
   for (const rawList of rawLists) {
     for (const part of rawList.split(",")) {
       const parsed = Number.parseInt(part.trim(), 10);
       if (Number.isFinite(parsed)) {
         ids.add(parsed);
+      } else if (part.trim() !== "") {
+        ignoredSegments++;
       }
     }
   }
+
+  if (ignoredSegments > 0) {
+    logger.warn(
+      `[Config] Ignored ${ignoredSegments} segment(s) that did not parse as a user id while reading the TELEGRAM_ALLOWED_USER_IDS allowlist.`,
+    );
+  }
+
   return [...ids];
 }
 
@@ -282,8 +290,7 @@ export const config = {
           : provider === "edge"
             ? "en-US-EmmaMultilingualNeural"
             : "alloy";
-    const defaultModel =
-      provider === "elevenlabs" ? "eleven_flash_v2_5" : "gpt-4o-mini-tts";
+    const defaultModel = provider === "elevenlabs" ? "eleven_flash_v2_5" : "gpt-4o-mini-tts";
     return {
       apiUrl: getEnvVar("TTS_API_URL", false),
       apiKey: getEnvVar("TTS_API_KEY", false),

--- a/src/config.ts
+++ b/src/config.ts
@@ -151,9 +151,27 @@ function getOptionalSttRequestFormatEnvVar(
   return defaultValue;
 }
 
+// Multi-operator allowlist: comma-separated TELEGRAM_ALLOWED_USER_IDS entries plus
+// the legacy single-user TELEGRAM_ALLOWED_USER_ID variable, deduplicated in
+// first-seen order. Junk segments are ignored rather than fatal, so a partially
+// derived list still admits the operators it did parse.
+export function parseAllowedUserIds(...rawLists: string[]): number[] {
+  const ids = new Set<number>();
+  for (const rawList of rawLists) {
+    for (const part of rawList.split(",")) {
+      const parsed = Number.parseInt(part.trim(), 10);
+      if (Number.isFinite(parsed)) {
+        ids.add(parsed);
+      }
+    }
+  }
+  return [...ids];
+}
+
 export function buildTelegramConfig(): {
   token: string;
   allowedUserId: number;
+  allowedUserIds: number[];
   proxyUrl: string;
   apiRoot: string;
   proxySecret: string;
@@ -183,6 +201,10 @@ export function buildTelegramConfig(): {
   return {
     token: getEnvVar("TELEGRAM_BOT_TOKEN"),
     allowedUserId: parseInt(getEnvVar("TELEGRAM_ALLOWED_USER_ID"), 10),
+    allowedUserIds: parseAllowedUserIds(
+      getEnvVar("TELEGRAM_ALLOWED_USER_IDS", false),
+      getEnvVar("TELEGRAM_ALLOWED_USER_ID", false),
+    ),
     proxyUrl,
     apiRoot,
     proxySecret,

--- a/tests/app/managers/background-session-manager.test.ts
+++ b/tests/app/managers/background-session-manager.test.ts
@@ -324,3 +324,81 @@ describe("BackgroundSessionTracker", () => {
     expect(onNotification).toHaveBeenCalledTimes(2);
   });
 });
+
+// Synthetic ids only - never real Telegram uids.
+const MULTI_OP_PRIMARY_USER_ID = 111;
+const MULTI_OP_SECONDARY_USER_ID = 222;
+
+describe("BackgroundSessionTracker multi-operator ownership", () => {
+  /**
+   * Fresh module registry so the frozen `config.telegram` allowlist matches
+   * the env stubbed here (the file-level import above keeps its solo default).
+   */
+  async function loadScopedModules() {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(MULTI_OP_PRIMARY_USER_ID));
+    vi.stubEnv(
+      "TELEGRAM_ALLOWED_USER_IDS",
+      `${MULTI_OP_PRIMARY_USER_ID},${MULTI_OP_SECONDARY_USER_ID}`,
+    );
+    vi.resetModules();
+    const [{ BackgroundSessionTracker }, { userScope }, settingsStore] = await Promise.all([
+      import("../../../src/app/managers/background-session-manager.js"),
+      import("../../../src/app/stores/user-scope.js"),
+      import("../../../src/app/stores/settings-store.js"),
+    ]);
+    return { BackgroundSessionTracker, userScope, settingsStore };
+  }
+
+  it("ignores sessions bound to an operator instead of demoting them to notifications", async () => {
+    const { BackgroundSessionTracker, userScope, settingsStore } = await loadScopedModules();
+
+    // Operator 222 owns their foreground tape.
+    await userScope.run({ userId: MULTI_OP_SECONDARY_USER_ID }, async () => {
+      settingsStore.setCurrentSession({
+        id: "bound-session-1",
+        title: "Operator 222 tape",
+        directory: "D:/repo",
+      });
+    });
+
+    const tracker = new BackgroundSessionTracker();
+    const onNotification = vi.fn();
+    tracker.setOnNotification(onNotification);
+
+    tracker.processEvent(
+      event({
+        type: "permission.asked",
+        properties: { id: "req-bound", sessionID: "bound-session-1" },
+      }),
+      null,
+    );
+    await flushNotifications();
+
+    expect(onNotification).not.toHaveBeenCalled();
+  });
+
+  it("still notifies for genuinely unowned sessions", async () => {
+    const { BackgroundSessionTracker } = await loadScopedModules();
+
+    const tracker = new BackgroundSessionTracker();
+    const onNotification = vi.fn();
+    tracker.setOnNotification(onNotification);
+
+    tracker.processEvent(
+      event({
+        type: "permission.asked",
+        properties: { id: "req-unbound", sessionID: "unbound-session-1" },
+      }),
+      null,
+    );
+    await flushNotifications();
+
+    expect(onNotification).toHaveBeenCalledWith({
+      kind: "permission_asked",
+      sessionId: "unbound-session-1",
+      sessionTitle: undefined,
+      requestId: "req-unbound",
+    });
+  });
+});

--- a/tests/app/stores/multi-operator-session-store.test.ts
+++ b/tests/app/stores/multi-operator-session-store.test.ts
@@ -1,0 +1,142 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../../../src/app/types/session.js";
+
+function sessionInfo(id: string): SessionInfo {
+  return { id, title: `Session ${id}`, directory: "/tmp/opencode-test-workspace" };
+}
+
+// Each test reloads config + stores through a fresh module registry so the
+// frozen `config.telegram` object matches the env stubbed for that test.
+describe("multi-operator scoped session storage", () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(os.tmpdir(), "opencode-telegram-multi-op-"));
+    process.env.OPENCODE_TELEGRAM_HOME = tempHome;
+  });
+
+  afterEach(async () => {
+    delete process.env.OPENCODE_TELEGRAM_HOME;
+    await rm(tempHome, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  async function loadStore() {
+    // Pin both allowlist variables explicitly: config is rebuilt inside this
+    // test and must not depend on ambient env left by other test files.
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    vi.resetModules();
+
+    const configModule = await import("../../../src/config.js");
+    const scopeModule = await import("../../../src/app/stores/user-scope.js");
+    const storeModule = await import("../../../src/app/stores/settings-store.js");
+
+    return {
+      config: configModule.config,
+      userScope: scopeModule.userScope,
+      ...storeModule,
+    };
+  }
+
+  it("seeds a solo operator's map entry from the legacy tape on first contact", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+    const store = await loadStore();
+
+    store.setCurrentSession(sessionInfo("legacy-1"));
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      expect(store.getCurrentSession()?.id).toBe("legacy-1");
+    });
+
+    expect(store.getAllUserSessions()["1234"]?.id).toBe("legacy-1");
+    expect(store.getRawCurrentSession()?.id).toBe("legacy-1");
+  });
+
+  it("never inherits the legacy tape when multiple operators are configured", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    store.setCurrentSession(sessionInfo("legacy-1"));
+
+    await store.userScope.run({ userId: 5678 }, async () => {
+      expect(store.getCurrentSession()).toBeUndefined();
+    });
+
+    expect(store.getAllUserSessions()).toEqual({});
+  });
+
+  it("keeps each operator's session tape isolated", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.setCurrentSession(sessionInfo("session-a"));
+    });
+    await store.userScope.run({ userId: 5678 }, async () => {
+      store.setCurrentSession(sessionInfo("session-b"));
+    });
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      expect(store.getCurrentSession()?.id).toBe("session-a");
+    });
+    await store.userScope.run({ userId: 5678 }, async () => {
+      expect(store.getCurrentSession()?.id).toBe("session-b");
+    });
+    expect(store.getRawCurrentSession()).toBeUndefined();
+  });
+
+  it("clears only the scoped operator's session entry", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.setCurrentSession(sessionInfo("session-a"));
+    });
+    await store.userScope.run({ userId: 5678 }, async () => {
+      store.setCurrentSession(sessionInfo("session-b"));
+    });
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.clearSession();
+      expect(store.getCurrentSession()).toBeUndefined();
+    });
+
+    expect(store.getSessionChatBinding("session-b")).toBe(5678);
+    expect(store.getSessionChatBinding("session-a")).toBeNull();
+  });
+
+  it("resolves the owning chat id for a bound session and null otherwise", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.setCurrentSession(sessionInfo("session-a"));
+    });
+    store.setCurrentSession(sessionInfo("legacy-1"));
+
+    expect(store.getSessionChatBinding("session-a")).toBe(1234);
+    expect(store.getSessionChatBinding("legacy-1")).toBeNull();
+    expect(store.getSessionChatBinding("session-missing")).toBeNull();
+  });
+
+  it("keeps unscoped writes on the legacy pointer outside any scope", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    store.setCurrentSession(sessionInfo("legacy-1"));
+
+    expect(store.getRawCurrentSession()?.id).toBe("legacy-1");
+    expect(store.getAllUserSessions()).toEqual({});
+    expect(store.getCurrentSession()?.id).toBe("legacy-1");
+  });
+});

--- a/tests/app/stores/multi-operator-session-store.test.ts
+++ b/tests/app/stores/multi-operator-session-store.test.ts
@@ -93,6 +93,60 @@ describe("multi-operator scoped session storage", () => {
     expect(store.getRawCurrentSession()).toBeUndefined();
   });
 
+  it("keeps a solo operator's cleared session cleared instead of resurrecting it", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+    const store = await loadStore();
+
+    // First contact adopts the legacy tape...
+    store.setCurrentSession(sessionInfo("legacy-1"));
+    await store.userScope.run({ userId: 1234 }, async () => {
+      expect(store.getCurrentSession()?.id).toBe("legacy-1");
+    });
+
+    // ...then /start, /detach, or a project switch clears it - and the clear
+    // must stick on every later read, not be re-seeded from the legacy pointer.
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.clearSession();
+      expect(store.getCurrentSession()).toBeUndefined();
+    });
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      expect(store.getCurrentSession()).toBeUndefined();
+      expect(store.getCurrentSession()).toBeUndefined();
+    });
+    expect(store.getAllUserSessions()["1234"]).toBeUndefined();
+    expect(store.getRawCurrentSession()).toBeUndefined();
+  });
+
+  it("mirrors a solo operator's scoped session onto the legacy pointer for unscoped readers", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+    const store = await loadStore();
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.setCurrentSession(sessionInfo("session-a"));
+    });
+
+    // Boot-time restore reads outside any scope; in solo mode it must observe
+    // exactly the tape the operator selected.
+    expect(store.getRawCurrentSession()?.id).toBe("session-a");
+    expect(store.getAllUserSessions()["1234"]?.id).toBe("session-a");
+  });
+
+  it("keeps multi-operator scoped writes off the shared legacy pointer", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    const store = await loadStore();
+
+    await store.userScope.run({ userId: 1234 }, async () => {
+      store.setCurrentSession(sessionInfo("session-a"));
+    });
+
+    expect(store.getRawCurrentSession()).toBeUndefined();
+    expect(store.getAllUserSessions()["1234"]?.id).toBe("session-a");
+  });
+
   it("clears only the scoped operator's session entry", async () => {
     vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
     vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");

--- a/tests/bot/callbacks/agent-selection-multi-operator-gate.test.ts
+++ b/tests/bot/callbacks/agent-selection-multi-operator-gate.test.ts
@@ -1,0 +1,111 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+
+// Synthetic ids only - never real Telegram uids.
+const PRIMARY_USER_ID = 111;
+const SECONDARY_USER_ID = 222;
+const MENU_MESSAGE_ID = 900;
+
+function createCallbackContext(data: string): Context {
+  return {
+    chat: { id: PRIMARY_USER_ID },
+    callbackQuery: {
+      data,
+      message: {
+        message_id: MENU_MESSAGE_ID,
+      },
+    } as Context["callbackQuery"],
+    api: {},
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue({ message_id: MENU_MESSAGE_ID + 1 }),
+  } as unknown as Context;
+}
+
+describe("agent-selection callback multi-operator keyboard gate", () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(os.tmpdir(), "opencode-telegram-agent-gate-"));
+    process.env.OPENCODE_TELEGRAM_HOME = tempHome;
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    vi.stubEnv("LOG_LEVEL", "error");
+  });
+
+  afterEach(async () => {
+    delete process.env.OPENCODE_TELEGRAM_HOME;
+    // Settings writes scheduled during the test need a real tick to land
+    // before the temp home is removed.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    vi.unstubAllEnvs();
+    const { resetSingletonState } = await import("../../helpers/reset-singleton-state.js");
+    await resetSingletonState();
+  });
+
+  async function loadGate() {
+    // Fresh module registry so the frozen `config.telegram` allowlist matches
+    // the env stubbed for this lane (global setup seeds a default first).
+    vi.resetModules();
+    const [{ handleAgentSelect }, { keyboardManager }, { interactionManager }] = await Promise.all([
+      import("../../../src/bot/callbacks/agent-selection-callback-handler.js"),
+      import("../../../src/bot/keyboards/keyboard-manager.js"),
+      import("../../../src/app/managers/interaction-manager.js"),
+    ]);
+    // Reset the singletons of THIS registry so no state leaks between lanes.
+    const { resetSingletonState } = await import("../../helpers/reset-singleton-state.js");
+    await resetSingletonState();
+    return { handleAgentSelect, keyboardManager, interactionManager };
+  }
+
+  async function runAgentSelectionCallback() {
+    const { handleAgentSelect, keyboardManager, interactionManager } = await loadGate();
+
+    // Arm a live agent menu so the callback passes the active-menu check and
+    // reaches the arm site under test instead of bailing as stale.
+    interactionManager.start({
+      kind: "inline",
+      expectedInput: "callback",
+      metadata: {
+        menuKind: "agent",
+        messageId: MENU_MESSAGE_ID,
+      },
+    });
+
+    const ctx = createCallbackContext(`agent:build`);
+    const handled = await handleAgentSelect(ctx);
+
+    return { handled, ctx, keyboardManager };
+  }
+
+  it("does not arm the reply keyboard from an agent callback in multi-operator mode", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+
+    const { handled, ctx, keyboardManager } = await runAgentSelectionCallback();
+
+    expect(handled).toBe(true);
+    // The handler ran to completion (confirmation sent with the new
+    // keyboard), yet the single-slot manager stayed unarmed - the selection
+    // must not adopt one operator's markup into the global slot.
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    expect(keyboardManager.isInitialized()).toBe(false);
+  });
+
+  it("still arms the reply keyboard for the same callback in solo mode", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+
+    const { handled, ctx, keyboardManager } = await runAgentSelectionCallback();
+
+    expect(handled).toBe(true);
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    // Sensitivity control for the lane above: identical rig with one
+    // operator, so the suppression (not some early bail) is what held.
+    expect(keyboardManager.isInitialized()).toBe(true);
+  });
+});

--- a/tests/bot/middleware/auth.test.ts
+++ b/tests/bot/middleware/auth.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "grammy";
+
+// Synthetic ids only - never real Telegram uids.
+const PRIMARY_USER_ID = 111;
+const SECONDARY_USER_ID = 222;
+const INTRUDER_USER_ID = 999;
+
+function createContext(userId: number, chatId: number): Context {
+  return {
+    from: { id: userId },
+    chat: { id: chatId },
+    api: {
+      setMyCommands: vi.fn().mockResolvedValue(true),
+    },
+  } as unknown as Context;
+}
+
+describe("bot/middleware/auth multi-operator scoping", () => {
+  beforeEach(() => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+  });
+
+  /**
+   * Fresh module registry so the frozen `config.telegram` allowlist matches
+   * the env stubbed by the calling test (global setup seeds a default first).
+   */
+  async function loadModules() {
+    vi.resetModules();
+    const [{ authMiddleware }, { userScope }] = await Promise.all([
+      import("../../../src/bot/middleware/auth.js"),
+      import("../../../src/app/stores/user-scope.js"),
+    ]);
+    return { authMiddleware, userScope };
+  }
+
+  it("enters the operator's user scope around authorized updates", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+    const { authMiddleware, userScope } = await loadModules();
+
+    let nextCalled = false;
+    let scopeInsideHandler: number | undefined;
+    const next = async () => {
+      nextCalled = true;
+      scopeInsideHandler = userScope.getStore()?.userId;
+    };
+
+    await authMiddleware(createContext(SECONDARY_USER_ID, SECONDARY_USER_ID), next);
+
+    expect(nextCalled).toBe(true);
+    expect(scopeInsideHandler).toBe(SECONDARY_USER_ID);
+  });
+
+  it("keeps each operator's scope separate per update", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+    const { authMiddleware, userScope } = await loadModules();
+
+    const observed: (number | undefined)[] = [];
+    const next = async () => {
+      observed.push(userScope.getStore()?.userId);
+    };
+
+    await authMiddleware(createContext(SECONDARY_USER_ID, SECONDARY_USER_ID), next);
+    await authMiddleware(createContext(PRIMARY_USER_ID, PRIMARY_USER_ID), next);
+
+    expect(observed).toEqual([SECONDARY_USER_ID, PRIMARY_USER_ID]);
+  });
+
+  it("drops unauthorized updates without entering any scope", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+    const { authMiddleware, userScope } = await loadModules();
+
+    let nextCalled = false;
+    const next = async () => {
+      nextCalled = true;
+    };
+
+    const ctx = createContext(INTRUDER_USER_ID, INTRUDER_USER_ID);
+    await authMiddleware(ctx, next);
+
+    expect(nextCalled).toBe(false);
+    expect(userScope.getStore()).toBeUndefined();
+    // Unauthorized chats get their command list hidden.
+    expect(ctx.api.setMyCommands).toHaveBeenCalledWith([], {
+      scope: { type: "chat", chat_id: INTRUDER_USER_ID },
+    });
+  });
+});

--- a/tests/bot/services/attach-presentation.test.ts
+++ b/tests/bot/services/attach-presentation.test.ts
@@ -1,0 +1,139 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Synthetic ids only - never real Telegram uids.
+const PRIMARY_USER_ID = 111;
+const SECONDARY_USER_ID = 222;
+
+type RecordedCall = { method: string; args: unknown[] };
+
+/**
+ * Records every API method invocation so the suppression lanes can assert that
+ * the single-slot presentation surfaces stay completely untouched.
+ */
+function createRecordingApi(): { api: unknown; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const api = new Proxy(
+    {},
+    {
+      get(_target, method: string) {
+        return (...args: unknown[]) => {
+          calls.push({ method, args });
+          return Promise.resolve({ message_id: 1 });
+        };
+      },
+    },
+  );
+  return { api, calls };
+}
+
+function sessionInfo(id: string) {
+  return { id, title: `Session ${id}`, directory: "/tmp/opencode-test-workspace" };
+}
+
+describe("attach-presentation multi-operator suppression", () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(os.tmpdir(), "opencode-telegram-attach-pres-"));
+    process.env.OPENCODE_TELEGRAM_HOME = tempHome;
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    await resetPresentationState();
+  });
+
+  afterEach(async () => {
+    delete process.env.OPENCODE_TELEGRAM_HOME;
+    // Settings writes scheduled during the test need a real tick to land
+    // before the temp home is removed.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    vi.unstubAllEnvs();
+    await resetPresentationState();
+  });
+
+  async function resetPresentationState() {
+    const { resetSingletonState } = await import("../../helpers/reset-singleton-state.js");
+    const settingsStore = await import("../../../src/app/stores/settings-store.js");
+    settingsStore.__resetSettingsForTests();
+    await resetSingletonState();
+  }
+
+  async function loadPresentation() {
+    // Fresh module registry so the frozen `config.telegram` allowlist matches
+    // the env stubbed for this test (global setup seeds a default first).
+    vi.resetModules();
+    const [{ createAttachPresentation }, { pinnedMessageManager }, { keyboardManager }] =
+      await Promise.all([
+        import("../../../src/bot/services/attach-presentation.js"),
+        import("../../../src/bot/pinned/pinned-message-manager.js"),
+        import("../../../src/bot/keyboards/keyboard-manager.js"),
+      ]);
+    // Reset the singletons of THIS registry so no state leaks between lanes.
+    const { resetSingletonState } = await import("../../helpers/reset-singleton-state.js");
+    await resetSingletonState();
+    return { createAttachPresentation, pinnedMessageManager, keyboardManager };
+  }
+
+  it("never arms the pin pump or keyboard from any operator's flow in multi-op", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+    const { createAttachPresentation, pinnedMessageManager, keyboardManager } =
+      await loadPresentation();
+    // Simulate an operator having armed the single-slot card via /start or
+    // /status before this call - the suppression must hold regardless.
+    const commandApi = createRecordingApi();
+    pinnedMessageManager.initialize(commandApi.api as never, SECONDARY_USER_ID);
+    keyboardManager.initialize(commandApi.api as never, SECONDARY_USER_ID);
+
+    const presentation = createAttachPresentation();
+    const streamerApi = createRecordingApi();
+    await presentation.ensurePinnedSession({
+      api: streamerApi.api as never,
+      chatId: SECONDARY_USER_ID,
+      session: sessionInfo("session-a"),
+    });
+
+    // Without the unconditional guard the card adopts the session into the
+    // arming operator's single slot; suppressed, nothing happens at all.
+    expect(streamerApi.calls).toEqual([]);
+    expect(pinnedMessageManager.getState().sessionId).toBeNull();
+  });
+
+  it("keeps syncAttachState a no-op even when the card was already initialized", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`);
+    const { createAttachPresentation, pinnedMessageManager } = await loadPresentation();
+
+    const anyApi = createRecordingApi();
+    pinnedMessageManager.initialize(anyApi.api as never, PRIMARY_USER_ID);
+
+    const presentation = createAttachPresentation();
+    await presentation.syncAttachState(true, true);
+
+    expect(pinnedMessageManager.getState().attachActive).toBe(false);
+    expect(pinnedMessageManager.getState().attachBusy).toBe(false);
+  });
+
+  it("still drives the pin pump for a solo operator", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+    const { createAttachPresentation, pinnedMessageManager } = await loadPresentation();
+
+    const presentation = createAttachPresentation();
+    const soloApi = createRecordingApi();
+    await presentation.ensurePinnedSession({
+      api: soloApi.api as never,
+      chatId: PRIMARY_USER_ID,
+      session: sessionInfo("session-solo"),
+    });
+
+    // Sensitivity check for the lanes above: solo mode must reach the manager
+    // and adopt the session into the single-slot card.
+    expect(pinnedMessageManager.isInitialized()).toBe(true);
+    expect(pinnedMessageManager.getState().sessionId).toBe("session-solo");
+  });
+});

--- a/tests/bot/services/event-subscription-service.multi-operator.test.ts
+++ b/tests/bot/services/event-subscription-service.multi-operator.test.ts
@@ -301,4 +301,128 @@ describe("bot/services/event-subscription-service multi-operator routing", () =>
     const targetChatIds = collectTargetChatIds(api);
     expect(targetChatIds).toContain(PRIMARY_USER_ID);
   });
+
+  function emitBackgroundCompletion(
+    tracker: { processEvent(event: Event, currentSessionId: string | null): void },
+    messageId: string,
+    sessionId: string,
+  ): void {
+    // currentSessionId=null mirrors the post-restart state: nothing is
+    // attached, yet the finished session's events still reach the bot.
+    tracker.processEvent(
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: messageId,
+            sessionID: sessionId,
+            role: "assistant",
+            time: { completed: Date.now() },
+          },
+        },
+      } as unknown as Event,
+      null,
+    );
+    tracker.processEvent(
+      { type: "session.idle", properties: { sessionID: sessionId } } as unknown as Event,
+      null,
+    );
+  }
+
+  async function importBackgroundTracker(): Promise<{
+    processEvent(event: Event, currentSessionId: string | null): void;
+  }> {
+    const { backgroundSessionTracker } = await import(
+      "../../../src/app/managers/background-session-manager.js"
+    );
+    return backgroundSessionTracker;
+  }
+
+  async function importLogger(): Promise<typeof import("../../../src/utils/logger.js")> {
+    return import("../../../src/utils/logger.js");
+  }
+
+  it("delivers a background completion for a bound session to the owning operator's chat", async () => {
+    const { api } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+      boundSessions: [{ userId: SECONDARY_USER_ID, sessionId: ROOT_SESSION_ID }],
+    });
+
+    // The delivery delegate is exactly what the background-session manager
+    // calls into; drive it directly so the target resolution is under test
+    // independent of the tracker's ignore-gate for live lanes.
+    const service = activeService as unknown as {
+      deliverBackgroundSessionNotification(notification: {
+        kind: "assistant_response";
+        sessionId: string;
+        sessionTitle?: string;
+      }): Promise<void>;
+    };
+    await service.deliverBackgroundSessionNotification({
+      kind: "assistant_response",
+      sessionId: ROOT_SESSION_ID,
+      sessionTitle: `Tape ${ROOT_SESSION_ID}`,
+    });
+    await flushPendingDispatch();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage.mock.calls[0]?.[0]).toBe(SECONDARY_USER_ID);
+    expect(api.sendMessage.mock.calls[0]?.[0]).not.toBe(PRIMARY_USER_ID);
+  });
+
+  it("delivers a background permission prompt for a bound session to the owning operator's chat", async () => {
+    const { api } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+      boundSessions: [{ userId: SECONDARY_USER_ID, sessionId: ROOT_SESSION_ID }],
+    });
+
+    const service = activeService as unknown as {
+      deliverBackgroundSessionNotification(notification: {
+        kind: "permission_asked";
+        sessionId: string;
+        requestId?: string;
+      }): Promise<void>;
+    };
+    await service.deliverBackgroundSessionNotification({
+      kind: "permission_asked",
+      sessionId: ROOT_SESSION_ID,
+      requestId: "req-bg-1",
+    });
+    await flushPendingDispatch();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage.mock.calls[0]?.[0]).toBe(SECONDARY_USER_ID);
+  });
+
+  it("drops a post-restart background completion for an unbound session instead of notifying the primary chat", async () => {
+    const { api } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+    });
+    const loggerModule = await importLogger();
+    const debugSpy = vi.spyOn(loggerModule.logger, "debug").mockImplementation(() => {});
+
+    const tracker = await importBackgroundTracker();
+    emitBackgroundCompletion(tracker, "message-ghost-1", GHOST_SESSION_ID);
+    await flushPendingDispatch();
+
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    const dropLogged = debugSpy.mock.calls.some((call) =>
+      String(call[0]).includes(GHOST_SESSION_ID),
+    );
+    expect(dropLogged).toBe(true);
+  });
+
+  it("keeps solo background completions on the legacy primary chat", async () => {
+    const { api } = await setupService({
+      allowUserIds: "",
+    });
+
+    const tracker = await importBackgroundTracker();
+    emitBackgroundCompletion(tracker, "message-solo-1", GHOST_SESSION_ID);
+    await flushPendingDispatch();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage.mock.calls[0]?.[0]).toBe(PRIMARY_USER_ID);
+  });
 });

--- a/tests/bot/services/event-subscription-service.multi-operator.test.ts
+++ b/tests/bot/services/event-subscription-service.multi-operator.test.ts
@@ -1,0 +1,304 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Bot, Context } from "grammy";
+import type { Event } from "@opencode-ai/sdk/v2";
+import { setRuntimeMode } from "../../../src/runtime/mode.js";
+
+// Synthetic ids only - never real Telegram uids.
+const PRIMARY_USER_ID = 111;
+const SECONDARY_USER_ID = 222;
+
+const ROOT_SESSION_ID = "session-1";
+const CHILD_SESSION_ID = "child-session-1";
+const GHOST_SESSION_ID = "ghost-session";
+
+const mocked = vi.hoisted(() => ({
+  subscribeToEvents: vi.fn(),
+  stopEventListening: vi.fn(),
+}));
+
+vi.mock("../../../src/opencode/events.js", () => ({
+  subscribeToEvents: mocked.subscribeToEvents,
+  stopEventListening: mocked.stopEventListening,
+}));
+
+type FakeBotApi = {
+  sendMessage: ReturnType<typeof vi.fn>;
+  sendRichMessage: ReturnType<typeof vi.fn>;
+  sendMessageDraft: ReturnType<typeof vi.fn>;
+  editMessageText: ReturnType<typeof vi.fn>;
+  deleteMessage: ReturnType<typeof vi.fn>;
+};
+
+function createFakeBot(): { bot: Bot<Context>; api: FakeBotApi } {
+  const api: FakeBotApi = {
+    sendMessage: vi.fn().mockResolvedValue({ message_id: 100 }),
+    // Rich rendering is tried first and falls back to plain text on this error.
+    sendRichMessage: vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("Bad Request: rich message unavailable"), { error_code: 400 }),
+      ),
+    sendMessageDraft: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+  };
+  return { bot: { api } as unknown as Bot<Context>, api };
+}
+
+function emitTaskTool(summaryAggregator: { processEvent(event: Event): void }): void {
+  summaryAggregator.processEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "part-task",
+        sessionID: ROOT_SESSION_ID,
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-task",
+        tool: "task",
+        state: {
+          status: "running",
+          input: {
+            description: "Explore the project",
+            subagent_type: "explore",
+            prompt: "Inspect architecture",
+          },
+          metadata: {},
+        },
+      },
+    },
+  } as unknown as Event);
+}
+
+function emitSubagentStart(summaryAggregator: { processEvent(event: Event): void }): void {
+  summaryAggregator.processEvent({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "subtask-1",
+        sessionID: ROOT_SESSION_ID,
+        messageID: "message-1",
+        type: "subtask",
+        prompt: "Inspect the project",
+        description: "inspect task",
+        agent: "explore",
+      },
+    },
+  } as unknown as Event);
+
+  summaryAggregator.processEvent({
+    type: "session.created",
+    properties: {
+      info: {
+        id: CHILD_SESSION_ID,
+        parentID: ROOT_SESSION_ID,
+        title: "inspect task (@explore subagent)",
+        slug: "child",
+        directory: "/tmp/opencode-test-workspace",
+        projectID: "p1",
+        version: "1",
+        time: { created: Date.now(), updated: Date.now() },
+      },
+    },
+  } as unknown as Event);
+}
+
+function emitPermissionAsked(
+  summaryAggregator: { processEvent(event: Event): void },
+  sessionId: string,
+  requestID: string,
+): void {
+  summaryAggregator.processEvent({
+    type: "permission.asked",
+    properties: {
+      id: requestID,
+      sessionID: sessionId,
+      permission: "external_directory",
+      patterns: ["/tmp/shared/*"],
+      metadata: {},
+      always: ["/tmp/shared/*"],
+    },
+  } as unknown as Event);
+}
+
+function emitQuestionAsked(summaryAggregator: { processEvent(event: Event): void }): void {
+  summaryAggregator.processEvent({
+    type: "question.asked",
+    properties: {
+      id: "question-request-1",
+      sessionID: summaryAggregatorCurrentSessionId(),
+      questions: [
+        {
+          header: "Confirm",
+          question: "Proceed with the plan?",
+          multiple: false,
+          options: [{ label: "Yes" }, { label: "No" }],
+        },
+      ],
+    },
+  } as unknown as Event);
+}
+
+// The question.asked handler drops events for any session other than the
+// aggregator's current one, so the ghost/drop lane drives the event through a
+// service whose aggregator session IS the unbound session.
+let currentAggregatorSessionId = ROOT_SESSION_ID;
+
+function summaryAggregatorCurrentSessionId(): string {
+  return currentAggregatorSessionId;
+}
+
+async function flushPendingDispatch(): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe("bot/services/event-subscription-service multi-operator routing", () => {
+  let tempHome: string;
+  let activeService: { cleanup(reason: string): void } | null = null;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(path.join(os.tmpdir(), "event-service-multi-op-"));
+    process.env.OPENCODE_TELEGRAM_HOME = tempHome;
+    setRuntimeMode("installed");
+
+    mocked.subscribeToEvents.mockReset();
+    mocked.stopEventListening.mockReset();
+    mocked.subscribeToEvents.mockResolvedValue(undefined);
+
+    const settingsStore = await import("../../../src/app/stores/settings-store.js");
+    settingsStore.__resetSettingsForTests();
+  });
+
+  afterEach(async () => {
+    activeService?.cleanup("test_cleanup");
+    activeService = null;
+
+    const settingsStore = await import("../../../src/app/stores/settings-store.js");
+    settingsStore.__resetSettingsForTests();
+    await rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    vi.unstubAllEnvs();
+  });
+
+  /**
+   * Fresh module registry per call so the frozen `config.telegram` allowlist
+   * matches the env stubbed by the calling test.
+   */
+  async function setupService(options: {
+    allowUserIds: string;
+    boundSessions?: Array<{ userId: number; sessionId: string }>;
+    aggregatorSessionId?: string;
+  }): Promise<{ api: FakeBotApi; summaryAggregator: { processEvent(event: Event): void } }> {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", String(PRIMARY_USER_ID));
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", options.allowUserIds);
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    vi.resetModules();
+
+    const [
+      { createEventSubscriptionService },
+      { summaryAggregator },
+      { userScope },
+      settingsStore,
+    ] = await Promise.all([
+      import("../../../src/bot/services/event-subscription-service.js"),
+      import("../../../src/app/managers/summary-aggregation-manager.js"),
+      import("../../../src/app/stores/user-scope.js"),
+      import("../../../src/app/stores/settings-store.js"),
+    ]);
+
+    settingsStore.__resetSettingsForTests();
+
+    for (const { userId, sessionId } of options.boundSessions ?? []) {
+      await userScope.run({ userId }, async () => {
+        settingsStore.setCurrentSession({
+          id: sessionId,
+          title: `Tape ${sessionId}`,
+          directory: "/tmp/opencode-test-workspace",
+        });
+      });
+    }
+
+    const { bot, api } = createFakeBot();
+    const service = createEventSubscriptionService();
+    activeService = service;
+    // The primary operator's delivery chat, exactly what production wires in.
+    service.setTelegramContext(bot, PRIMARY_USER_ID);
+    await service.ensureEventSubscription("/tmp/opencode-test-workspace");
+
+    currentAggregatorSessionId = options.aggregatorSessionId ?? ROOT_SESSION_ID;
+    summaryAggregator.setSession(currentAggregatorSessionId);
+
+    return { api, summaryAggregator };
+  }
+
+  function collectTargetChatIds(api: FakeBotApi): number[] {
+    return [
+      ...api.sendMessage.mock.calls.map((call) => call[0] as number),
+      ...api.editMessageText.mock.calls.map((call) => call[0] as number),
+    ];
+  }
+
+  it("routes a subagent's permission prompt to the parent session's operator", async () => {
+    const { api, summaryAggregator } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+      boundSessions: [{ userId: SECONDARY_USER_ID, sessionId: ROOT_SESSION_ID }],
+    });
+
+    emitTaskTool(summaryAggregator);
+    emitSubagentStart(summaryAggregator);
+    emitPermissionAsked(summaryAggregator, CHILD_SESSION_ID, "req-child-1");
+    await flushPendingDispatch();
+
+    const targetChatIds = collectTargetChatIds(api);
+    expect(targetChatIds).toContain(SECONDARY_USER_ID);
+    expect(targetChatIds).not.toContain(PRIMARY_USER_ID);
+  });
+
+  it("renders a bound session's question poll in the owning operator's chat", async () => {
+    const { api, summaryAggregator } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+      boundSessions: [{ userId: SECONDARY_USER_ID, sessionId: ROOT_SESSION_ID }],
+    });
+
+    emitQuestionAsked(summaryAggregator);
+    await flushPendingDispatch();
+
+    const targetChatIds = collectTargetChatIds(api);
+    expect(targetChatIds).toContain(SECONDARY_USER_ID);
+    expect(targetChatIds).not.toContain(PRIMARY_USER_ID);
+  });
+
+  it("drops question events for sessions no operator owns instead of falling back to the primary chat", async () => {
+    const { api, summaryAggregator } = await setupService({
+      allowUserIds: `${PRIMARY_USER_ID},${SECONDARY_USER_ID}`,
+      aggregatorSessionId: GHOST_SESSION_ID,
+    });
+
+    emitQuestionAsked(summaryAggregator);
+    await flushPendingDispatch();
+
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("keeps solo question rendering on the primary chat", async () => {
+    const { api, summaryAggregator } = await setupService({
+      allowUserIds: "",
+      // Post-seed solo reality: the operator's tape is bound to their own id,
+      // which for a Telegram private chat equals their delivery chat.
+      boundSessions: [{ userId: PRIMARY_USER_ID, sessionId: ROOT_SESSION_ID }],
+    });
+
+    emitQuestionAsked(summaryAggregator);
+    await flushPendingDispatch();
+
+    const targetChatIds = collectTargetChatIds(api);
+    expect(targetChatIds).toContain(PRIMARY_USER_ID);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -454,4 +454,36 @@ describe("config multi-operator allowlist parsing", () => {
 
     expect(telegram.allowedUserIds).toEqual([1234, 2250]);
   });
+
+  it("warns with a segment count when junk segments are ignored", async () => {
+    const { parseAllowedUserIds } = await loadConfigModule();
+    const { logger } = await import("../src/utils/logger.js");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      expect(parseAllowedUserIds("1234, oops ,2250")).toEqual([1234, 2250]);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0]);
+      expect(message).toMatch(/1 segment/);
+      // The typo itself must never be logged.
+      expect(message).not.toContain("oops");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("stays silent when every allowlist segment parses", async () => {
+    const { parseAllowedUserIds } = await loadConfigModule();
+    const { logger } = await import("../src/utils/logger.js");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      expect(parseAllowedUserIds("1234,2250")).toEqual([1234, 2250]);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -405,3 +405,53 @@ describe("config telegram reverse-proxy", () => {
     expect(() => buildTelegramConfig()).toThrow(/TELEGRAM_PROXY_SECRET requires TELEGRAM_API_ROOT/);
   });
 });
+
+describe("config multi-operator allowlist parsing", () => {
+  beforeEach(() => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "test-telegram-token");
+    vi.stubEnv("OPENCODE_MODEL_PROVIDER", "test-provider");
+    vi.stubEnv("OPENCODE_MODEL_ID", "test-model");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "");
+  });
+
+  async function loadTelegramConfig() {
+    vi.resetModules();
+    const module = await import("../src/config.js");
+    return module.config.telegram;
+  }
+
+  it("absorbs the legacy single-user variable into the allowlist", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+
+    const telegram = await loadTelegramConfig();
+
+    expect(telegram.allowedUserIds).toEqual([1234]);
+  });
+
+  it("parses a comma-separated list of user ids", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "1234,5678");
+
+    const telegram = await loadTelegramConfig();
+
+    expect(telegram.allowedUserIds).toEqual([1234, 5678]);
+  });
+
+  it("merges both variables and drops duplicates, first occurrence wins", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", "5678,1234");
+
+    const telegram = await loadTelegramConfig();
+
+    expect(telegram.allowedUserIds).toEqual([5678, 1234]);
+  });
+
+  it("tolerates whitespace and junk segments between ids", async () => {
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_ID", "1234");
+    vi.stubEnv("TELEGRAM_ALLOWED_USER_IDS", " 1234 , not-a-number , , 2250 ");
+
+    const telegram = await loadTelegramConfig();
+
+    expect(telegram.allowedUserIds).toEqual([1234, 2250]);
+  });
+});


### PR DESCRIPTION
## Multi-operator telegram sessions

**N authorized operators × 1 bot token = N independent session tapes**, each with its own `/new`, its own context, and its own notification stream.

### Problem

The bot assumes exactly one human per machine: `TELEGRAM_ALLOWED_USER_ID` is a single integer, auth is one equality check, and one global `currentSession` pointer serves the whole process. Real deployments break this the moment a second operator joins an org (co-founder, partner, builder): today they are silently rejected (`Unauthorized access attempt`) or forced to share one conversation tape — which confuses both the model and the humans.

Naive multi-user (one shared tape) is the wrong goal anyway. The right primitive is **per-operator isolation**: each authorized operator gets their own session tape automatically.

### Solution (three moving parts)

1. **Allowlist** — `TELEGRAM_ALLOWED_USER_IDS` (comma-separated) absorbs the legacy singular var; backward compatible by construction.
2. **Per-user session scope** — an `AsyncLocalStorage` set in `authMiddleware` tags every update with its sender; the settings store resolves sessions through it. All ~70 existing call sites become per-user *without modification* — this is the key move. `/new`, model switches, aborts, renames isolate automatically. **Solo backward-compat seed:** a solo operator (allowlist length 1) adopts the legacy pointer on first contact — upgrading never orphans an existing conversation. Net effect for existing single-user deployments: zero behavior change, ever.
3. **Ownership-aware event routing** — server events arrive outside any user scope; every delivery guard resolves the target chat via `chatIdForSession(sessionId)` → bound operator's chat, else legacy pointer, else background/discard path. Applied across streams, completions, tool cards, permission/question prompts, error notices, and background-session notifications.

Single-slot affordances that cannot follow ownership (the global pinned status card, reply-keyboard markup) are disabled in multi-operator mode rather than pinned to one operator's chat — fail-closed instead of misrouting by construction. Subagent permission/question prompts resolve through their parent session's binding.

### Pitfalls found running this in production

- The compat seed must treat scoped clear + legacy pointer as one logical tape in solo mode, or a cleared session resurrects on next read (regression-tested).
- Boot-time restore of the legacy pointer must not attach into one operator's chat when multiple operators exist.
- Background-session tracking must ignore sessions that are owned by another active operator's scope.

### Compatibility & safety

- Solo deployments: no behavior change (explicitly tested — including clear/restore/restart paths).
- Settings schema change is additive (`userSessions` map); atomic write path unchanged.
- No new dependencies beyond `node:async_hooks`.
- 17+ new behavioral tests (RED-first where practical); full suite 1634 passing; lint/typecheck clean under strict tsconfig.

### Notes for maintainers

- Happy to split into smaller PRs if preferred (allowlist / scope store / routing are reasonably separable).
- Two production dual-operator deployments have run this design for several days under real load.


### Background-session notifications

Background completion/reply notifications resolve the owning operator's chat via the persisted session binding; solo deployments keep the legacy target; multi-operator unresolvable targets are dropped fail-closed rather than delivered to the primary chat (found and fixed during a live production canary across a mid-task bot restart).
